### PR TITLE
Avoid failing spark bug SPARK-44242 while generate run_dir [databricks]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -187,7 +187,18 @@ else
 
     mkdir -p "$TARGET_DIR"
 
-    RUN_DIR=${RUN_DIR-$(mktemp -p "$TARGET_DIR" -d run_dir-$(date +%Y%m%d%H%M%S)-XXXX)}
+    while true; do
+      # to avoid hit spark bug https://issues.apache.org/jira/browse/SPARK-44242
+      # do not dry-run to provide a safe directory name
+      temp_rundir=$(mktemp -p "${TARGET_DIR}" -d "run_dir-$(date +%Y%m%d%H%M%S)-XXXX")
+      if [[ ! "${temp_rundir}" =~ [xX][mM][xXsS] ]]; then
+        echo "run_dir: ${temp_rundir}"
+        break
+      fi
+      echo "invalid ${temp_rundir}, regenerating..."
+    done
+
+    RUN_DIR=${RUN_DIR-"${temp_rundir}"}
     mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
 

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -196,6 +196,7 @@ else
         break
       fi
       echo "invalid ${temp_rundir}, regenerating..."
+      rmdir "$temp_rundir"
     done
 
     RUN_DIR=${RUN_DIR-"${temp_rundir}"}


### PR DESCRIPTION
fix #11216 

Run mktemp to get the candidate, and try re-gen if contains "Xmx" or "Xms"
to avoid hit https://issues.apache.org/jira/browse/SPARK-44242