### PR TITLE
Create a PrioritySemaphore to back the GpuSemaphore

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids
 
 import java.util
-import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, Semaphore}
+import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -183,6 +183,7 @@ private final class SemaphoreTaskInfo() extends Logging {
    * If this task holds the GPU semaphore or not.
    */
   private var hasSemaphore = false
+  private var lastHeld: Long = 0
 
   /**
    * Does this task have the GPU semaphore or not. Be careful because it can change at
@@ -216,7 +217,7 @@ private final class SemaphoreTaskInfo() extends Logging {
    * Block the current thread until we have the semaphore.
    * @param semaphore what we are going to wait on.
    */
-  def blockUntilReady(semaphore: Semaphore): Unit = {
+  def blockUntilReady(semaphore: PrioritySemaphore[Long]): Unit = {
     val t = Thread.currentThread()
     // All threads start out in blocked, but will move out of it inside of the while loop.
     synchronized {
@@ -250,7 +251,7 @@ private final class SemaphoreTaskInfo() extends Logging {
         if (!done && shouldBlockOnSemaphore) {
           // We cannot be in a synchronized block and wait on the semaphore
           // so we have to release it and grab it again afterwards.
-          semaphore.acquire(numPermits)
+          semaphore.acquire(numPermits, lastHeld)
           synchronized {
             // We now own the semaphore so we need to wake up all of the other tasks that are
             // waiting.
@@ -277,7 +278,7 @@ private final class SemaphoreTaskInfo() extends Logging {
     }
   }
 
-  def tryAcquire(semaphore: Semaphore): Boolean = synchronized {
+  def tryAcquire(semaphore: PrioritySemaphore[Long]): Boolean = synchronized {
     val t = Thread.currentThread()
     if (hasSemaphore) {
       activeThreads.add(t)
@@ -299,12 +300,13 @@ private final class SemaphoreTaskInfo() extends Logging {
     }
   }
 
-  def releaseSemaphore(semaphore: Semaphore): Unit = synchronized {
+  def releaseSemaphore(semaphore: PrioritySemaphore[Long]): Unit = synchronized {
     val t = Thread.currentThread()
     activeThreads.remove(t)
     if (hasSemaphore) {
       semaphore.release(numPermits)
       hasSemaphore = false
+      lastHeld = System.currentTimeMillis()
     }
     // It should be impossible for the current thread to be blocked when releasing the semaphore
     // because no blocked thread should ever leave `blockUntilReady`, which is where we put it in
@@ -317,7 +319,8 @@ private final class SemaphoreTaskInfo() extends Logging {
 
 private final class GpuSemaphore() extends Logging {
   import GpuSemaphore._
-  private val semaphore = new Semaphore(MAX_PERMITS)
+
+  private val semaphore = new PrioritySemaphore[Long](MAX_PERMITS)
   // Keep track of all tasks that are both active on the GPU and blocked waiting on the GPU
   private val tasks = new ConcurrentHashMap[Long, SemaphoreTaskInfo]
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util.concurrent.locks.{Condition, ReentrantLock}
+
+import scala.collection.mutable.PriorityQueue
+
+object PrioritySemaphore {
+  private val DEFAULT_MAX_PERMITS = 1000
+}
+
+class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) {
+  private val lock = new ReentrantLock()
+  private var occupiedSlots: Int = 0
+
+  private case class ThreadInfo(priority: T, condition: Condition)
+
+  private val waitingQueue: PriorityQueue[ThreadInfo] = PriorityQueue()(Ordering.by(_.priority))
+
+  def this()(implicit ordering: Ordering[T]) = this(PrioritySemaphore.DEFAULT_MAX_PERMITS)(ordering)
+
+  def tryAcquire(numPermits: Int): Boolean = {
+    lock.lock()
+    try {
+    if (canAcquire(numPermits)) {
+      commitAcquire(numPermits)
+      true
+    } else {
+      false
+    }
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  def acquire(numPermits: Int, priority: T): Unit = {
+    lock.lock()
+    try {
+      val condition = lock.newCondition()
+      while (!canAcquire(numPermits)) {
+        waitingQueue.enqueue(ThreadInfo(priority, condition))
+        condition.await()
+      }
+      commitAcquire(numPermits)
+
+    } finally {
+      lock.unlock()
+    }}
+
+  private def commitAcquire(numPermits: Int): Unit = {
+    occupiedSlots += numPermits
+  }
+
+  def release(numPermits: Int): Unit = {
+    lock.lock()
+    try {
+      occupiedSlots -= numPermits
+      if (waitingQueue.nonEmpty) {
+        val nextThread = waitingQueue.dequeue()
+        nextThread.condition.signal()
+      }
+    }
+    finally {
+      lock.unlock()
+    }
+  }
+
+  private def canAcquire(numPermits: Int): Boolean = {
+    occupiedSlots + numPermits <= maxPermits
+  }
+
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/PrioritySemaphoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/PrioritySemaphoreSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/PrioritySemaphoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/PrioritySemaphoreSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import scala.collection.JavaConverters._
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PrioritySemaphoreSuite extends AnyFunSuite {
+  type TestPrioritySemaphore = PrioritySemaphore[Long]
+
+  test("tryAcquire should return true if permits are available") {
+    val semaphore = new TestPrioritySemaphore(10)
+
+    assert(semaphore.tryAcquire(5))
+    assert(semaphore.tryAcquire(3))
+    assert(semaphore.tryAcquire(2))
+    assert(!semaphore.tryAcquire(1))
+  }
+
+  test("acquire and release should work correctly") {
+    val semaphore = new TestPrioritySemaphore(1)
+
+    assert(semaphore.tryAcquire(1))
+
+    val latch = new CountDownLatch(1)
+    val t = new Thread(() => {
+      try {
+        semaphore.acquire(1, 1)
+        fail("Should not acquire permit")
+      } catch {
+        case _: InterruptedException =>
+          semaphore.acquire(1, 1)
+      } finally {
+        latch.countDown()
+      }
+    })
+    t.start()
+
+    Thread.sleep(100)
+    t.interrupt()
+
+    semaphore.release(1)
+
+    latch.await(1, TimeUnit.SECONDS)
+  }
+
+  test("multiple threads should handle permits and priority correctly") {
+    val semaphore = new TestPrioritySemaphore(0)
+    val latch = new CountDownLatch(3)
+    val results = new java.util.ArrayList[Int]()
+
+    def taskWithPriority(priority: Int) = new Runnable {
+      override def run(): Unit = {
+        try {
+          semaphore.acquire(1, priority)
+          results.add(priority)
+          semaphore.release(1)
+        } finally {
+          latch.countDown()
+        }
+      }
+    }
+
+    new Thread(taskWithPriority(2)).start()
+    new Thread(taskWithPriority(1)).start()
+    new Thread(taskWithPriority(3)).start()
+
+    Thread.sleep(100)
+    semaphore.release(1)
+
+    latch.await(1, TimeUnit.SECONDS)
+    assert(results.asScala.toList == List(3, 2, 1))
+  }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
Closes https://github.com/NVIDIA/spark-rapids/issues/8301

This PR adds a PrioritySemaphore which has a similar interface to the java Semaphore, but also uses a priority queue to determine the order in which to wake blocked threads. It changes the existing GpuSemaphore, which was using a regular Semaphore underneath, to use this new version, specifying a priority based on when a given task most recently held the semaphore. This has the effect of reducing spill as tasks with data loaded on the GPU will be more likely to resume processing on the data before it's evicted by a new task.