### PR TITLE
Fix ArrayIndexOutOfBoundsException on join counts with constant join keys

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -14,10 +14,10 @@
 
 import pytest
 from _pytest.mark.structures import ParameterSet
-from pyspark.sql.functions import array_contains, broadcast, col
+from pyspark.sql.functions import array_contains, broadcast, col, lit
 from pyspark.sql.types import *
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect, assert_cpu_and_gpu_are_equal_collect_with_capture
-from conftest import is_databricks_runtime, is_emr_runtime, is_not_utc
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal, assert_gpu_fallback_collect, assert_cpu_and_gpu_are_equal_collect_with_capture
+from conftest import is_emr_runtime
 from data_gen import *
 from marks import ignore_order, allow_non_gpu, incompat, validate_execs_in_gpu_plan
 from spark_session import with_cpu_session, is_before_spark_330, is_databricks_runtime
@@ -163,6 +163,14 @@ def test_empty_broadcast_hash_join(join_type):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(right.hint("broadcast"), left.a == right.r_a, join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.sql.adaptive.enabled': 'true'})
+
+@pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
+def test_broadcast_hash_join_constant_keys(join_type):
+    def do_join(spark):
+        left = spark.range(10).withColumn("s", lit(1))
+        right = spark.range(10000).withColumn("r_s", lit(1))
+        return left.join(right.hint("broadcast"), left.s == right.r_s, join_type)
+    assert_gpu_and_cpu_row_counts_equal(do_join, conf={'spark.sql.adaptive.enabled': 'true'})
 
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -563,6 +563,7 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
       case GpuLiteral(true, BooleanType) =>
         // Spark can generate a degenerate conditional join when the join keys are constants
         output.isEmpty
+      case GpuAlias(e: GpuExpression, _) => isUnconditionalJoin(Some(e))
       case _ => false
     }
   }


### PR DESCRIPTION
Fixes #11243.  Treats conditional nested loop joins as unconditional if the join condition is literal true and there are no output columns (i..e: a row-count-only join).  Spark can generate a degenerate conditional join when the join keys are known constants during query analysis.