### PR TITLE
Explicitly disable ANSI mode for ast_test.py [databricks]

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ import pytest
 
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture
 from data_gen import *
-from marks import approximate_float, datagen_overrides, ignore_order
+from marks import approximate_float, datagen_overrides, ignore_order, disable_ansi_mode
 from spark_session import with_cpu_session, is_before_spark_330
 import pyspark.sql.functions as f
 
@@ -110,10 +110,12 @@ def test_unary_positive_for_daytime_interval():
     assert_unary_ast(data_descr, lambda df: df.selectExpr('+a'))
 
 @pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+@disable_ansi_mode
 def test_unary_minus(data_descr):
     assert_unary_ast(data_descr, lambda df: df.selectExpr('-a'))
 
 @pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+@disable_ansi_mode
 def test_abs(data_descr):
     assert_unary_ast(data_descr, lambda df: df.selectExpr('abs(a)'))
 
@@ -313,6 +315,7 @@ def test_bitwise_xor(data_descr):
             f.col('a').bitwiseXOR(f.col('b'))))
 
 @pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+@disable_ansi_mode
 def test_addition(data_descr):
     data_type = data_descr[0].data_type
     assert_binary_ast(data_descr,
@@ -322,6 +325,7 @@ def test_addition(data_descr):
             f.col('a') + f.col('b')))
 
 @pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+@disable_ansi_mode
 def test_subtraction(data_descr):
     data_type = data_descr[0].data_type
     assert_binary_ast(data_descr,
@@ -331,6 +335,7 @@ def test_subtraction(data_descr):
             f.col('a') - f.col('b')))
 
 @pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+@disable_ansi_mode
 def test_multiplication(data_descr):
     data_type = data_descr[0].data_type
     assert_binary_ast(data_descr,
@@ -373,6 +378,7 @@ def test_or(data_gen):
                        f.col('a') | f.col('b')))
 
 @ignore_order
+@disable_ansi_mode
 def test_multi_tier_ast():
     assert_gpu_ast(
         is_supported=True,


### PR DESCRIPTION
As a part of the effort to add support for Spark 4.0.0 we are explicitly disabling ANSI mode. 

We will be adding more tests with ANSI enabled but that will have to come as #5120 is done 

fixes #11008 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
