### PR TITLE
[Spark 4.0] Address test failures in cast_test.py [databricks]

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -291,8 +291,7 @@ def test_cast_integral_to_decimal_ansi_off(data_gen, to_type):
 @pytest.mark.parametrize('to_type', [DecimalType(2, 0)], ids=idfn)
 def test_cast_integral_to_decimal_ansi_on(data_gen, to_type):
     assert_gpu_and_cpu_are_equal_collect(
-        # lambda spark : unary_op_df(spark, data_gen).select(
-        lambda spark : gen_and_persist(spark, data_gen).select(
+        lambda spark : unary_op_df(spark, data_gen).select(
                 f.col('a').cast(to_type)),
         conf=ansi_enabled_conf)
 

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -854,8 +854,8 @@ def test_cast_fallback_not_UTC(from_gen, to_type):
 def test_cast_date_integral_and_fp_ansi_off():
     """
     This tests that a date column can be cast to different numeric/floating-point types.
-    This needs to be tested with ANSI disabled, because some of these conversions are
-    not ANSI-compliant.
+    This needs to be tested with ANSI disabled, because none of these conversions are
+    ANSI-compliant.
     """
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, date_gen).selectExpr(

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -26,11 +26,6 @@ import math
 
 _decimal_gen_36_5 = DecimalGen(precision=36, scale=5)
 
-#  TODO: DELETEME!
-def gen_and_persist(spark, data_gen):
-    df = unary_op_df(spark, data_gen, length=10)
-    df.repartition(1).write.mode("overwrite").parquet("/tmp/myth/test_input")
-    return df
 
 def test_cast_empty_string_to_int_ansi_off():
     assert_gpu_and_cpu_are_equal_collect(
@@ -45,7 +40,7 @@ def test_cast_empty_string_to_int_ansi_off():
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/11552")
 def test_cast_empty_string_to_int_ansi_on():
     assert_gpu_and_cpu_error(
-        lambda spark : gen_and_persist(spark, StringGen(pattern="")).selectExpr(
+        lambda spark : unary_op_df(spark, StringGen(pattern="")).selectExpr(
             'CAST(a as BYTE)',
             'CAST(a as SHORT)',
             'CAST(a as INTEGER)',
@@ -93,7 +88,7 @@ def test_cast_string_date_valid_format_ansi_on():
     # In Spark 3.2.0+ the valid format changed, and we cannot support all formats.
     # This provides values that are valid in all of those formats.
     assert_gpu_and_cpu_error(
-        lambda spark : gen_and_persist(spark, StringGen(date_start_1_1_1)).select(f.col('a').cast(DateType())).collect(),
+        lambda spark : unary_op_df(spark, StringGen(date_start_1_1_1)).select(f.col('a').cast(DateType())).collect(),
         conf = copy_and_update(ansi_enabled_conf, {'spark.rapids.sql.hasExtendedYearValues': 'false'}),
         error_message="One or more values could not be converted to DateType")
 

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -454,7 +454,7 @@ def test_cast_double_to_string():
 def test_cast_array_with_unmatched_element_to_string(data_gen, legacy):
     _assert_cast_to_string_equal(
         data_gen,
-        {"spark.rapids.sql.castFloatToString.enabled"       : "true",
+        {"spark.rapids.sql.castFloatToString.enabled"       : True,
          "spark.sql.legacy.castComplexTypesToString.enabled": legacy}
     )
 
@@ -474,7 +474,7 @@ def test_cast_map_to_string(data_gen, legacy):
 def test_cast_map_with_unmatched_element_to_string(data_gen, legacy):
     _assert_cast_to_string_equal(
         data_gen,
-        {"spark.rapids.sql.castFloatToString.enabled"       : "true",
+        {"spark.rapids.sql.castFloatToString.enabled"       : True,
          "spark.sql.legacy.castComplexTypesToString.enabled": legacy}
     )
 
@@ -528,7 +528,7 @@ def test_two_col_struct_legacy_cast(cast_conf):
 def test_cast_struct_with_unmatched_element_to_string(data_gen, legacy):
     _assert_cast_to_string_equal(
         data_gen,
-        {"spark.rapids.sql.castFloatToString.enabled"       : "true",
+        {"spark.rapids.sql.castFloatToString.enabled"       : True,
          "spark.sql.legacy.castComplexTypesToString.enabled": legacy}
     )
 
@@ -850,7 +850,7 @@ def test_cast_fallback_not_UTC(from_gen, to_type):
         lambda spark: unary_op_df(spark, from_gen).selectExpr("CAST(a AS {}) as casted".format(to_type)),
         "Cast",
         {"spark.sql.session.timeZone": "+08",
-         "spark.rapids.sql.castStringToTimestamp.enabled": "true"})
+         "spark.rapids.sql.castStringToTimestamp.enabled": True})
 
 
 def test_cast_date_integral_and_fp_ansi_off():

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -279,10 +279,22 @@ def test_ansi_cast_failures_decimal_to_decimal(data_gen, to_type):
     DecimalType(10, 2),
     DecimalType(18, 0),
     DecimalType(18, 2)], ids=idfn)
-def test_cast_integral_to_decimal(data_gen, to_type):
+def test_cast_integral_to_decimal_ansi_off(data_gen, to_type):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).select(
-            f.col('a').cast(to_type)))
+            f.col('a').cast(to_type)),
+        conf=ansi_disabled_conf)
+
+
+@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/11550")
+@pytest.mark.parametrize('data_gen', [long_gen], ids=idfn)
+@pytest.mark.parametrize('to_type', [DecimalType(2, 0)], ids=idfn)
+def test_cast_integral_to_decimal_ansi_on(data_gen, to_type):
+    assert_gpu_and_cpu_are_equal_collect(
+        # lambda spark : unary_op_df(spark, data_gen).select(
+        lambda spark : gen_and_persist(spark, data_gen).select(
+                f.col('a').cast(to_type)),
+        conf=ansi_enabled_conf)
 
 def test_cast_byte_to_decimal_overflow():
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -520,13 +520,17 @@ def test_cast_float_to_timestamp_side_effect():
 # non ansi mode, will get null
 @pytest.mark.parametrize('type', [DoubleType(), FloatType()], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_cast_float_to_timestamp_for_nan_inf(type):
+def test_with_ansi_off_cast_float_to_timestamp_for_nan_inf(type):
+    """
+    Tests the behaviour of floats when cast to timestamp, with ANSI disabled.
+    ANSI mode tests are covered in test_cast_float_to_timestamp_ansi_for_nan_inf.
+    """
     def fun(spark):
         data = [(float("inf"),), (float("-inf"),), (float("nan"),)]
         schema = StructType([StructField("value", type, True)])
         df = spark.createDataFrame(data, schema)
         return df.select(f.col('value').cast(TimestampType()))
-    assert_gpu_and_cpu_are_equal_collect(fun)
+    assert_gpu_and_cpu_are_equal_collect(fun, conf=ansi_disabled_conf)
 
 # gen for casting long to timestamp, range is about in [0000, 9999]
 long_gen_to_timestamp = LongGen(max_val=math.floor((9999-1970) * 365 * 86400),

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -661,7 +661,9 @@ def test_cast_timestamp_to_numeric_ansi_no_overflow():
         conf=ansi_enabled_conf)
 
 
-@pytest.mark.skipif(not is_before_spark_400(),
+@pytest.mark.skipif(is_databricks_runtime() and is_databricks_version_or_later(14, 3),
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/11555")
+@pytest.mark.skipif(not is_databricks_runtime() and is_spark_400_or_later(),
                     reason="https://github.com/NVIDIA/spark-rapids/issues/11555")
 def test_cast_timestamp_to_numeric_non_ansi():
     """


### PR DESCRIPTION
Fixes #11009 and #11530.

This commit addresses the test failures in cast_test.py, on Spark 4.0.
These generally have to do with changes in behaviour of Spark when
ANSI mode is enabled.  In these cases, the tests have been split out into ANSI=on and ANSI=off.  

The bugs uncovered from the tests have been spun into their own issues;  fixing all of them was beyond the scope of this change.

