### PR TITLE
Change DataSource calendar interval error to fix spark400 build [databricks]

### DIFF
--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuDataSource.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuDataSource.scala
@@ -121,14 +121,16 @@ case class GpuDataSource(
       data: LogicalPlan,
       outputColumnNames: Seq[String]): BaseRelation = {
 
-    val outputColumns = DataWritingCommand.logicalPlanOutputWithNames(data, outputColumnNames)
-    if (outputColumns.map(_.dataType).exists(_.isInstanceOf[CalendarIntervalType])) {
-      throw QueryCompilationErrors.cannotSaveIntervalIntoExternalStorageError()
-    }
-
     val format = originalProvidingInstance()
     if (!format.isInstanceOf[FileFormat]) {
       throw new IllegalArgumentException(s"Original provider does not extend FileFormat: $format")
+    }
+
+    val outputColumns = DataWritingCommand.logicalPlanOutputWithNames(data, outputColumnNames)
+    outputColumns.toStructType.foreach { field =>
+      if (field.dataType.isInstanceOf[CalendarIntervalType]) {
+        throw QueryCompilationErrors.dataTypeUnsupportedByDataSourceError(format.toString, field)
+      }
     }
 
     val cmd = planForWritingFileFormat(format.asInstanceOf[FileFormat], mode, data)


### PR DESCRIPTION
Updates the error reported by GpuDataSource for CalendarIntervalType to use dataTypeUnsupportedByDataSourceError rather than cannotSaveIntervalIntoExternalStorageError which was removed in Spark 4.0.0 by [SPARK-49892](https://issues.apache.org/jira/browse/SPARK-49892).