### PR TITLE
Fix `string_test.py` errors on Spark 4.0

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -23,7 +23,7 @@ from marks import *
 from pyspark.sql.types import *
 import pyspark.sql.utils
 import pyspark.sql.functions as f
-from spark_session import with_cpu_session, with_gpu_session, is_databricks104_or_later, is_before_spark_320
+from spark_session import with_cpu_session, with_gpu_session, is_databricks104_or_later, is_before_spark_320, is_before_spark_400
 
 _regexp_conf = { 'spark.rapids.sql.regexp.enabled': 'true' }
 
@@ -90,10 +90,15 @@ def test_substring_index(data_gen,delim):
 
 
 @allow_non_gpu('ProjectExec')
+@pytest.mark.skipif(condition=not is_before_spark_400(),
+                    reason="Bug in Apache Spark 4.0 causes NumberFormatExceptions from substring_index(), "
+                           "if called with index==null. For further information, see: "
+                           "https://issues.apache.org/jira/browse/SPARK-48989.")
 @pytest.mark.parametrize('data_gen', [mk_str_gen('([ABC]{0,3}_?){0,7}')], ids=idfn)
 def test_unsupported_fallback_substring_index(data_gen):
     delim_gen = StringGen(pattern="_")
     num_gen = IntegerGen(min_val=0, max_val=10, special_cases=[])
+
     def assert_gpu_did_fallback(sql_text):
         assert_gpu_fallback_collect(lambda spark:
             gen_df(spark, [("a", data_gen),
@@ -332,6 +337,9 @@ def test_unsupported_fallback_startswith():
     assert_gpu_did_fallback(f.col("a").startswith(f.col("a")))
 
 
+@pytest.mark.skipif(condition=not is_before_spark_400(),
+                    reason="endswith(None) seems to cause an NPE in Column.fn() on Apache Spark 4.0. "
+                           "See https://issues.apache.org/jira/browse/SPARK-48995.")
 def test_endswith():
     gen = mk_str_gen('[Ab\ud720]{3}A.{0,3}Z[Ab\ud720]{3}')
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
Fixes #11030.

This commit skips the tests pertaining to the following operations on Apache Spark 4.0:

1. Column.endswith()
2. substring_index()

In both cases, the CPU version of Apache Spark 4.0 seems to cause exceptions, unrelated to the Spark RAPIDS plugin. See:

1. https://issues.apache.org/jira/browse/SPARK-48989
2. https://issues.apache.org/jira/browse/SPARK-48995

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
