### PR TITLE
Support legacy mode for yyyymmdd format [databricks]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -652,6 +652,7 @@ guaranteed to produce the same results as the CPU:
 - `yyyy/MM/dd`
 - `yyyy-MM-dd`
 - `yyyyMMdd`
+- `yyyymmdd`
 - `yyyy/MM/dd HH:mm:ss`
 - `yyyy-MM-dd HH:mm:ss`
 
@@ -661,6 +662,8 @@ LEGACY timeParserPolicy support has the following limitations when running on th
 - The proleptic Gregorian calendar is used instead of the hybrid Julian+Gregorian calendar
   that Spark uses in legacy mode
 - When format is `yyyyMMdd`, GPU only supports 8 digit strings. Spark supports like 7 digit
+  `2024101` string while GPU does not support.
+- When format is `yyyymmdd`, GPU only supports 8 digit strings. Spark supports like 7 digit
   `2024101` string while GPU does not support.
 
 ## Formatting dates and timestamps as strings

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -462,9 +462,10 @@ def test_to_timestamp(parser_policy):
 # mm: minute; MM: month
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
-def test_formats_for_legacy_mode(format):
-    # this regexp excludes zero year, python does not like zero year
-    gen = StringGen("([0-9]{3}[1-9])([0-5][0-9])([0-3][0-9])")
+# these regexps exclude zero year, python does not like zero year
+@pytest.mark.parametrize("data_gen_regexp", ['([0-9]{3}[1-9])([0-5][0-9])([0-3][0-9])', '([0-9]{3}[1-9])([0-9]{4})'], ids=idfn)
+def test_formats_for_legacy_mode(format, data_gen_regexp):
+    gen = StringGen(data_gen_regexp)
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : unary_op_df(spark, gen),
         "tab",

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -459,10 +459,12 @@ def test_to_timestamp(parser_policy):
             .select(f.col("a"), f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
 
+# mm: minute; MM: month
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
 def test_formats_for_legacy_mode(format):
-    gen = StringGen("[0-9]{3}[1-9](0[1-9]|1[0-2])(0[1-9]|[1-2][0-9])")
+    # this regexp excludes zero year, python does not like zero year
+    gen = StringGen("([0-9]{3}[1-9])([0-5][0-9])([0-3][0-9])")
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : unary_op_df(spark, gen),
         "tab",

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -460,16 +460,17 @@ def test_to_timestamp(parser_policy):
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
 
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
-def test_yyyyMMdd_format_for_legacy_mode():
+@pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
+def test_formats_for_legacy_mode(format):
     gen = StringGen("[0-9]{3}[1-9](0[1-9]|1[0-2])(0[1-9]|[1-2][0-9])")
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : unary_op_df(spark, gen),
         "tab",
-        '''select unix_timestamp(a, 'yyyyMMdd'),
-                  from_unixtime(unix_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd'),
-                  date_format(to_timestamp(a, 'yyyyMMdd'), 'yyyyMMdd')
+        '''select unix_timestamp(a, '{}'),
+                  from_unixtime(unix_timestamp(a, '{}'), '{}'),
+                  date_format(to_timestamp(a, '{}'), '{}')
            from tab
-        ''',
+        '''.format(format, format, format, format, format),
         {  'spark.sql.legacy.timeParserPolicy': 'LEGACY',
            'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -642,6 +642,8 @@ object GpuToTimestamp {
     "yyyy/MM/dd HH:mm:ss" -> ParseFormatMeta(Option('/'), isTimestamp = true,
       raw"\A\d{4}/\d{1,2}/\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
     "yyyyMMdd" -> ParseFormatMeta(None, isTimestamp = false,
+      raw"\A\d{8}(\D|\s|\Z)"),
+    "yyyymmdd" -> ParseFormatMeta(None, isTimestamp = false,
       raw"\A\d{8}(\D|\s|\Z)")
   )
 


### PR DESCRIPTION
closes #11505

Required by customer.

Similar to this [PR](https://github.com/NVIDIA/spark-rapids/pull/11449) which supports `yyyyMMdd`, this PR supports `yyyymmdd`

Note: `MM` is month while `mm` is minute

Note:  GPU and CPU are not 100% consistent for `yyyymmdd` format, GPU only supports 8 digit strings.

Signed-off-by: Chong Gao <res_life@163.com>
