### PR TITLE
Fix `collection_ops_test` for [databricks] 14.3

### DIFF
--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -18,11 +18,10 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_err
 from data_gen import *
 from pyspark.sql.types import *
 
-from spark_session import is_before_spark_400
 from string_test import mk_str_gen
 import pyspark.sql.functions as f
 import pyspark.sql.utils
-from spark_session import with_cpu_session, with_gpu_session, is_before_spark_334, is_before_spark_351, is_before_spark_342, is_before_spark_340, is_spark_350
+from spark_session import with_cpu_session, with_gpu_session, is_before_spark_334, is_before_spark_342, is_before_spark_340, is_databricks_version_or_later, is_spark_350, is_spark_400_or_later
 from conftest import get_datagen_seed
 from marks import allow_non_gpu
 
@@ -330,8 +329,9 @@ sequence_too_long_length_gens = [
 def test_sequence_too_long_sequence(stop_gen):
     msg = "Too long sequence" if is_before_spark_334() \
                                  or (not is_before_spark_340() and is_before_spark_342()) \
-                                 or is_spark_350() \
-          else "Can't create array" if not is_before_spark_400() \
+                                 or (is_spark_350() and not is_databricks_version_or_later(14, 3)) \
+          else "Can't create array" if ((is_databricks_version_or_later(14, 3))
+                                         or is_spark_400_or_later()) \
           else "Unsuccessful try to create array with"
     assert_gpu_and_cpu_error(
         # To avoid OOM, reduce the row number to 1, it is enough to verify this case.

--- a/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -19,5 +19,5 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
-object RapidsErrorUtils extends RapidsErrorUtils341DBBase
+object RapidsErrorUtils extends RapidsErrorUtils341DBPlusBase
   with SequenceSizeTooLongErrorBuilder

--- a/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils341DBPlusBase.scala
+++ b/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils341DBPlusBase.scala
@@ -15,15 +15,16 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "400"}
+{"spark": "341db"}
+{"spark": "350db"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
 import org.apache.spark.sql.errors.QueryExecutionErrors
 
-trait SequenceSizeExceededLimitErrorBuilder {
-  def getTooLongSequenceErrorString(sequenceSize: Int, functionName: String): String = {
-    QueryExecutionErrors.createArrayWithElementsExceedLimitError(functionName, sequenceSize)
-                        .getMessage
+trait RapidsErrorUtils341DBPlusBase extends RapidsErrorUtilsBase
+  with RapidsQueryErrorUtils {
+  def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
+    QueryExecutionErrors.invalidIndexOfZeroError(context = null)
   }
 }

--- a/sql-plugin/src/main/spark350db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/spark350db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "341db"}
+{"spark": "350db"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
-object RapidsErrorUtils extends RapidsErrorUtils341DBBase
-  with SequenceSizeTooLongErrorBuilder
+object RapidsErrorUtils extends RapidsErrorUtils341DBPlusBase
+  with SequenceSizeExceededLimitErrorBuilder

--- a/sql-plugin/src/main/spark350db/scala/org/apache/spark/sql/rapids/shims/SequenceSizeExceededLimitErrorBuilder.scala
+++ b/sql-plugin/src/main/spark350db/scala/org/apache/spark/sql/rapids/shims/SequenceSizeExceededLimitErrorBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,16 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "341db"}
+{"spark": "350db"}
+{"spark": "400"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
-object RapidsErrorUtils extends RapidsErrorUtils341DBBase
-  with SequenceSizeTooLongErrorBuilder
+import org.apache.spark.sql.errors.QueryExecutionErrors
+
+trait SequenceSizeExceededLimitErrorBuilder {
+  def getTooLongSequenceErrorString(sequenceSize: Int, functionName: String): String = {
+    QueryExecutionErrors.createArrayWithElementsExceedLimitError(functionName, sequenceSize)
+                        .getMessage
+  }
+}


### PR DESCRIPTION
Fixes #11532.

This commit introduces a `RapidsErrorUtils` shim for Databricks 14.3, to deal with the new error messages thrown for large array/sequences.

This should fix the failure in `collection_ops_test.py::test_sequence_too_long_sequence` on Databricks 14.3.