### PR TITLE
Fix Delta Lake truncation of min/max string values [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -123,6 +123,10 @@ def _decode_jsons(json_data):
     jsons.sort(key=json_to_sort_key)
     return jsons
 
+def read_delta_logs(spark, path):
+    log_data = spark.sparkContext.wholeTextFiles(path).collect()
+    return dict([(os.path.basename(x), _decode_jsons(y)) for x, y in log_data])
+
 def assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path):
     cpu_log_data = spark.sparkContext.wholeTextFiles(data_path + "/CPU/_delta_log/*").collect()
     gpu_log_data = spark.sparkContext.wholeTextFiles(data_path + "/GPU/_delta_log/*").collect()


### PR DESCRIPTION
This pulls in the changes from delta-io/delta#3430 to fix incorrect truncation of strings in Delta log statistics.  Since this does not match the behavior of the CPU on most Delta Lake versions we support, the test was updated to use canned values and check the GPU statistics for what is expected when those values are truncated.