### PR TITLE
[auto-merge] branch-24.08 to branch-24.10 [skip ci] [bot]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change log
-Generated on 2024-08-12
+Generated on 2024-08-16
 
 ## Release 24.08
 
@@ -88,6 +88,8 @@ Generated on 2024-08-12
 ### PRs
 |||
 |:---|:---|
+|[#11335](https://github.com/NVIDIA/spark-rapids/pull/11335)|Fix Delta Lake truncation of min/max string values|
+|[#11304](https://github.com/NVIDIA/spark-rapids/pull/11304)|Update changelog for v24.08.0 release [skip ci]|
 |[#11303](https://github.com/NVIDIA/spark-rapids/pull/11303)|Update rapids JNI and private dependency to 24.08.0|
 |[#11296](https://github.com/NVIDIA/spark-rapids/pull/11296)|[DOC] update doc for 2408 release [skip CI]|
 |[#11309](https://github.com/NVIDIA/spark-rapids/pull/11309)|[Doc ]Update lore doc about the range [skip ci]|


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-24.08` to create a PR keeping `branch-24.10` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.