### PR TITLE
Swap build side for outer joins when natural build side is explosive [databricks]

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -24,9 +24,10 @@ from spark_session import with_cpu_session, is_before_spark_330, is_databricks_r
 
 pytestmark = [pytest.mark.nightly_resource_consuming_test]
 
-all_non_symmetric_join_types = ['Left', 'Right', 'LeftSemi', 'LeftAnti', 'Cross']
-all_symmetric_join_types = ['Inner', 'FullOuter']
-all_join_types = all_non_symmetric_join_types + all_symmetric_join_types
+all_non_sized_join_types = ['LeftSemi', 'LeftAnti', 'Cross']
+all_symmetric_sized_join_types = ['Inner', 'FullOuter']
+all_asymmetric_sized_join_types = ['LeftOuter', 'RightOuter']
+all_join_types = all_non_sized_join_types + all_symmetric_sized_join_types + all_asymmetric_sized_join_types
 
 all_gen = [StringGen(), ByteGen(), ShortGen(), IntegerGen(), LongGen(),
            BooleanGen(), DateGen(), TimestampGen(), null_gen,
@@ -218,32 +219,46 @@ def test_sortmerge_join_wrong_key_fallback(data_gen, join_type):
 # 3 times smaller than the other side.  So it is not likely to happen
 # unless we can give it some help. Parameters are setup to try to make
 # this happen, if test fails something might have changed related to that.
-def hash_join_ridealong(data_gen, join_type, sub_part_enabled):
+def hash_join_ridealong(data_gen, join_type, confs):
     def do_join(spark):
         left, right = create_ridealong_df(spark, short_gen, data_gen, 50, 500)
         return left.join(right, left.key == right.r_key, join_type)
-    _all_conf = copy_and_update(_hash_join_conf, {
-        "spark.rapids.sql.test.subPartitioning.enabled": sub_part_enabled
-    })
+    _all_conf = copy_and_update(_hash_join_conf, confs)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=_all_conf)
 
 @validate_execs_in_gpu_plan('GpuShuffledHashJoinExec')
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize('join_type', all_non_symmetric_join_types, ids=idfn)
+@pytest.mark.parametrize('join_type', all_non_sized_join_types, ids=idfn)
 @pytest.mark.parametrize('sub_part_enabled', ['false', 'true'], ids=['SubPartition_OFF', 'SubPartition_ON'])
 @allow_non_gpu(*non_utc_allow)
