### PR TITLE
Deploy all submodules for default sparkver in nightly [skip ci]

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -182,7 +182,7 @@ if [[ $SKIP_DEPLOY != 'true' ]]; then
     distWithReducedPom "deploy"
 
     # this deploys selected submodules that is unconditionally built with Spark 3.2.0
-    $MVN -B deploy -pl $DEPLOY_SUBMODULES \
+    $MVN -B deploy -pl "!${DIST_PL}" \
         -Dbuildver=$SPARK_BASE_SHIM_VERSION \
         -DskipTests \
         -Dmaven.scaladoc.skip -Dmaven.scalastyle.skip=true \


### PR DESCRIPTION
We met issue started from 24.12, this is due to we stop deploying some nightly modules after https://github.com/NVIDIA/spark-rapids/pull/11301

e.g. spark-shell run with --packages
```
/home/jenkins/agent/workspace/jenkins-rapids_integration-dev-github-1093-3.2.0/jars/spark-3.2.0-bin-hadoop3.2/bin/spark-shell 
--master 'local-cluster[1,2,1024]' 
--conf spark.plugins=com.nvidia.spark.SQLPlugin 
--conf spark.deploy.maxExecutorRetries=0 
--packages com.nvidia:rapids-4-spark_2.12:24.12.0-SNAPSHOT 
--repositories https://urm.nvidia.com/artifactory/sw-spark-maven
```
which would fail to find jdk-profiles


Update the nightly script to deploy all submodules for default sparkver. Keep other spark shims build to deploy integration_tests module only