### PR TITLE
Update from_json to use null as line delimiter

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -350,7 +350,7 @@ class JsonPartitionReader(
     maxBytesPerChunk, execMetrics, FilterEmptyHostLineBuffererFactory) {
 
   def buildJsonOptions(parsedOptions: JSONOptions): cudf.JSONOptions =
-    GpuJsonReadCommon.cudfJsonOptions(parsedOptions)
+    GpuJsonReadCommon.cudfJsonOptions(parsedOptions, None)
 
   /**
    * Read the host buffer to GPU table


### PR DESCRIPTION
I am leaving this as draft for two reasons.

1) it does not fix having \r in the JSON. See https://github.com/rapidsai/cudf/issues/16915
2) There is a very large performance hit going to a regexp for stripping the characters from the input. I am a bit conflicted here because we do need a fix for this at some point even without trying to support \r and \n in the data because \t is not being treated as an empty line and will fail.