### PR TITLE
prevent duplicate queueing in the prio semaphore

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -288,7 +288,7 @@ private final class SemaphoreTaskInfo() extends Logging {
     } else {
       if (blockedThreads.size() == 0) {
         // No other threads for this task are waiting, so we might be able to grab this directly
-        val ret = semaphore.tryAcquire(numPermits)
+        val ret = semaphore.tryAcquire(numPermits, lastHeld)
         if (ret) {
           hasSemaphore = true
           activeThreads.add(t)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
@@ -59,7 +59,9 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
     try {
       val condition = lock.newCondition()
       while (!canAcquire(numPermits)) {
-        waitingQueue.enqueue(ThreadInfo(priority, condition))
+        if (!waitingQueue.exists(_.condition == condition)) {
+          waitingQueue.enqueue(ThreadInfo(priority, condition))
+        }
         condition.await()
       }
       commitAcquire(numPermits)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
@@ -19,10 +19,6 @@ package com.nvidia.spark.rapids
 import java.util.{Comparator, PriorityQueue}
 import java.util.concurrent.locks.{Condition, ReentrantLock}
 
-object PrioritySemaphore {
-  private val DEFAULT_MAX_PERMITS = 1000
-}
-
 class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) {
   // This lock is used to generate condition variables, which affords us the flexibility to notify
   // specific threads at a time. If we use the regular synchronized pattern, we have to either
@@ -42,8 +38,6 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
   // time, therefore we are not concerned with the insertion/removal time complexity.
   private val waitingQueue: PriorityQueue[ThreadInfo] =
     new PriorityQueue[ThreadInfo](threadComparator.reversed())
-
-  def this()(implicit ordering: Ordering[T]) = this(PrioritySemaphore.DEFAULT_MAX_PERMITS)(ordering)
 
   def tryAcquire(numPermits: Int, priority: T): Boolean = {
     lock.lock()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
@@ -54,26 +54,26 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
 
   def acquire(numPermits: Int, priority: T): Unit = {
     lock.lock()
-    if (tryAcquire(numPermits, priority)) {
-      lock.unlock()
-    } else {
-      val condition = lock.newCondition()
-      val info = ThreadInfo(priority, condition, numPermits)
-      try {
-        waitingQueue.add(info)
-        while (!info.signaled) {
-          info.condition.await()
-        }
-      } catch {
-        case e: Exception =>
-          waitingQueue.remove(info)
-          if (info.signaled) {
-            release(numPermits)
+    try {
+      if (!tryAcquire(numPermits, priority)) {
+        val condition = lock.newCondition()
+        val info = ThreadInfo(priority, condition, numPermits)
+        try {
+          waitingQueue.add(info)
+          while (!info.signaled) {
+            info.condition.await()
           }
-          throw e
-      } finally {
-        lock.unlock()
+        } catch {
+          case e: Exception =>
+            waitingQueue.remove(info)
+            if (info.signaled) {
+              release(numPermits)
+            }
+            throw e
+        }
       }
+    } finally {
+      lock.unlock()
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
@@ -16,9 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import java.util.{Comparator, PriorityQueue}
 import java.util.concurrent.locks.{Condition, ReentrantLock}
-
-import scala.collection.mutable.PriorityQueue
 
 object PrioritySemaphore {
   private val DEFAULT_MAX_PERMITS = 1000
@@ -34,19 +33,22 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
 
   private case class ThreadInfo(priority: T, condition: Condition, numPermits: Int) {
     var signaled: Boolean = false
-    var interrupted: Boolean = false
   }
+
+  private val threadComparator: Comparator[ThreadInfo] =
+    (o1: ThreadInfo, o2: ThreadInfo) => ordering.compare(o1.priority, o2.priority)
 
   // We expect a relatively small number of threads to be contending for this lock at any given
   // time, therefore we are not concerned with the insertion/removal time complexity.
-  private val waitingQueue: PriorityQueue[ThreadInfo] = PriorityQueue()(Ordering.by(_.priority))
+  private val waitingQueue: PriorityQueue[ThreadInfo] =
+    new PriorityQueue[ThreadInfo](threadComparator.reversed())
 
   def this()(implicit ordering: Ordering[T]) = this(PrioritySemaphore.DEFAULT_MAX_PERMITS)(ordering)
 
   def tryAcquire(numPermits: Int, priority: T): Boolean = {
     lock.lock()
     try {
-      if (waitingQueue.nonEmpty && ordering.gt(waitingQueue.head.priority, priority)) {
+      if (waitingQueue.size() > 0 && ordering.gt(waitingQueue.peek.priority, priority)) {
         false
       } else if (!canAcquire(numPermits)) {
         false
@@ -67,14 +69,15 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
       if (canAcquire(numPermits)) {
         commitAcquire(numPermits)
       } else {
-        waitingQueue.enqueue(info)
+        waitingQueue.add(info)
         while (!info.signaled) {
           info.condition.await()
         }
       }
     } catch {
-      case _: InterruptedException =>
-        info.interrupted = true
+      case e: Exception =>
+        waitingQueue.remove(info)
+        throw e
     } finally {
       lock.unlock()
     }
@@ -90,12 +93,10 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
       occupiedSlots -= numPermits
       // acquire and wakeup for all threads that now have enough permits
       var done = false
-      while (!done && waitingQueue.nonEmpty) {
-        val nextThread = waitingQueue.head
-        if (nextThread.interrupted) {
-          waitingQueue.dequeue()
-        } else if (canAcquire(nextThread.numPermits)) {
-          val popped = waitingQueue.dequeue()
+      while (!done && waitingQueue.size() > 0) {
+        val nextThread = waitingQueue.peek()
+        if (canAcquire(nextThread.numPermits)) {
+          val popped = waitingQueue.poll()
           assert(popped eq nextThread)
           commitAcquire(nextThread.numPermits)
           nextThread.signaled = true

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
@@ -77,6 +77,9 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
     } catch {
       case e: Exception =>
         waitingQueue.remove(info)
+        if (info.signaled) {
+          release(numPermits)
+        }
         throw e
     } finally {
       lock.unlock()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PrioritySemaphore.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import java.util.{Comparator, PriorityQueue}
+import java.util.PriorityQueue
 import java.util.concurrent.locks.{Condition, ReentrantLock}
 
 class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) {
@@ -31,13 +31,10 @@ class PrioritySemaphore[T](val maxPermits: Int)(implicit ordering: Ordering[T]) 
     var signaled: Boolean = false
   }
 
-  private val threadComparator: Comparator[ThreadInfo] =
-    (o1: ThreadInfo, o2: ThreadInfo) => ordering.compare(o1.priority, o2.priority)
-
   // We expect a relatively small number of threads to be contending for this lock at any given
   // time, therefore we are not concerned with the insertion/removal time complexity.
   private val waitingQueue: PriorityQueue[ThreadInfo] =
-    new PriorityQueue[ThreadInfo](threadComparator.reversed())
+    new PriorityQueue[ThreadInfo](Ordering.by[ThreadInfo, T](_.priority).reverse)
 
   def tryAcquire(numPermits: Int, priority: T): Boolean = {
     lock.lock()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/PrioritySemaphoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/PrioritySemaphoreSuite.scala
@@ -28,16 +28,16 @@ class PrioritySemaphoreSuite extends AnyFunSuite {
   test("tryAcquire should return true if permits are available") {
     val semaphore = new TestPrioritySemaphore(10)
 
-    assert(semaphore.tryAcquire(5))
-    assert(semaphore.tryAcquire(3))
-    assert(semaphore.tryAcquire(2))
-    assert(!semaphore.tryAcquire(1))
+    assert(semaphore.tryAcquire(5, 0))
+    assert(semaphore.tryAcquire(3, 0))
+    assert(semaphore.tryAcquire(2, 0))
+    assert(!semaphore.tryAcquire(1, 0))
   }
 
   test("acquire and release should work correctly") {
     val semaphore = new TestPrioritySemaphore(1)
 
-    assert(semaphore.tryAcquire(1))
+    assert(semaphore.tryAcquire(1, 0))
 
     val latch = new CountDownLatch(1)
     val t = new Thread(() => {


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
Follow up to https://github.com/NVIDIA/spark-rapids/pull/11376 incorporating a fix to prevent duplicate queueing in the event of spurious wakeups