-def test_hash_join_ridealong_non_symmetric(data_gen, join_type, sub_part_enabled):
-    hash_join_ridealong(data_gen, join_type, sub_part_enabled)
+def test_hash_join_ridealong_non_sized(data_gen, join_type, sub_part_enabled):
+    confs = {
+        "spark.rapids.sql.test.subPartitioning.enabled": sub_part_enabled
+    }
+    hash_join_ridealong(data_gen, join_type, confs)
 
 @validate_execs_in_gpu_plan('GpuShuffledSymmetricHashJoinExec')
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize('join_type', all_symmetric_join_types, ids=idfn)
-@pytest.mark.parametrize('sub_part_enabled', ['false', 'true'], ids=['SubPartition_OFF', 'SubPartition_ON'])
+@pytest.mark.parametrize('join_type', all_symmetric_sized_join_types, ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_join_ridealong_symmetric(data_gen, join_type, sub_part_enabled):
-    hash_join_ridealong(data_gen, join_type, sub_part_enabled)
+def test_hash_join_ridealong_symmetric(data_gen, join_type):
+    confs = {
+        "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
+    }
+    hash_join_ridealong(data_gen, join_type, confs)
+
+@validate_execs_in_gpu_plan('GpuShuffledAsymmetricHashJoinExec')
+@ignore_order(local=True)
+@pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
+@pytest.mark.parametrize('join_type', all_asymmetric_sized_join_types, ids=idfn)
+@allow_non_gpu(*non_utc_allow)
+def test_hash_join_ridealong_asymmetric(data_gen, join_type):
+    confs = {
+        "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
+    }
+    hash_join_ridealong(data_gen, join_type, confs)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -997,6 +1012,8 @@ def hash_join_different_key_integral_types(left_gen, right_gen, join_type):
         right = unary_op_df(spark, right_gen, length=500)
         return left.join(right, left.a == right.a, join_type)
     _all_conf = copy_and_update(_hash_join_conf, {
+        "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
+        "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
         "spark.rapids.sql.test.subPartitioning.enabled": True
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=_all_conf)
@@ -1005,16 +1022,24 @@ def hash_join_different_key_integral_types(left_gen, right_gen, join_type):
 @ignore_order(local=True)
 @pytest.mark.parametrize('left_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('right_gen', limited_integral_gens, ids=idfn)
-@pytest.mark.parametrize('join_type', all_non_symmetric_join_types, ids=idfn)
-def test_hash_join_different_key_integral_types_non_symmetric(left_gen, right_gen, join_type):
+@pytest.mark.parametrize('join_type', all_non_sized_join_types, ids=idfn)
+def test_hash_join_different_key_integral_types_non_sized(left_gen, right_gen, join_type):
     hash_join_different_key_integral_types(left_gen, right_gen, join_type)
 
 @validate_execs_in_gpu_plan('GpuShuffledSymmetricHashJoinExec')
 @ignore_order(local=True)
 @pytest.mark.parametrize('left_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('right_gen', limited_integral_gens, ids=idfn)
-@pytest.mark.parametrize('join_type', all_symmetric_join_types, ids=idfn)
+@pytest.mark.parametrize('join_type', all_symmetric_sized_join_types, ids=idfn)
 def test_hash_join_different_key_integral_types_symmetric(left_gen, right_gen, join_type):
+    hash_join_different_key_integral_types(left_gen, right_gen, join_type)
+
+@validate_execs_in_gpu_plan('GpuShuffledAsymmetricHashJoinExec')
+@ignore_order(local=True)
+@pytest.mark.parametrize('left_gen', limited_integral_gens, ids=idfn)
+@pytest.mark.parametrize('right_gen', limited_integral_gens, ids=idfn)
+@pytest.mark.parametrize('join_type', all_asymmetric_sized_join_types, ids=idfn)
+def test_hash_join_different_key_integral_types_asymmetric(left_gen, right_gen, join_type):
     hash_join_different_key_integral_types(left_gen, right_gen, join_type)
 
 
@@ -1200,15 +1225,16 @@ def test_distinct_join(join_type, batch_size):
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=join_conf)
 
 @ignore_order(local=True)
-@pytest.mark.parametrize("join_type", ["Inner", "FullOuter"], ids=idfn)
+@pytest.mark.parametrize("join_type", ["Inner", "FullOuter", "LeftOuter", "RightOuter"], ids=idfn)
 @pytest.mark.parametrize("is_left_host_shuffle", [False, True], ids=idfn)
 @pytest.mark.parametrize("is_right_host_shuffle", [False, True], ids=idfn)
 @pytest.mark.parametrize("is_left_smaller", [False, True], ids=idfn)
 @pytest.mark.parametrize("batch_size", ["1024", "1g"], ids=idfn)
-def test_new_symmetric_join(join_type, is_left_host_shuffle, is_right_host_shuffle,
-                            is_left_smaller, batch_size):
+def test_sized_join(join_type, is_left_host_shuffle, is_right_host_shuffle,
+                    is_left_smaller, batch_size):
     join_conf = {
         "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
+        "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
         "spark.sql.autoBroadcastJoinThreshold": "1",
         "spark.rapids.sql.batchSizeBytes": batch_size
     }
@@ -1236,15 +1262,17 @@ def test_new_symmetric_join(join_type, is_left_host_shuffle, is_right_host_shuff
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=join_conf)
 
 @ignore_order(local=True)
-@pytest.mark.parametrize("join_type", ["Inner", "FullOuter"], ids=idfn)
+@pytest.mark.parametrize("join_type", ["Inner", "FullOuter", "LeftOuter", "RightOuter"], ids=idfn)
 @pytest.mark.parametrize("is_left_smaller", [False, True], ids=idfn)
 @pytest.mark.parametrize("is_ast_supported", [False, True], ids=idfn)
 @pytest.mark.parametrize("batch_size", ["1024", "1g"], ids=idfn)
-def test_new_symmetric_join_conditional(join_type, is_ast_supported, is_left_smaller, batch_size):
-    if join_type == "FullOuter" and not is_ast_supported:
-        pytest.skip("Full outer joins do not support a non-AST condition")
+def test_sized_join_conditional(join_type, is_ast_supported, is_left_smaller, batch_size):
+    if join_type != "Inner" and not is_ast_supported:
+        pytest.skip("Only inner joins support a non-AST condition")
     join_conf = {
         "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
+        "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
+        "spark.rapids.sql.join.use"
         "spark.sql.autoBroadcastJoinThreshold": "1",
         "spark.rapids.sql.batchSizeBytes": batch_size
     }
@@ -1267,3 +1295,41 @@ def test_new_symmetric_join_conditional(join_type, is_ast_supported, is_left_sma
             cond.append(left_df.ints >= f.log(right_df.ints))
         return left_df.join(right_df, cond, join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=join_conf)
+
+@pytest.mark.parametrize("join_type", ["LeftOuter", "RightOuter"], ids=idfn)
+@pytest.mark.parametrize("is_left_replicated", [False, True], ids=idfn)
+@pytest.mark.parametrize("is_conditional", [False, True], ids=idfn)
+@pytest.mark.parametrize("is_outer_side_small", [False, True], ids=idfn)
+def test_sized_join_high_key_replication(join_type, is_left_replicated, is_conditional,
+                                         is_outer_side_small):
+    join_conf = {
+        "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
+        "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
+        "spark.rapids.sql.join.use"
+        "spark.sql.autoBroadcastJoinThreshold": "1"
+    }
+    left_size, right_size = (30000, 40000)
+    left_key_gen, right_key_gen = (
+        RepeatSeqGen([1, 2, 3, 4, 5, 6, 7, None], data_type=IntegerType()),
+        RepeatSeqGen([1, None], data_type=IntegerType()))
+    if is_left_replicated:
+        left_key_gen, right_key_gen = (right_key_gen, left_key_gen)
+    if is_outer_side_small:
+        join_conf["spark.rapids.sql.batchSizeBytes"] = "131072"
+        if join_type == "LeftOuter":
+            left_size = 100
+        else:
+            right_size = 100
+    def do_join(spark):
+        left_df = gen_df(spark, [
+            ("key1", left_key_gen),
+            ("ints", RepeatSeqGen(IntegerGen(), length = 5)),
+            ("floats", float_gen)], left_size)
+        right_df = gen_df(spark, [
+            ("ints2", int_gen),
+            ("key2", right_key_gen)], right_size)
+        cond = [left_df.key1 == right_df.key2]
+        if is_conditional:
+            cond.append(left_df.ints >= right_df.ints2)
+        return left_df.join(right_df, cond, join_type)
+    assert_gpu_and_cpu_row_counts_equal(do_join, conf=join_conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -23,8 +23,8 @@ import ai.rapids.cudf.JCudfSerialization.HostConcatResult
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
 import com.nvidia.spark.rapids.shims.{GpuHashPartitioning, ShimBinaryExecNode}
-import org.apache.spark.TaskContext
 
+import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -304,7 +304,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
    */
   def shuffledHashJoinOptimizeShuffle(plan: SparkPlan): SparkPlan = {
     plan match {
-      case j: GpuShuffledSymmetricHashJoinExec =>
+      case j: GpuShuffledSizedHashJoinExec[_] =>
         val newChildren = Seq(j.left, j.right).map {
           case GpuCoalesceBatches(GpuShuffleCoalesceExec(c, _), _) => c
           case GpuShuffleCoalesceExec(c, _) => c

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -665,10 +665,28 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
 
   val USE_SHUFFLED_SYMMETRIC_HASH_JOIN = conf("spark.rapids.sql.join.useShuffledSymmetricHashJoin")
     .doc("Use the experimental shuffle symmetric hash join designed to improve handling of large " +
-      "joins. Requires spark.rapids.sql.shuffledHashJoin.optimizeShuffle=true.")
+      "symmetric joins. Requires spark.rapids.sql.shuffledHashJoin.optimizeShuffle=true.")
     .internal()
     .booleanConf
     .createWithDefault(true)
+
+  val USE_SHUFFLED_ASYMMETRIC_HASH_JOIN =
+    conf("spark.rapids.sql.join.useShuffledAsymmetricHashJoin")
+      .doc("Use the experimental shuffle asymmetric hash join designed to improve handling of " +
+        "large joins for left and right outer joins. Requires " +
+        "spark.rapids.sql.shuffledHashJoin.optimizeShuffle=true and " +
+        "spark.rapids.sql.join.useShuffledSymmetricHashJoin=true")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
+  val JOIN_OUTER_MAGNIFICATION_THRESHOLD =
+    conf("spark.rapids.sql.join.outer.magnificationFactorThreshold")
+      .doc("The magnification factor threshold at which outer joins will consider using the " +
+        "unnatural side of the join to build the hash table")
+      .internal()
+      .integerConf
+      .createWithDefault(10000)
 
   val STABLE_SORT = conf("spark.rapids.sql.stableSort.enabled")
       .doc("Enable or disable stable sorting. Apache Spark's sorting is typically a stable " +
@@ -2580,6 +2598,11 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val shuffledHashJoinOptimizeShuffle: Boolean = get(SHUFFLED_HASH_JOIN_OPTIMIZE_SHUFFLE)
 
   lazy val useShuffledSymmetricHashJoin: Boolean = get(USE_SHUFFLED_SYMMETRIC_HASH_JOIN)
+
+  lazy val useShuffledAsymmetricHashJoin: Boolean =
+    get(USE_SHUFFLED_ASYMMETRIC_HASH_JOIN)
+
+  lazy val joinOuterMagnificationThreshold: Int = get(JOIN_OUTER_MAGNIFICATION_THRESHOLD)
 
   lazy val stableSort: Boolean = get(STABLE_SORT)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -264,8 +264,7 @@ object GpuHashJoin {
 case class JoinBuildSideStats(streamMagnificationFactor: Double, isDistinct: Boolean)
 
 object JoinBuildSideStats {
-  // TODO: Make boundBuildKeys Seq[GpuExpression]
-  def fromBatch(batch: ColumnarBatch, boundBuildKeys: Seq[Expression]): JoinBuildSideStats = {
+  def fromBatch(batch: ColumnarBatch, boundBuildKeys: Seq[GpuExpression]): JoinBuildSideStats = {
     // This is okay because the build keys must be deterministic
     withResource(GpuProjectExec.project(batch, boundBuildKeys)) { buildKeys =>
       // Based off of the keys on the build side guess at how many output rows there
@@ -283,10 +282,10 @@ object JoinBuildSideStats {
 
 abstract class BaseHashJoinIterator(
     built: LazySpillableColumnarBatch,
-    boundBuiltKeys: Seq[Expression],
+    boundBuiltKeys: Seq[GpuExpression],
     buildStatsOpt: Option[JoinBuildSideStats],
     stream: Iterator[LazySpillableColumnarBatch],
-    boundStreamKeys: Seq[Expression],
+    boundStreamKeys: Seq[GpuExpression],
     streamAttributes: Seq[Attribute],
     targetSize: Long,
     joinType: JoinType,
@@ -441,10 +440,10 @@ abstract class BaseHashJoinIterator(
  */
 class HashJoinIterator(
     built: LazySpillableColumnarBatch,
-    val boundBuiltKeys: Seq[Expression],
+    val boundBuiltKeys: Seq[GpuExpression],
     buildStatsOpt: Option[JoinBuildSideStats],
     private val stream: Iterator[LazySpillableColumnarBatch],
-    val boundStreamKeys: Seq[Expression],
+    val boundStreamKeys: Seq[GpuExpression],
     val streamAttributes: Seq[Attribute],
     val targetSize: Long,
     val joinType: JoinType,
@@ -508,10 +507,10 @@ class HashJoinIterator(
  */
 class ConditionalHashJoinIterator(
     built: LazySpillableColumnarBatch,
-    boundBuiltKeys: Seq[Expression],
+    boundBuiltKeys: Seq[GpuExpression],
     buildStatsOpt: Option[JoinBuildSideStats],
     stream: Iterator[LazySpillableColumnarBatch],
-    boundStreamKeys: Seq[Expression],
+    boundStreamKeys: Seq[GpuExpression],
     streamAttributes: Seq[Attribute],
     compiledCondition: CompiledExpression,
     targetSize: Long,
@@ -612,11 +611,11 @@ class ConditionalHashJoinIterator(
 class HashJoinStreamSideIterator(
     joinType: JoinType,
     built: LazySpillableColumnarBatch,
-    boundBuiltKeys: Seq[Expression],
+    boundBuiltKeys: Seq[GpuExpression],
     buildStatsOpt: Option[JoinBuildSideStats],
     buildSideTrackerInit: Option[SpillableColumnarBatch],
     stream: Iterator[LazySpillableColumnarBatch],
-    boundStreamKeys: Seq[Expression],
+    boundStreamKeys: Seq[GpuExpression],
     streamAttributes: Seq[Attribute],
     compiledCondition: Option[CompiledExpression],
     targetSize: Long,
@@ -851,11 +850,11 @@ class HashJoinStreamSideIterator(
 class HashOuterJoinIterator(
     joinType: JoinType,
     built: LazySpillableColumnarBatch,
-    boundBuiltKeys: Seq[Expression],
+    boundBuiltKeys: Seq[GpuExpression],
     buildStats: Option[JoinBuildSideStats],
     buildSideTrackerInit: Option[SpillableColumnarBatch],
     stream: Iterator[LazySpillableColumnarBatch],
-    boundStreamKeys: Seq[Expression],
+    boundStreamKeys: Seq[GpuExpression],
     streamAttributes: Seq[Attribute],
     boundCondition: Option[GpuExpression],
     numFirstConditionTableColumns: Int,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -256,9 +256,35 @@ object GpuHashJoin {
   }
 }
 
+/**
+ * Class to hold statistics on the build-side batch of a hash join.
+ * @param streamMagnificationFactor estimated magnification of a stream batch during join
+ * @param isDistinct true if all build-side join keys are distinct
+ */
+case class JoinBuildSideStats(streamMagnificationFactor: Double, isDistinct: Boolean)
+
+object JoinBuildSideStats {
+  // TODO: Make boundBuildKeys Seq[GpuExpression]
+  def fromBatch(batch: ColumnarBatch, boundBuildKeys: Seq[Expression]): JoinBuildSideStats = {
+    // This is okay because the build keys must be deterministic
+    withResource(GpuProjectExec.project(batch, boundBuildKeys)) { buildKeys =>
+      // Based off of the keys on the build side guess at how many output rows there
+      // will be for each input row on the stream side. This does not take into account
+      // the join type, data skew or even if the keys actually match.
+      val builtCount = withResource(GpuColumnVector.from(buildKeys)) { keysTable =>
+        keysTable.distinctCount(NullEquality.EQUAL)
+      }
+      val isDistinct = builtCount == buildKeys.numRows()
+      val magnificationFactor = buildKeys.numRows().toDouble / builtCount
+      JoinBuildSideStats(magnificationFactor, isDistinct)
+    }
+  }
+}
+
 abstract class BaseHashJoinIterator(
     built: LazySpillableColumnarBatch,
     boundBuiltKeys: Seq[Expression],
+    buildStatsOpt: Option[JoinBuildSideStats],
     stream: Iterator[LazySpillableColumnarBatch],
     boundStreamKeys: Seq[Expression],
     streamAttributes: Seq[Attribute],
@@ -276,20 +302,19 @@ abstract class BaseHashJoinIterator(
       opTime = opTime,
       joinTime = joinTime) {
   // We can cache this because the build side is not changing
-  protected lazy val (streamMagnificationFactor, isDistinctJoin) = joinType match {
-    case _: InnerLike | LeftOuter | RightOuter | FullOuter =>
-      built.checkpoint()
-      withRetryNoSplit {
-        withRestoreOnRetry(built) {
-          // This is okay because the build keys must be deterministic
-          withResource(GpuProjectExec.project(built.getBatch, boundBuiltKeys)) { builtKeys =>
-            guessStreamMagnificationFactor(builtKeys)
+  protected lazy val buildStats: JoinBuildSideStats = buildStatsOpt.getOrElse {
+    joinType match {
+      case _: InnerLike | LeftOuter | RightOuter | FullOuter =>
+        built.checkpoint()
+        withRetryNoSplit {
+          withRestoreOnRetry(built) {
+            JoinBuildSideStats.fromBatch(built.getBatch, boundBuiltKeys)
           }
         }
-      }
-    case _ =>
-      // existence joins don't change size
-      (1.0, false)
+      case _ =>
+        // existence joins don't change size
+        JoinBuildSideStats(1.0, isDistinct = false)
+    }
   }
 
   override def computeNumJoinRows(cb: LazySpillableColumnarBatch): Long = {
@@ -298,7 +323,7 @@ abstract class BaseHashJoinIterator(
     joinType match {
       // Full Outer join is implemented via LeftOuter/RightOuter, so use same estimate.
       case _: InnerLike | LeftOuter | RightOuter | FullOuter =>
-        Math.ceil(cb.numRows * streamMagnificationFactor).toLong
+        Math.ceil(cb.numRows * buildStats.streamMagnificationFactor).toLong
       case _ => cb.numRows
     }
   }
@@ -398,30 +423,13 @@ abstract class BaseHashJoinIterator(
     }
   }
 
-  /**
-   * Guess the magnification factor for a stream side batch and detect if the build side contains
-   * only unique join keys.
-   * This is temporary until cudf gives us APIs to get the actual gather map size.
-   */
-  private def guessStreamMagnificationFactor(builtKeys: ColumnarBatch): (Double, Boolean) = {
-    // Based off of the keys on the build side guess at how many output rows there
-    // will be for each input row on the stream side. This does not take into account
-    // the join type, data skew or even if the keys actually match.
-    val builtCount = withResource(GpuColumnVector.from(builtKeys)) { keysTable =>
-      keysTable.distinctCount(NullEquality.EQUAL)
-    }
-    val isDistinct = builtCount == builtKeys.numRows()
-    val magnificationFactor = builtKeys.numRows().toDouble / builtCount
-    (magnificationFactor, isDistinct)
-  }
-
   private def estimatedNumBatches(cb: LazySpillableColumnarBatch): Int = joinType match {
     case _: InnerLike | LeftOuter | RightOuter | FullOuter =>
       // We want the gather map size to be around the target size. There are two gather maps
       // that are made up of ints, so estimate how many rows per batch on the stream side
       // will produce the desired gather map size.
       val approximateStreamRowCount = ((targetSize.toDouble / 2) /
-          DType.INT32.getSizeInBytes) / streamMagnificationFactor
+          DType.INT32.getSizeInBytes) / buildStats.streamMagnificationFactor
       val estimatedRowsPerStreamBatch = Math.min(Int.MaxValue, approximateStreamRowCount)
       Math.ceil(cb.numRows / estimatedRowsPerStreamBatch).toInt
     case _ => 1
@@ -434,6 +442,7 @@ abstract class BaseHashJoinIterator(
 class HashJoinIterator(
     built: LazySpillableColumnarBatch,
     val boundBuiltKeys: Seq[Expression],
+    buildStatsOpt: Option[JoinBuildSideStats],
     private val stream: Iterator[LazySpillableColumnarBatch],
     val boundStreamKeys: Seq[Expression],
     val streamAttributes: Seq[Attribute],
@@ -446,6 +455,7 @@ class HashJoinIterator(
     extends BaseHashJoinIterator(
       built,
       boundBuiltKeys,
+      buildStatsOpt,
       stream,
       boundStreamKeys,
       streamAttributes,
@@ -466,14 +476,14 @@ class HashJoinIterator(
         None
       } else {
         val maps = joinType match {
-          case LeftOuter if isDistinctJoin =>
+          case LeftOuter if buildStats.isDistinct =>
             Array(leftKeys.leftDistinctJoinGatherMap(rightKeys, compareNullsEqual))
           case LeftOuter => leftKeys.leftJoinGatherMaps(rightKeys, compareNullsEqual)
           case RightOuter =>
             // Reverse the output of the join, because we expect the right gather map to
             // always be on the right
             rightKeys.leftJoinGatherMaps(leftKeys, compareNullsEqual).reverse
-          case _: InnerLike if isDistinctJoin =>
+          case _: InnerLike if buildStats.isDistinct =>
             if (buildSide == GpuBuildRight) {
               leftKeys.innerDistinctJoinGatherMaps(rightKeys, compareNullsEqual)
             } else {
@@ -499,6 +509,7 @@ class HashJoinIterator(
 class ConditionalHashJoinIterator(
     built: LazySpillableColumnarBatch,
     boundBuiltKeys: Seq[Expression],
+    buildStatsOpt: Option[JoinBuildSideStats],
     stream: Iterator[LazySpillableColumnarBatch],
     boundStreamKeys: Seq[Expression],
     streamAttributes: Seq[Attribute],
@@ -512,6 +523,7 @@ class ConditionalHashJoinIterator(
     extends BaseHashJoinIterator(
       built,
       boundBuiltKeys,
+      buildStatsOpt,
       stream,
       boundStreamKeys,
       streamAttributes,
@@ -574,14 +586,16 @@ class ConditionalHashJoinIterator(
 
 
 /**
- * An iterator that does the stream-side only of a hash full join  In other words, it performs the
- * left or right outer join for the stream side's view of a full outer join. As the join is
- * performed, the build-side rows that are referenced during the join are tracked and can be
- * retrieved after the iteration has completed to assist in performing the anti-join needed to
- * produce the final results needed for the full outer join.
+ * An iterator that does the stream-side only of a hash join. Using full join as an example,
+ * it performs the left or right outer join for the stream side's view of a full outer join.
+ * As the join is performed, the build-side rows that are referenced during the join are tracked
+ * and can be retrieved after the iteration has completed to assist in performing the anti-join
+ * needed to produce the final results needed for the full outer join.
  *
+ * @param joinType the type of join being performed
  * @param built spillable form of the build side table. This will be closed by the iterator.
  * @param boundBuiltKeys bound expressions for the build side equi-join keys
+ * @param buildStatsOpt statistics computed for the build side batch, if any
  * @param buildSideTrackerInit initial value of the build side row tracker, if any. This will be
  *                             closed by the iterator.
  * @param stream iterator to produce batches for the stream side table
@@ -595,9 +609,11 @@ class ConditionalHashJoinIterator(
  * @param opTime metric to update for total operation time
  * @param joinTime metric to update for join time
  */
-class HashFullJoinStreamSideIterator(
+class HashJoinStreamSideIterator(
+    joinType: JoinType,
     built: LazySpillableColumnarBatch,
     boundBuiltKeys: Seq[Expression],
+    buildStatsOpt: Option[JoinBuildSideStats],
     buildSideTrackerInit: Option[SpillableColumnarBatch],
     stream: Iterator[LazySpillableColumnarBatch],
     boundStreamKeys: Seq[Expression],
@@ -611,33 +627,44 @@ class HashFullJoinStreamSideIterator(
     extends BaseHashJoinIterator(
       built,
       boundBuiltKeys,
+      buildStatsOpt,
       stream,
       boundStreamKeys,
       streamAttributes,
       targetSize,
-      FullOuter,
+      joinType,
       buildSide,
       opTime = opTime,
       joinTime = joinTime) {
-  // Full Join is implemented via LeftOuter or RightOuter join, depending on the build side.
-  private val useLeftOuterJoin = (buildSide == GpuBuildRight)
+  private val subJoinType = joinType match {
+    case FullOuter if buildSide == GpuBuildRight => LeftOuter
+    case FullOuter if buildSide == GpuBuildLeft => RightOuter
+    case LeftOuter | RightOuter => Inner
+    case t =>
+      throw new IllegalStateException(s"unsupported join type: $t")
+  }
 
   private val nullEquality = if (compareNullsEqual) NullEquality.EQUAL else NullEquality.UNEQUAL
 
   private[this] var builtSideTracker: Option[SpillableColumnarBatch] = buildSideTrackerInit
 
-  private def unconditionalLeftJoinGatherMaps(
+  private def unconditionalJoinGatherMaps(
       leftKeys: Table, rightKeys: Table): Array[GatherMap] = {
-    if (useLeftOuterJoin) {
-      leftKeys.leftJoinGatherMaps(rightKeys, compareNullsEqual)
-    } else {
-      // Reverse the output of the join, because we expect the right gather map to
-      // always be on the right
-      rightKeys.leftJoinGatherMaps(leftKeys, compareNullsEqual).reverse
+    subJoinType match {
+      case LeftOuter =>
+        leftKeys.leftJoinGatherMaps(rightKeys, compareNullsEqual)
+      case RightOuter =>
+        // Reverse the output of the join, because we expect the right gather map to
+        // always be on the right
+        rightKeys.leftJoinGatherMaps(leftKeys, compareNullsEqual).reverse
+      case Inner =>
+        leftKeys.innerJoinGatherMaps(rightKeys, compareNullsEqual)
+      case t =>
+        throw new IllegalStateException(s"unsupported join type: $t")
     }
   }
 
-  private def conditionalLeftJoinGatherMaps(
+  private def conditionalJoinGatherMaps(
       leftKeys: Table,
       leftData: LazySpillableColumnarBatch,
       rightKeys: Table,
@@ -645,14 +672,20 @@ class HashFullJoinStreamSideIterator(
       compiledCondition: CompiledExpression): Array[GatherMap] = {
     withResource(GpuColumnVector.from(leftData.getBatch)) { leftTable =>
       withResource(GpuColumnVector.from(rightData.getBatch)) { rightTable =>
-        if (useLeftOuterJoin) {
-          Table.mixedLeftJoinGatherMaps(leftKeys, rightKeys, leftTable, rightTable,
-            compiledCondition, nullEquality)
-        } else {
-          // Reverse the output of the join, because we expect the right gather map to
-          // always be on the right
-          Table.mixedLeftJoinGatherMaps(rightKeys, leftKeys, rightTable, leftTable,
-            compiledCondition, nullEquality).reverse
+        subJoinType match {
+          case LeftOuter =>
+            Table.mixedLeftJoinGatherMaps(leftKeys, rightKeys, leftTable, rightTable,
+              compiledCondition, nullEquality)
+          case RightOuter =>
+            // Reverse the output of the join, because we expect the right gather map to
+            // always be on the right
+            Table.mixedLeftJoinGatherMaps(rightKeys, leftKeys, rightTable, leftTable,
+              compiledCondition, nullEquality).reverse
+          case Inner =>
+            Table.mixedInnerJoinGatherMaps(leftKeys, rightKeys, leftTable, rightTable,
+              compiledCondition, nullEquality)
+          case t =>
+            throw new IllegalStateException(s"unsupported join type: $t")
         }
       }
     }
@@ -666,9 +699,9 @@ class HashFullJoinStreamSideIterator(
     withResource(new NvtxWithMetrics("full hash join gather map",
       NvtxColor.ORANGE, joinTime)) { _ =>
       val maps = compiledCondition.map { condition =>
-        conditionalLeftJoinGatherMaps(leftKeys, leftData, rightKeys, rightData, condition)
+        conditionalJoinGatherMaps(leftKeys, leftData, rightKeys, rightData, condition)
       }.getOrElse {
-        unconditionalLeftJoinGatherMaps(leftKeys, rightKeys)
+        unconditionalJoinGatherMaps(leftKeys, rightKeys)
       }
       assert(maps.length == 2)
       try {
@@ -680,12 +713,11 @@ class HashFullJoinStreamSideIterator(
             updateTrackingMask(if (buildSide == GpuBuildRight) lazyRightMap else lazyLeftMap)
           }
         }
-        val (leftOutOfBoundsPolicy, rightOutOfBoundsPolicy) = {
-          if (useLeftOuterJoin) {
-            (OutOfBoundsPolicy.DONT_CHECK, OutOfBoundsPolicy.NULLIFY)
-          } else {
-            (OutOfBoundsPolicy.NULLIFY, OutOfBoundsPolicy.DONT_CHECK)
-          }
+        val (leftOutOfBoundsPolicy, rightOutOfBoundsPolicy) = subJoinType match {
+          case LeftOuter => (OutOfBoundsPolicy.DONT_CHECK, OutOfBoundsPolicy.NULLIFY)
+          case RightOuter => (OutOfBoundsPolicy.NULLIFY, OutOfBoundsPolicy.DONT_CHECK)
+          case Inner => (OutOfBoundsPolicy.DONT_CHECK, OutOfBoundsPolicy.DONT_CHECK)
+          case t => throw new IllegalStateException(s"unsupported join type $t")
         }
         val gatherer = JoinGatherer(lazyLeftMap, leftData, lazyRightMap, rightData,
           leftOutOfBoundsPolicy, rightOutOfBoundsPolicy)
@@ -786,12 +818,16 @@ class HashFullJoinStreamSideIterator(
 }
 
 /**
- * An iterator that does a hash full join against a stream of batches.  It does this by
- * doing a left or right outer join and keeping track of the hits on the build side.  It then
+ * An iterator that does a hash outer join against a stream of batches where either the join
+ * type is a full outer join or the join type is a left or right outer join and the build side
+ * matches the outer join side.  It does this by doing a subset of the original join (e.g.:
+ * left outer for a full outer join) and keeping track of the hits on the build side.  It then
  * produces a final batch of all the build side rows that were not already included.
  *
+ * @param joinType the type of join to perform
  * @param built spillable form of the build side table. This will be closed by the iterator.
  * @param boundBuiltKeys bound expressions for the build side equi-join keys
+ * @param buildStats statistics computed for the build side batch, if any
  * @param buildSideTrackerInit initial value of the build side row tracker, if any. This will be
  *                             closed by the iterator.
  * @param stream iterator to produce batches for the stream side table
@@ -804,9 +840,11 @@ class HashFullJoinStreamSideIterator(
  * @param opTime metric to update for total operation time
  * @param joinTime metric to update for join time
  */
-class HashFullJoinIterator(
+class HashOuterJoinIterator(
+    joinType: JoinType,
     built: LazySpillableColumnarBatch,
     boundBuiltKeys: Seq[Expression],
+    buildStats: Option[JoinBuildSideStats],
     buildSideTrackerInit: Option[SpillableColumnarBatch],
     stream: Iterator[LazySpillableColumnarBatch],
     boundStreamKeys: Seq[Expression],
@@ -823,9 +861,9 @@ class HashFullJoinIterator(
     use(opTime.ns(gpuExpr.convertToAst(numFirstConditionTableColumns).compile()))
   }
 
-  private val streamJoinIter = new HashFullJoinStreamSideIterator(built, boundBuiltKeys,
-    buildSideTrackerInit, stream, boundStreamKeys, streamAttributes, compiledCondition, targetSize,
-    buildSide, compareNullsEqual, opTime, joinTime)
+  private val streamJoinIter = new HashJoinStreamSideIterator(joinType, built, boundBuiltKeys,
+    buildStats, buildSideTrackerInit, stream, boundStreamKeys, streamAttributes, compiledCondition,
+    targetSize, buildSide, compareNullsEqual, opTime, joinTime)
 
   private var finalBatch: Option[ColumnarBatch] = None
 
@@ -1137,21 +1175,22 @@ trait GpuHashJoin extends GpuJoinExec {
           opTime,
           joinTime)
       case FullOuter =>
-        new HashFullJoinIterator(spillableBuiltBatch, boundBuildKeys, None, lazyStream,
-          boundStreamKeys, streamedPlan.output, boundCondition, numFirstConditionTableColumns,
-          targetSize, buildSide, compareNullsEqual, opTime, joinTime)
+        new HashOuterJoinIterator(joinType, spillableBuiltBatch, boundBuildKeys, None, None,
+          lazyStream, boundStreamKeys, streamedPlan.output,
+          boundCondition, numFirstConditionTableColumns, targetSize, buildSide,
+          compareNullsEqual, opTime, joinTime)
       case _ =>
         if (boundCondition.isDefined) {
           // ConditionalHashJoinIterator will close the compiled condition
           val compiledCondition =
             boundCondition.get.convertToAst(numFirstConditionTableColumns).compile()
-          new ConditionalHashJoinIterator(spillableBuiltBatch, boundBuildKeys, lazyStream,
-            boundStreamKeys, streamedPlan.output, compiledCondition,
+          new ConditionalHashJoinIterator(spillableBuiltBatch, boundBuildKeys, None,
+            lazyStream, boundStreamKeys, streamedPlan.output, compiledCondition,
             targetSize, joinType, buildSide, compareNullsEqual, opTime, joinTime)
         } else {
-          new HashJoinIterator(spillableBuiltBatch, boundBuildKeys, lazyStream, boundStreamKeys,
-            streamedPlan.output, targetSize, joinType, buildSide, compareNullsEqual,
-            opTime, joinTime)
+          new HashJoinIterator(spillableBuiltBatch, boundBuildKeys, None,
+            lazyStream, boundStreamKeys, streamedPlan.output, targetSize, joinType, buildSide,
+            compareNullsEqual, opTime, joinTime)
         }
     }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -81,6 +81,7 @@ class AdaptiveQueryExecSuite
     collect(plan) {
       case j: GpuShuffledHashJoinExec => j
       case j: GpuShuffledSymmetricHashJoinExec => j
+      case j: GpuShuffledAsymmetricHashJoinExec => j
     }
   }
 


### PR DESCRIPTION
Fixes #11234.  Adds a new asymmetric hash join exec that is similar to the existing symmetric hash join handling of full outer joins except it has a slightly different algorithm for determining the build side.  It tries the natural build side first.  If that does not fit in a single batch, it will switch to the stream side if that does.  If the build side fits but appears to be explosive due to highly replicated keys, it will pivot to the stream side if that also fits in a single batch and is less explosive.