### PR TITLE
xfail array and map cast to string tests

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -322,6 +322,7 @@ def _assert_cast_to_string_equal (data_gen, conf):
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/11437")
 @pytest.mark.parametrize('data_gen', all_array_gens_for_cast_to_string, ids=idfn)
 @pytest.mark.parametrize('legacy', ['true', 'false'])
 @allow_non_gpu(*non_utc_allow)
@@ -357,6 +358,7 @@ def test_cast_array_with_unmatched_element_to_string(data_gen, legacy):
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/11437")
 @pytest.mark.parametrize('data_gen', basic_map_gens_for_cast_to_string, ids=idfn)
 @pytest.mark.parametrize('legacy', ['true', 'false'])
 @allow_non_gpu(*non_utc_allow)

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -55,7 +55,8 @@ class MortgageSparkSuite extends AnyFunSuite {
     builder.getOrCreate()
   }
 
-  test("extract mortgage data") {
+  // test failing, tracked by https://github.com/NVIDIA/spark-rapids/issues/11436
+  ignore("extract mortgage data") {
     val df = Run.csv(
       session,
       getClass.getClassLoader.getResource("Performance_2007Q3.txt_0").getPath,


### PR DESCRIPTION
Related to #11436 and #11437.  Marked the failing tests as xfail or ignore to unblock premerge and nightly builds.