### PR TITLE
Replace libmamba-solver with mamba command [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -46,12 +46,11 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 RUN conda init
-# TODO: re-enable mamba solver after https://github.com/NVIDIA/spark-rapids/issues/9393
-# conda config --set solver libmamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
+    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults libmambapy=1.15.10 \
+        cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
     conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -45,16 +45,16 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
-RUN conda init
+RUN conda init && conda install -n base -c conda-forge mamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults libmambapy=1.15.10 \
+    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
         cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
-    conda install -y spacy && python -m spacy download en_core_web_sm && \
-    conda install -y -c anaconda pytest requests && \
-    conda install -y -c conda-forge sre_yield && \
-    conda clean -ay
+    mamba install -y spacy && python -m spacy download en_core_web_sm && \
+    mamba install -y -c anaconda pytest requests && \
+    mamba install -y -c conda-forge sre_yield && \
+    mamba clean -ay
 # install pytest plugins for xdist parallel run
 RUN python -m pip install findspark pytest-xdist pytest-order fastparquet==2024.5.0
 

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -58,12 +58,11 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 RUN conda init
-# TODO: re-enable mamba solver after https://github.com/NVIDIA/spark-rapids/issues/9393
-# conda config --set solver libmamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
+    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults libmambapy=1.15.10 \
+        cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
     conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -57,16 +57,16 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
-RUN conda init
+RUN conda init && conda install -n base -c conda-forge mamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults libmambapy=1.15.10 \
+    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
         cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
-    conda install -y spacy && python -m spacy download en_core_web_sm && \
-    conda install -y -c anaconda pytest requests && \
-    conda install -y -c conda-forge sre_yield && \
-    conda clean -ay
+    mamba install -y spacy && python -m spacy download en_core_web_sm && \
+    mamba install -y -c anaconda pytest requests && \
+    mamba install -y -c conda-forge sre_yield && \
+    mamba clean -ay
 # install pytest plugins for xdist parallel run
 RUN python -m pip install findspark pytest-xdist pytest-order fastparquet==2024.5.0
 


### PR DESCRIPTION
as described in https://github.com/NVIDIA/spark-rapids/pull/11506.

We had switched to the libmamba-solver because the mamba CLI was previously incompatible with conda. But with the recent release of libmamba 2.0, we met failures in our internal builds in the DinD env with conda default libmamba-solver. Consequently, we reverted to using the mamba CLI directly, again...


This change has been successfully verified in our internal Docker build pipelines.