### PR TITLE
Asynchronously copy table data to the host during shuffle

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -970,8 +970,9 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       RapidsHostColumnVector[] hostCols = new RapidsHostColumnVector[gpuCols.length];
       try {
         for (int i = 0; i < gpuCols.length; i++) {
-          hostCols[i] = gpuCols[i].copyToHost();
+          hostCols[i] = gpuCols[i].copyToHostAsync(Cuda.DEFAULT_STREAM);
         }
+        Cuda.DEFAULT_STREAM.sync();
       } catch (Exception e) {
         for (RapidsHostColumnVector hostCol : hostCols) {
           if (hostCol != null) {
@@ -1092,6 +1093,10 @@ public class GpuColumnVector extends GpuColumnVectorBase {
 
   public final RapidsHostColumnVector copyToHost() {
     return new RapidsHostColumnVector(type, cudfCv.copyToHost());
+  }
+
+  public final RapidsHostColumnVector copyToHostAsync(Cuda.Stream stream) {
+    return new RapidsHostColumnVector(type, cudfCv.copyToHostAsync(stream));
   }
 
   public final RapidsNullSafeHostColumnVector copyToNullSafeHost() {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -130,10 +130,10 @@ trait GpuPartitioning extends Partitioning {
       val hostCols = withRetryNoSplit {
         partitionColumns.safeMap(_.copyToHostAsync(Cuda.DEFAULT_STREAM))
       }
-      closeOnExcept(hostCols) { _ =>
-        Cuda.DEFAULT_STREAM.sync()
-      }
       hostCols
+    }
+    closeOnExcept(hostPartColumns) { _ =>
+      Cuda.DEFAULT_STREAM.sync()
     }
     try {
       // Leaving the GPU for a while


### PR DESCRIPTION
Leverages rapidsai/cudf#16429 to asynchronously copy the partitioned table data to the host.  This avoids unnecessary stream synchronization between each device buffer being copied back to the host and better overlaps CPU and GPU work during sliceInternalOnCpu.  This has no measurable performance difference on NDS runs because the schema of shuffled data is relatively narrow (i.e.: not many separate buffers to copy back to the host and thus not many unnecessary CUDA stream synchronizations to save), but for wide shuffled schemas, this can make a significant difference.  For example, sliceInternalOnCpu for a repartition of a table with 512 integer columns takes half the time with this asynchronous copy.
