### PR TITLE
Add a new NVTX range for task GPU ownership

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange, NvtxUniqueRange}
-import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2383,6 +2383,13 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
       .booleanConf
       .createWithDefault(true)
 
+  val TRACE_TASK_GPU_OWNERSHIP = conf("spark.rapids.sql.traceTaskGpuOwnership")
+    .doc("Enable tracing of the GPU ownership of tasks. This can be useful for debugging " +
+      "deadlocks and other issues related to GPU semaphore.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2383,7 +2383,7 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
       .booleanConf
       .createWithDefault(true)
 
-  val TRACE_TASK_GPU_OWNERSHIP = conf("spark.rapids.sql.traceTaskGpuOwnership")
+  val TRACE_TASK_GPU_OWNERSHIP = conf("spark.rapids.sql.nvtx.traceTaskGpuOwnership")
     .doc("Enable tracing of the GPU ownership of tasks. This can be useful for debugging " +
       "deadlocks and other issues related to GPU semaphore.")
     .internal()


### PR DESCRIPTION
If you have ever been curious about the semaphore-based GPU concurrency control mechanism, you may have wondered at some point exactly what tasks are holding the semaphore at a given point of time during query processing. This PR can help you in that case. This PR adds a new NVTX range that shows what task owns GPU in the nsys profile result. This feature is off by default (since I don't think it's always useful), and can be enabled by setting `spark.rapids.sql.traceTaskGpuOwnership = true`. The screenshot below shows an example nsys result with the new semaphore ranges. The orange boxes with `Sem-${taskAttemptId}` represent the ranges in which each spark task was holding the semaphore.

![Screenshot 2024-10-11 at 4 09 11 PM](https://github.com/user-attachments/assets/c29863c1-bab7-4dc9-9c15-9abe7f113371)
