### PR TITLE
Quick fix for the build script failure of Scala 2.13 jars [skip ci]

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -22,6 +22,8 @@ set -ex
 ## MVN_OPT : maven options environment, e.g. MVN_OPT='-Dspark-rapids-jni.version=xxx' to specify spark-rapids-jni dependency's version.
 MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3 ${MVN_OPT} -Psource-javadoc"
 
+DIST_PL="dist"
+DIST_PATH="$DIST_PL" # The path of the dist module is used only outside of the mvn cmd
 SCALA_BINARY_VER=${SCALA_BINARY_VER:-"2.12"}
 if [ $SCALA_BINARY_VER == "2.13" ]; then
     # Run scala2.13 build and test against JDK17
@@ -30,13 +32,13 @@ if [ $SCALA_BINARY_VER == "2.13" ]; then
     java -version
 
     MVN="$MVN -f scala2.13/"
+    DIST_PATH="scala2.13/$DIST_PL"
 fi
 
 WORKSPACE=${WORKSPACE:-$(pwd)}
 ## export 'M2DIR' so that shims can get the correct Spark dependency info
 export M2DIR=${M2DIR:-"$WORKSPACE/.m2"}
 
-DIST_PL="dist"
 function mvnEval {
     $MVN help:evaluate -q -pl $DIST_PL $MVN_URM_MIRROR -Prelease320 -Dmaven.repo.local=$M2DIR -DforceStdout -Dexpression=$1
 }
@@ -79,7 +81,7 @@ function distWithReducedPom {
             mvnCmd="deploy:deploy-file"
             if (( ${#CLASSIFIERS_ARR[@]} > 1 )); then
               # try move tmp artifacts back to target folder for simplifying separate release process
-              mv ${TMP_PATH}/${ART_ID}-${ART_VER}-*.jar ${DIST_PL}/target/
+              mv ${TMP_PATH}/${ART_ID}-${ART_VER}-*.jar ${DIST_PATH}/target/
             fi
             mvnExtraFlags="-Durl=${URM_URL}-local -DrepositoryId=snapshots -Dtypes=${DEPLOY_TYPES} -Dfiles=${DEPLOY_FILES} -Dclassifiers=${DEPLOY_CLASSIFIERS}"
             ;;
@@ -165,7 +167,7 @@ if (( ${#CLASSIFIERS_ARR[@]} > 1 )); then
 
     # move artifacts to temp for deployment later
     artifactFile="${ART_ID}-${ART_VER}-${classifier}.jar"
-    mv ${DIST_PL}/target/${artifactFile} ${TMP_PATH}/
+    mv ${DIST_PATH}/target/${artifactFile} ${TMP_PATH}/
     # update deployment properties
     DEPLOY_TYPES="${DEPLOY_TYPES},jar"
     DEPLOY_FILES="${DEPLOY_FILES},${DIST_PL}/target/${artifactFile}"


### PR DESCRIPTION
To fix the nightly build CI error:

    mv: cannot stat 'dist/target/rapids-4-spark_2.13-24.12.0-SNAPSHOT-cuda12.jar': No such file or directory


To follow up the bug in https://github.com/NVIDIA/spark-rapids/pull/11608