### PR TITLE
Update CI scripts to work with the "Dynamic Shim Detection" change [skip ci]

### DIFF
--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -70,11 +70,9 @@ DEPLOY_TYPES=$(echo $CLASSIFIERS | sed -e 's;[^,]*;jar;g')
 DEPLOY_FILES=$(echo $CLASSIFIERS | sed -e "s;\([^,]*\);${FPATH}-\1.jar;g")
 
 # dist does not have javadoc and sources jars, use 'sql-plugin' instead
-source jenkins/version-def.sh >/dev/null 2>&1
-echo $SPARK_BASE_SHIM_VERSION
 SQL_ART_ID=$(mvnEval $SQL_PL project.artifactId)
 SQL_ART_VER=$(mvnEval $SQL_PL project.version)
-JS_FPATH="${SQL_PL}/target/spark${SPARK_BASE_SHIM_VERSION}/${SQL_ART_ID}-${SQL_ART_VER}"
+JS_FPATH="$(echo -n ${SQL_PL}/target/spark*)/${SQL_ART_ID}-${SQL_ART_VER}"
 cp $JS_FPATH-sources.jar $FPATH-sources.jar
 cp $JS_FPATH-javadoc.jar $FPATH-javadoc.jar
 

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -17,6 +17,8 @@
 
 set -ex
 
+. jenkins/version-def.sh
+
 SCALA_BINARY_VER=${SCALA_BINARY_VER:-"2.12"}
 if [ $SCALA_BINARY_VER == "2.13" ]; then
     # Run scala2.13 build and test against JDK17
@@ -27,8 +29,6 @@ if [ $SCALA_BINARY_VER == "2.13" ]; then
     cd scala2.13
     ln -sf ../jenkins jenkins
 fi
-
-. jenkins/version-def.sh
 
 WORKSPACE=${WORKSPACE:-$(pwd)}
 ## export 'M2DIR' so that shims can get the correct Spark dependency info


### PR DESCRIPTION
Move '. version-def.sh' ahead of 'cd scala2.13' in the spark-nightly-build.sh, to work with the "Dynamic Shim Detection" [PR11308](https://github.com/NVIDIA/spark-rapids/pull/11308/),

Get the base shim version in deploy.sh using fuzzy matching instead of relying on version-def.sh

