### PR TITLE
Update test case related to LEACY datetime format to unblock nightly CI

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -662,9 +662,10 @@ LEGACY timeParserPolicy support has the following limitations when running on th
 - The proleptic Gregorian calendar is used instead of the hybrid Julian+Gregorian calendar
   that Spark uses in legacy mode
 - When format is `yyyyMMdd`, GPU only supports 8 digit strings. Spark supports like 7 digit
-  `2024101` string while GPU does not support.
+  `2024101` string while GPU does not support. Only tested `UTC` and `Asia/Shanghai` timezones.
 - When format is `yyyymmdd`, GPU only supports 8 digit strings. Spark supports like 7 digit
-  `2024101` string while GPU does not support.
+  `2024101` string while GPU does not support. Only tested `UTC` and `Asia/Shanghai` timezones.
+
 
 ## Formatting dates and timestamps as strings
 

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -459,24 +459,24 @@ def test_to_timestamp(parser_policy):
             .select(f.col("a"), f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
 
+
 # mm: minute; MM: month
-@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
-@pytest.mark.skip(reason="blocked by https://github.com/NVIDIA/spark-rapids/issues/11539, https://github.com/NVIDIA/spark-rapids/issues/11543")
+@pytest.mark.skipif(not is_supported_time_zone(),
+                    reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
-# these regexps exclude zero year, python does not like zero year
-@pytest.mark.parametrize("data_gen_regexp", ['([0-9]{3}[1-9])([0-5][0-9])([0-3][0-9])', '([0-9]{3}[1-9])([0-9]{4})'], ids=idfn)
-def test_formats_for_legacy_mode(format, data_gen_regexp):
-    gen = StringGen(data_gen_regexp)
+# Test years after 1900, refer to issues: https://github.com/NVIDIA/spark-rapids/issues/11543, https://github.com/NVIDIA/spark-rapids/issues/11539
+def test_formats_for_legacy_mode(format):
+    gen = StringGen('(19[0-9]{2}|[2-9][0-9]{3})([0-9]{4})')
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark : unary_op_df(spark, gen),
+        lambda spark: unary_op_df(spark, gen),
         "tab",
         '''select unix_timestamp(a, '{}'),
                   from_unixtime(unix_timestamp(a, '{}'), '{}'),
                   date_format(to_timestamp(a, '{}'), '{}')
            from tab
         '''.format(format, format, format, format, format),
-        {  'spark.sql.legacy.timeParserPolicy': 'LEGACY',
-           'spark.rapids.sql.incompatibleDateFormats.enabled': True})
+        {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
+         'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
 @tz_sensitive_test
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -461,6 +461,7 @@ def test_to_timestamp(parser_policy):
 
 # mm: minute; MM: month
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+@pytest.mark.skip(reason="blocked by https://github.com/NVIDIA/spark-rapids/issues/11539, https://github.com/NVIDIA/spark-rapids/issues/11543")
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
 # these regexps exclude zero year, python does not like zero year
 @pytest.mark.parametrize("data_gen_regexp", ['([0-9]{3}[1-9])([0-5][0-9])([0-3][0-9])', '([0-9]{3}[1-9])([0-9]{4})'], ids=idfn)

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -461,8 +461,7 @@ def test_to_timestamp(parser_policy):
 
 
 # mm: minute; MM: month
-@pytest.mark.skipif(not is_supported_time_zone(),
-                    reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
 # Test years after 1900, refer to issues: https://github.com/NVIDIA/spark-rapids/issues/11543, https://github.com/NVIDIA/spark-rapids/issues/11539
 def test_formats_for_legacy_mode(format):

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -463,6 +463,7 @@ def test_to_timestamp(parser_policy):
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
 # Test years after 1900, refer to issues: https://github.com/NVIDIA/spark-rapids/issues/11543, https://github.com/NVIDIA/spark-rapids/issues/11539
+@pytest.mark.skipif(get_test_tz() != "Asia/Shanghai" and get_test_tz() != "UTC", reason="https://github.com/NVIDIA/spark-rapids/issues/11562")
 def test_formats_for_legacy_mode(format):
     gen = StringGen('(19[0-9]{2}|[2-9][0-9]{3})([0-9]{4})')
     assert_gpu_and_cpu_are_equal_sql(

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -459,7 +459,6 @@ def test_to_timestamp(parser_policy):
             .select(f.col("a"), f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
 
-
 # mm: minute; MM: month
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
@@ -467,7 +466,7 @@ def test_to_timestamp(parser_policy):
 def test_formats_for_legacy_mode(format):
     gen = StringGen('(19[0-9]{2}|[2-9][0-9]{3})([0-9]{4})')
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: unary_op_df(spark, gen),
+        lambda spark : unary_op_df(spark, gen),
         "tab",
         '''select unix_timestamp(a, '{}'),
                   from_unixtime(unix_timestamp(a, '{}'), '{}'),


### PR DESCRIPTION
Closes #11539

### Changes
Update test case: Only test years after 1900

### Description
This issue is related to LEGACY mode, Spark itself has different behaviors between LEGACY mode and non-LEGACY mode, and Rapids kernel has not 100% matched non-LEGACY yet.
Rapids keeps consistent with Spark when mode is CORRECTED mode.

We already documented that `LEGACY` mode has several [limitations](https://github.com/NVIDIA/spark-rapids/blob/branch-24.10/docs/compatibility.md#legacy-timeparserpolicy)

So only update test case.

Signed-off-by: Chong Gao <res_life@163.com>