### PR TITLE
Update the rapids JNI and private dependency version to 24.10.0-SNAPSHOT

### DIFF
--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -20,7 +20,7 @@
 
 set -ex
 
-CUDF_VER=${CUDF_VER:-24.08} # TODO: https://github.com/NVIDIA/spark-rapids/issues/11240
+CUDF_VER=${CUDF_VER:-24.10}
 CUDA_VER=${CUDA_VER:-11.8}
 
 # Need to explicitly add conda into PATH environment, to activate conda environment.

--- a/pom.xml
+++ b/pom.xml
@@ -686,9 +686,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <!-- TODO: https://github.com/NVIDIA/spark-rapids/issues/11240 -->
-        <spark-rapids-jni.version>24.08.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.08.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>24.10.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>24.10.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -686,9 +686,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <!-- TODO: https://github.com/NVIDIA/spark-rapids/issues/11240 -->
-        <spark-rapids-jni.version>24.08.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.08.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>24.10.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>24.10.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.13</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
Fix issue : https://github.com/NVIDIA/spark-rapids/issues/11240

Update the rapids JNI and private dependency version to 24.10.0-SNAPSHOT as the nightly CI has been completed

