### PR TITLE
Support yyyyMMdd in GetTimestamp operator for LEGACY mode [databricks]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -651,6 +651,7 @@ guaranteed to produce the same results as the CPU:
 - `dd/MM/yyyy`
 - `yyyy/MM/dd`
 - `yyyy-MM-dd`
+- `yyyyMMdd`
 - `yyyy/MM/dd HH:mm:ss`
 - `yyyy-MM-dd HH:mm:ss`
 
@@ -659,6 +660,8 @@ LEGACY timeParserPolicy support has the following limitations when running on th
 - Only 4 digit years are supported
 - The proleptic Gregorian calendar is used instead of the hybrid Julian+Gregorian calendar
   that Spark uses in legacy mode
+- When format is `yyyyMMdd`, GPU only supports 8 digit strings. Spark supports like 7 digit
+  `2024101` string while GPU does not support.
 
 ## Formatting dates and timestamps as strings
 

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_error
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_error, assert_gpu_and_cpu_are_equal_sql
 from conftest import is_utc, is_supported_time_zone, get_test_tz
 from data_gen import *
 from datetime import date, datetime, timezone
@@ -458,6 +458,15 @@ def test_to_timestamp(parser_policy):
         lambda spark : unary_op_df(spark, gen)
             .select(f.col("a"), f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
+
+
+def test_to_timestamp_legacy_mode_yyyyMMdd_format():
+    gen = StringGen("[0-9]{3}[1-9](0[1-9]|1[0-2])(0[1-9]|[1-2][0-9])")
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, gen).select(f.to_timestamp(f.col("a"), "yyyyMMdd")),
+        {
+                'spark.sql.legacy.timeParserPolicy': 'LEGACY',
+                'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
 
 @tz_sensitive_test

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -460,15 +460,18 @@ def test_to_timestamp(parser_policy):
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
 
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
-def test_to_timestamp_legacy_mode_yyyyMMdd_format():
+def test_yyyyMMdd_format_for_legacy_mode():
     gen = StringGen("[0-9]{3}[1-9](0[1-9]|1[0-2])(0[1-9]|[1-2][0-9])")
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : unary_op_df(spark, gen),
         "tab",
-        "select unix_timestamp(a, 'yyyyMMdd'), from_unixtime(unix_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd'), date_format(to_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd') from tab",
-        {
-                'spark.sql.legacy.timeParserPolicy': 'LEGACY',
-                'spark.rapids.sql.incompatibleDateFormats.enabled': True})
+        '''select unix_timestamp(a, 'yyyyMMdd'),
+                  from_unixtime(unix_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd'),
+                  date_format(to_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd')
+           from tab
+        ''',
+        {  'spark.sql.legacy.timeParserPolicy': 'LEGACY',
+           'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
 @tz_sensitive_test
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -459,15 +459,16 @@ def test_to_timestamp(parser_policy):
             .select(f.col("a"), f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
 
-
+@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 def test_to_timestamp_legacy_mode_yyyyMMdd_format():
     gen = StringGen("[0-9]{3}[1-9](0[1-9]|1[0-2])(0[1-9]|[1-2][0-9])")
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, gen).select(f.to_timestamp(f.col("a"), "yyyyMMdd")),
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark : unary_op_df(spark, gen),
+        "tab",
+        "select unix_timestamp(a, 'yyyyMMdd'), from_unixtime(unix_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd'), date_format(to_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd') from tab",
         {
                 'spark.sql.legacy.timeParserPolicy': 'LEGACY',
                 'spark.rapids.sql.incompatibleDateFormats.enabled': True})
-
 
 @tz_sensitive_test
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")


### PR DESCRIPTION
closes #11445

This PR supports yyyyMMdd in GetTimestamp operator for LEGACY mode
Note: this PR introduced inconsistent behavior compared to Spark:

Spark behavior:

```
  "20240101"  =>  2024-01-01
  "202401 01" =>  2024-01-01
  "2024 0101" =>  invalid
  "202411"    =>  invalid
  "2024101"   =>  2024-10-01  // Note: 10-01 not 01-01
  "202411"    =>  invalid
```

GPU only support 8 digit strings.


