### PR TITLE
CI Docker to support integration tests with Rocky OS + jdk17 [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -33,7 +33,7 @@ ARG URM_URL
 # Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
     yum install epel-release -y && \
-    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect rsync zip unzip procps
+    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel java-17-openjdk-devel wget expect rsync zip unzip procps
 
 # The plugin: net.alchim31.maven requires a higher mvn version.
 ENV MAVEN_HOME "/usr/local/apache-maven-3.6.3"


### PR DESCRIPTION
Part of : https://github.com/NVIDIA/spark-rapids/issues/11121

Install jdk17 in the Rocky CI Docker image to support rapids integration tests with jdk17 JVM

