### PR TITLE
[DOC] remove the redundant archive link [skip ci]

### DIFF
--- a/docs/archive.md
+++ b/docs/archive.md
@@ -260,10 +260,6 @@ Refer to perfio.s3.enabled in [advanced_configs](./additional-functionality/adva
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
 
-## Archived releases
-
-As new releases come out, previous ones will still be available in [archived releases](./archive.md).
-
 ## Release v24.04.0
 ### Hardware Requirements:
 


### PR DESCRIPTION
This pr address #11417 to remove the redundant link in the archive page.
Signed-off-by: liyuan <yuali@nvidia.com>