### PR TITLE
Move SparkRapidsBuildInfoEvent to its own file

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -37,7 +37,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.spark.{ExceptionFailure, SparkConf, SparkContext, TaskContext, TaskFailedReason}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.SparkListenerEvent
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
@@ -84,8 +83,6 @@ object RapidsPluginUtils extends Logging {
     cudfBuildInfo = loadProps(CUDF_PROPS_FILENAME),
     sparkRapidsPrivateBuildInfo =loadProps(PRIVATE_PROPS_FILENAME)
   )
-
-
 
   {
     logInfo(s"RAPIDS Accelerator build: ${buildInfoEvent.sparkRapidsBuildInfo}")
@@ -411,14 +408,6 @@ object RapidsPluginUtils extends Logging {
     }
   }
 }
-
-
-case class SparkRapidsBuildInfoEvent(
-  sparkRapidsBuildInfo: Map[String, String],
-  sparkRapidsJniBuildInfo: Map[String, String],
-  cudfBuildInfo: Map[String, String],
-  sparkRapidsPrivateBuildInfo: Map[String, String]
-) extends SparkListenerEvent
 
 /**
  * The Spark driver plugin provided by the RAPIDS Spark plugin.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/sparkRapidsListeners.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/sparkRapidsListeners.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.scheduler.SparkListenerEvent
+
+case class SparkRapidsBuildInfoEvent(
+  sparkRapidsBuildInfo: Map[String, String],
+  sparkRapidsJniBuildInfo: Map[String, String],
+  cudfBuildInfo: Map[String, String],
+  sparkRapidsPrivateBuildInfo: Map[String, String]
+) extends SparkListenerEvent


### PR DESCRIPTION
Create a file for the SparkListener events we have. Currently this is just the SparkRapidsBuildInfoEvent.  Move it to its own file so that the tools could more easily get this file.

related to https://github.com/NVIDIA/spark-rapids-tools/issues/1296

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
