### PR TITLE
To mitigate github degraded perf [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -402,18 +402,23 @@ void abortDupBuilds() {
 }
 
 void checkoutCode(String url, String sha) {
-    checkout(
-        changelog: false,
-        poll: true,
-        scm: [
-            $class           : 'GitSCM', branches: [[name: sha]],
-            userRemoteConfigs: [[
-                                    credentialsId: 'github-token',
-                                    url          : url,
-                                    refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-             extensions      : [[$class: 'CloneOption', shallow: true]]
-        ]
-    )
+    // try mitigate github degraded performance issue
+    sh 'git config --global http.lowSpeedLimit 1000'
+    sh 'git config --global http.lowSpeedTime 1800'
+    retry(3) {
+        checkout(
+            changelog: false,
+            poll: true,
+            scm: [
+                $class           : 'GitSCM', branches: [[name: sha]],
+                userRemoteConfigs: [[
+                                        credentialsId: 'github-token',
+                                        url          : url,
+                                        refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
+                extensions      : [[$class: 'CloneOption', shallow: true, timeout: 30]]
+            ]
+        )
+    }
     sh "git submodule update --init"
     if (!common.isSubmoduleInit(this)) {
         error "Failed to clone submodule : thirdparty/parquet-testing"

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -402,9 +402,6 @@ void abortDupBuilds() {
 }
 
 void checkoutCode(String url, String sha) {
-    // try mitigate github degraded performance issue
-    sh 'git config --global http.lowSpeedLimit 1000'
-    sh 'git config --global http.lowSpeedTime 1800'
     retry(3) {
         checkout(
             changelog: false,
@@ -415,7 +412,7 @@ void checkoutCode(String url, String sha) {
                                         credentialsId: 'github-token',
                                         url          : url,
                                         refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-                extensions      : [[$class: 'CloneOption', shallow: true, timeout: 30]]
+                extensions      : [[$class: 'CloneOption', shallow: true, timeout: 20]]
             ]
         )
     }

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -209,9 +209,6 @@ void databricksBuild() {
 }
 
 void checkoutCode(String url, String sha) {
-    // try mitigate github degraded performance issue
-    sh 'git config --global http.lowSpeedLimit 1000'
-    sh 'git config --global http.lowSpeedTime 1800'
     retry(3) {
         checkout(
             changelog: false,
@@ -222,7 +219,7 @@ void checkoutCode(String url, String sha) {
                                         credentialsId: 'github-token',
                                         url          : url,
                                         refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-                extensions      : [[$class: 'CloneOption', shallow: true, timeout: 30]]
+                extensions      : [[$class: 'CloneOption', shallow: true, timeout: 20]]
             ]
         )
     }

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -209,18 +209,23 @@ void databricksBuild() {
 }
 
 void checkoutCode(String url, String sha) {
-    checkout(
-        changelog: false,
-        poll: true,
-        scm: [
-            $class           : 'GitSCM', branches: [[name: sha]],
-            userRemoteConfigs: [[
-                                    credentialsId: 'github-token',
-                                    url          : url,
-                                    refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-             extensions      : [[$class: 'CloneOption', shallow: true]]
-        ]
-    )
+    // try mitigate github degraded performance issue
+    sh 'git config --global http.lowSpeedLimit 1000'
+    sh 'git config --global http.lowSpeedTime 1800'
+    retry(3) {
+        checkout(
+            changelog: false,
+            poll: true,
+            scm: [
+                $class           : 'GitSCM', branches: [[name: sha]],
+                userRemoteConfigs: [[
+                                        credentialsId: 'github-token',
+                                        url          : url,
+                                        refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
+                extensions      : [[$class: 'CloneOption', shallow: true, timeout: 30]]
+            ]
+        )
+    }
     sh "git submodule update --init"
     if (!common.isSubmoduleInit(this)) {
         error "Failed to clone submodule : thirdparty/parquet-testing"


### PR DESCRIPTION
Github performance degradation (they do not always post incidents at the status page) is becoming increasingly frequent. 

```
error: 7104 bytes of body are still expected
13:47:10  fetch-pack: unexpected disconnect while reading sideband packet
13:47:10  fatal: early EOF
13:47:10  fatal: index-pack failed
```

We've added a default three-time retry to the Jenkins checkout function for internal pipelines, but this doesn't always resolve the issue if the service remains unstable for a long period. 

some content may also be broken in some CDN copies from the previous github incidents. And people should wait some hours until cache gets refreshed.

As pre-merge CI must rely on latest PR commits,
Lets try add some retry and longer clone timeout to mitigate the issue for now