### PR TITLE
Update test now that code is fixed

### DIFF
--- a/integration_tests/src/main/python/json_matrix_test.py
+++ b/integration_tests/src/main/python/json_matrix_test.py
@@ -791,7 +791,7 @@ def test_from_json_strings(std_input_path, input_file):
     "int_struct_formatted.json",
     "int_mixed_array_struct_formatted.json",
     "bad_whitespace.json",
-    pytest.param("escaped_strings.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11386')),
+    "escaped_strings.json",
     pytest.param("nested_escaped_strings.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11387')),
     pytest.param("repeated_columns.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/11361')),
     "mixed_objects.json",


### PR DESCRIPTION
processing of escaped keys was fixed for get_json_object in https://github.com/NVIDIA/spark-rapids-jni/pull/2410

This updates the test to not xfail any more. I am not sure why I put `https://github.com/NVIDIA/spark-rapids/issues/11386` as the issues that is making the one test not work because it is not correct.