### PR TITLE
Fix race conditions in `RapidsBufferCatalog`

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
@@ -341,8 +341,8 @@ class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
     }(ec)
 
     latch.await()
-    // Let's wait for a little more, so that the future is likely executed first.
-    Thread.sleep(100)
+    // Let's wait for a little more, so that registerNewBuffer is likely executed first.
+    Thread.sleep(300)
     val acquired = catalog.acquireBuffer(handle)
     Await.ready(future, 1.second)
     assertResult(StorageTier.DEVICE)(acquired.storageTier)
@@ -365,8 +365,8 @@ class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
     }(ec)
 
     latch.await()
-    // Let's wait for a little more, so that the future is likely executed first.
-    Thread.sleep(500)
+    // Let's wait for a little more, so that setSpillPriority is likely executed first.
+    Thread.sleep(300)
     val acquired = catalog.acquireBuffer(handle)
     Await.ready(future, 1.second)
     assertResult(priority)(acquired.getSpillPriority)
@@ -388,8 +388,8 @@ class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
     }(ec)
 
     latch.await()
-    // Let's wait for a little more, so that the future is likely executed first.
-    Thread.sleep(500)
+    // Let's wait for a little more, so that removeBufferTier is likely executed first.
+    Thread.sleep(300)
     val caught = intercept[NoSuchElementException]{
       catalog.acquireBuffer(handle)
     }
@@ -413,8 +413,8 @@ class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
     }(ec)
 
     latch.await()
-    // Let's wait for a little more, so that the future is likely executed first.
-    Thread.sleep(500)
+    // Let's wait for a little more, so that updateTiers is likely executed first.
+    Thread.sleep(300)
     val isSpilled: Boolean = catalog.isBufferSpilled(bufferId, StorageTier.DEVICE)
     Await.ready(future, 1.second)
     assert(isSpilled)
@@ -436,8 +436,8 @@ class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
     }(ec)
 
     latch.await()
-    // Let's wait for a little more, so that the future is likely executed first.
-    Thread.sleep(500)
+    // Let's wait for a little more, so that updateTiers is likely executed first.
+    Thread.sleep(300)
     val meta = catalog.getBufferMeta(bufferId)
     Await.ready(future, 1.second)
     assertResult(hostBuffer.meta)(meta)


### PR DESCRIPTION
Currently some functions in `RapidsBufferCatalog` use the `ConcurrentHashMap.get()` function to find a value first, which is `Seq[RapidsBuffer]`, and then perform some stateful action on the value, such as getting a spill state of one of buffers or get the buffer at the highest tier. This is not thread-safe because the operations performed after `ConcurrentHashMap.get()` are not "guarded" by any lock. The new unit tests added illustrate these cases. This PR fixes these race conditions by delegating synchronization to the `ConcurrentHashMap.compute()`.

As for the new unit tests, I used the `CountDownLatch()` _and_ `Thread.sleep()` for the ordering of calls within multiple threads. However, this is not ideal for a couple of reasons. The major issues with this approach include:
- The tests can flake as the ordering based on `Thread.sleep()` is never trustable.
- The tests might not be testing what we should. The test case we want to test is when one thread enters a synchronized block and then another thread tries to enter. This cannot be done deterministically without pushing some synchronization control logic (such as the latch) to the synchronized block in the target functions.
  - For example, to test the case of concurrent calls to `registerNewBuffer()` and `acquireBuffer()` when `registerNewBuffer()` acquires the lock first, the latch should be pushed down to inside of the `bufferMap.compute()` in `registerNewBuffer()`, so that it can be counted down after `registerNewBuffer()` very likely acquires the lock.

I wonder what we usually do in this case. Here are what I used to do in the past. I do not think any of them is ideal, appreciate any better idea.
1. Keep the `Thread.sleep()`. We might happen to test some cases we want if the timing is right. For flaky tests, let them flake, but add some retries for them. 
2. Or, we add some special logic in the production code path only for testing. The new tests call the special logic directly, so that they can test the test cases they want to test.