### PR TITLE
Enable tests after string_split was fixed [databricks]

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -322,7 +322,6 @@ def _assert_cast_to_string_equal (data_gen, conf):
     )
 
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/11437")
 @pytest.mark.parametrize('data_gen', all_array_gens_for_cast_to_string, ids=idfn)
 @pytest.mark.parametrize('legacy', ['true', 'false'])
 @allow_non_gpu(*non_utc_allow)
@@ -358,7 +357,6 @@ def test_cast_array_with_unmatched_element_to_string(data_gen, legacy):
     )
 
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/11437")
 @pytest.mark.parametrize('data_gen', basic_map_gens_for_cast_to_string, ids=idfn)
 @pytest.mark.parametrize('legacy', ['true', 'false'])
 @allow_non_gpu(*non_utc_allow)

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -55,8 +55,7 @@ class MortgageSparkSuite extends AnyFunSuite {
     builder.getOrCreate()
   }
 
-  // test failing, tracked by https://github.com/NVIDIA/spark-rapids/issues/11436
-  ignore("extract mortgage data") {
+  test("extract mortgage data") {
     val df = Run.csv(
       session,
       getClass.getClassLoader.getResource("Performance_2007Q3.txt_0").getPath,


### PR DESCRIPTION
This fixes #11437 

Actually CUDF fixed the issue, but this enables the tests again.