### PR TITLE
Disable date/timestamp types by default when parsing JSON

### DIFF
--- a/docs/additional-functionality/advanced_configs.md
+++ b/docs/additional-functionality/advanced_configs.md
@@ -129,6 +129,7 @@ Name | Description | Default Value | Applicable at
 <a name="sql.join.leftOuter.enabled"></a>spark.rapids.sql.join.leftOuter.enabled|When set to true left outer joins are enabled on the GPU|true|Runtime
 <a name="sql.join.leftSemi.enabled"></a>spark.rapids.sql.join.leftSemi.enabled|When set to true left semi joins are enabled on the GPU|true|Runtime
 <a name="sql.join.rightOuter.enabled"></a>spark.rapids.sql.join.rightOuter.enabled|When set to true right outer joins are enabled on the GPU|true|Runtime
+<a name="sql.json.read.datetime.enabled"></a>spark.rapids.sql.json.read.datetime.enabled|JSON reading is not 100% compatible when reading dates and timestamps.|false|Runtime
 <a name="sql.json.read.decimal.enabled"></a>spark.rapids.sql.json.read.decimal.enabled|When reading a quoted string as a decimal Spark supports reading non-ascii unicode digits, and the RAPIDS Accelerator does not.|true|Runtime
 <a name="sql.json.read.double.enabled"></a>spark.rapids.sql.json.read.double.enabled|JSON reading is not 100% compatible when reading doubles.|true|Runtime
 <a name="sql.json.read.float.enabled"></a>spark.rapids.sql.json.read.float.enabled|JSON reading is not 100% compatible when reading floats.|true|Runtime

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -418,6 +418,9 @@ The `from_json` function is disabled by default because it is experimental and h
 incompatibilities with Spark, and can be enabled by setting 
 `spark.rapids.sql.expression.JsonToStructs=true`. You don't need to set 
 `spark.rapids.sql.format.json.enabled` and`spark.rapids.sql.format.json.read.enabled` to true.
+In addition, if the input schema contains date and/or timestamp types, an additional config 
+`spark.rapids.sql.json.read.datetime.enabled` also needs to be set to `true` in order 
+to turn on this function.
 
 There is no schema discovery as a schema is required as input to `from_json`
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -393,10 +393,14 @@ consistent with the behavior in Spark 3.3.0 and later.
 Another limitation of the GPU JSON reader is that it will parse strings containing non-string boolean or numeric values where
 Spark will treat them as invalid inputs and will just return `null`.
 
-### JSON Timestamps/Dates
+### JSON Dates/Timestamps
 
-The JSON parser does not support the `TimestampNTZ` type and will fall back to CPU if `spark.sql.timestampType` is
-set to `TIMESTAMP_NTZ` or if an explicit schema is provided that contains the `TimestampNTZ` type.
+Dates and timestamps are not supported by default in JSON parser, since the GPU implementation is not 100%
+compatible with Apache Spark.
+If needed, they can be turned on through the config `spark.rapids.sql.json.read.datetime.enabled`.
+Once enabled, the JSON parser still does not support the `TimestampNTZ` type and will fall back to CPU
+if `spark.sql.timestampType` is set to `TIMESTAMP_NTZ` or if an explicit schema is provided that
+contains the `TimestampNTZ` type.
 
 There is currently no support for reading numeric values as timestamps and null values are returned instead
 ([#4940](https://github.com/NVIDIA/spark-rapids/issues/4940)). A workaround would be to read as longs and then cast
@@ -420,7 +424,7 @@ incompatibilities with Spark, and can be enabled by setting
 `spark.rapids.sql.format.json.enabled` and`spark.rapids.sql.format.json.read.enabled` to true.
 In addition, if the input schema contains date and/or timestamp types, an additional config 
 `spark.rapids.sql.json.read.datetime.enabled` also needs to be set to `true` in order 
-to turn on this function.
+to enable this function on the GPU.
 
 There is no schema discovery as a schema is required as input to `from_json`
 

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -23058,8 +23058,8 @@ dates or timestamps, or for a lack of type coercion support.
 <td>S</td>
 <td>S</td>
 <td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td><em>PS<br/>DATE is not supported by default due to compatibility</em></td>
+<td><em>PS<br/>TIMESTAMP is not supported by default due to compatibility;<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td>S</td>
 <td>S</td>
 <td> </td>

--- a/integration_tests/src/main/python/json_matrix_test.py
+++ b/integration_tests/src/main/python/json_matrix_test.py
@@ -1032,7 +1032,9 @@ def test_from_json_doubles(std_input_path, input_file):
 @pytest.mark.parametrize('read_func', [read_json_df])
 @allow_non_gpu(*non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
 def test_scan_json_corrected_dates(std_input_path, read_func, spark_tmp_table_factory, input_file):
-    conf = copy_and_update(_enable_all_types_json_scan_conf, {"spark.sql.legacy.timeParserPolicy": "CORRECTED"})
+    conf = copy_and_update(_enable_all_types_json_scan_conf, 
+        {"spark.sql.legacy.timeParserPolicy": "CORRECTED",
+         "spark.rapids.sql.json.read.datetime.enabled": "true"})
     assert_gpu_and_cpu_are_equal_collect(
         read_func(std_input_path + '/' + input_file,
         StructType([StructField("data", DateType())]),
@@ -1093,7 +1095,9 @@ def test_from_json_corrected_dates(std_input_path, input_file):
 @pytest.mark.parametrize('read_func', [read_json_df])
 @allow_non_gpu(*non_utc_allow)
 def test_scan_json_corrected_timestamps(std_input_path, read_func, spark_tmp_table_factory, input_file):
-    conf = copy_and_update(_enable_all_types_json_scan_conf, {"spark.sql.legacy.timeParserPolicy": "CORRECTED"})
+    conf = copy_and_update(_enable_all_types_json_scan_conf, 
+        {"spark.sql.legacy.timeParserPolicy": "CORRECTED",
+         "spark.rapids.sql.json.read.datetime.enabled": "true"})
     assert_gpu_and_cpu_are_equal_collect(
         read_func(std_input_path + '/' + input_file,
         StructType([StructField("data", TimestampType())]),

--- a/integration_tests/src/main/python/json_matrix_test.py
+++ b/integration_tests/src/main/python/json_matrix_test.py
@@ -1062,7 +1062,9 @@ def test_scan_json_corrected_dates(std_input_path, read_func, spark_tmp_table_fa
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
 def test_from_json_corrected_dates(std_input_path, input_file):
     schema = StructType([StructField("data", DateType())])
-    conf = copy_and_update(_enable_json_to_structs_conf, {"spark.sql.legacy.timeParserPolicy": "CORRECTED"})
+    conf = copy_and_update(_enable_json_to_structs_conf, 
+        {"spark.sql.legacy.timeParserPolicy": "CORRECTED",
+         "spark.rapids.sql.json.read.datetime.enabled": "true"})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : read_json_as_text(spark, std_input_path + '/' + input_file, "json").select(f.col('json'), f.from_json(f.col('json'), schema)),
         conf = conf)
@@ -1121,7 +1123,9 @@ def test_scan_json_corrected_timestamps(std_input_path, read_func, spark_tmp_tab
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow)
 def test_from_json_corrected_timestamps(std_input_path, input_file):
     schema = StructType([StructField("data", TimestampType())])
-    conf = copy_and_update(_enable_json_to_structs_conf, {"spark.sql.legacy.timeParserPolicy": "CORRECTED"})
+    conf = copy_and_update(_enable_json_to_structs_conf, 
+        {"spark.sql.legacy.timeParserPolicy": "CORRECTED",
+         "spark.rapids.sql.json.read.datetime.enabled": "true"})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : read_json_as_text(spark, std_input_path + '/' + input_file, "json").select(f.col('json'), f.from_json(f.col('json'), schema)),
         conf = conf)
@@ -1448,7 +1452,9 @@ def test_scan_json_mixed_struct(std_input_path, read_func, spark_tmp_table_facto
     ])
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
 def test_from_json_mixed_corrected(std_input_path, input_file, schema):
-    conf = copy_and_update(_enable_json_to_structs_conf, {"spark.sql.legacy.timeParserPolicy": "CORRECTED"})
+    conf = copy_and_update(_enable_json_to_structs_conf, 
+        {"spark.sql.legacy.timeParserPolicy": "CORRECTED",
+         "spark.rapids.sql.json.read.datetime.enabled": "true"})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : read_json_as_text(spark, std_input_path + '/' + input_file, "json").selectExpr('json',
             "from_json(json, '" + schema + "') as parsed"),

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -200,7 +200,9 @@ def test_json_date_formats_round_trip(spark_tmp_path, date_format, v1_enabled_li
     gen = StructGen([('a', DateGen())], nullable=False)
     data_path = spark_tmp_path + '/JSON_DATA'
     schema = gen.data_type
-    updated_conf = copy_and_update(_enable_all_types_conf, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    updated_conf = copy_and_update(_enable_all_types_conf,
+        {'spark.sql.sources.useV1SourceList': v1_enabled_list,
+         'spark.rapids.sql.json.read.datetime.enabled': 'true'})
 
     def create_test_data(spark):
         write = gen_df(spark, gen).write
@@ -238,7 +240,9 @@ def test_json_ts_formats_round_trip(spark_tmp_path, timestamp_format, v1_enabled
         write.json(data_path)
 
     with_cpu_session(lambda spark: create_test_data(spark))
-    updated_conf = copy_and_update(_enable_all_types_conf, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    updated_conf = copy_and_update(_enable_all_types_conf,
+        {'spark.sql.sources.useV1SourceList': v1_enabled_list,
+         'spark.rapids.sql.json.read.datetime.enabled': 'true'})
 
     def do_read(spark):
         read = spark.read.schema(schema)
@@ -280,7 +284,8 @@ def json_ts_formats_round_trip_ntz(spark_tmp_path, timestamp_format, timestamp_t
     updated_conf = copy_and_update(_enable_all_types_conf,
         {
             'spark.sql.sources.useV1SourceList': v1_enabled_list,
-            'spark.sql.timestampType': timestamp_type
+            'spark.sql.timestampType': timestamp_type,
+            'spark.rapids.sql.json.read.datetime.enabled': 'true'
         })
 
     def do_read(spark):
@@ -343,7 +348,8 @@ def test_basic_json_read(std_input_path, filename, schema, read_func, allow_non_
         allow_numeric_leading_zeros, ansi_enabled, spark_tmp_table_factory, date_format):
     updated_conf = copy_and_update(_enable_all_types_conf,
         {'spark.sql.ansi.enabled': ansi_enabled,
-         'spark.sql.legacy.timeParserPolicy': 'CORRECTED'})
+         'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
+         'spark.rapids.sql.json.read.datetime.enabled': 'true'})
     options = {"allowNonNumericNumbers": allow_non_numeric_numbers,
            "allowNumericLeadingZeros": allow_numeric_leading_zeros,
            }
@@ -512,7 +518,8 @@ not_utc_json_scan_allow=['FileSourceScanExec'] if is_not_utc() else []
 def test_json_read_valid_dates(std_input_path, filename, schema, read_func, ansi_enabled, time_parser_policy, spark_tmp_table_factory):
     updated_conf = copy_and_update(_enable_all_types_conf,
                                    {'spark.sql.ansi.enabled': ansi_enabled,
-                                    'spark.sql.legacy.timeParserPolicy': time_parser_policy})
+                                    'spark.sql.legacy.timeParserPolicy': time_parser_policy,
+                                    'spark.rapids.sql.json.read.datetime.enabled': 'true'})
     f = read_func(std_input_path + '/' + filename, schema, spark_tmp_table_factory, {})
     if time_parser_policy == 'LEGACY' and ansi_enabled == 'true':
         assert_gpu_fallback_collect(
@@ -547,7 +554,8 @@ def test_json_read_generated_dates(spark_tmp_table_factory, spark_tmp_path, date
 
     updated_conf = copy_and_update(_enable_all_types_conf, {
         'spark.sql.ansi.enabled': ansi_enabled,
-        'spark.sql.legacy.timeParserPolicy': 'CORRECTED'})
+        'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
+        'spark.rapids.sql.json.read.datetime.enabled': 'true'})
 
     options = { 'allowNumericLeadingZeros': allow_numeric_leading_zeros }
     if date_format:
@@ -573,7 +581,8 @@ def test_json_read_invalid_dates(std_input_path, filename, schema, read_func, an
         time_parser_policy, spark_tmp_table_factory):
     updated_conf = copy_and_update(_enable_all_types_conf,
                                    {'spark.sql.ansi.enabled': ansi_enabled,
-                                    'spark.sql.legacy.timeParserPolicy': time_parser_policy })
+                                    'spark.sql.legacy.timeParserPolicy': time_parser_policy,
+                                    'spark.rapids.sql.json.read.datetime.enabled': 'true'})
     options = { 'dateFormat': date_format } if date_format else {}
     f = read_func(std_input_path + '/' + filename, schema, spark_tmp_table_factory, options)
     if time_parser_policy == 'EXCEPTION':
@@ -606,7 +615,8 @@ def test_json_read_valid_timestamps(std_input_path, filename, schema, read_func,
         spark_tmp_table_factory):
     updated_conf = copy_and_update(_enable_all_types_conf,
                                    {'spark.sql.ansi.enabled': ansi_enabled,
-                                    'spark.sql.legacy.timeParserPolicy': time_parser_policy})
+                                    'spark.sql.legacy.timeParserPolicy': time_parser_policy,
+                                    'spark.rapids.sql.json.read.datetime.enabled': 'true'})
     f = read_func(std_input_path + '/' + filename, schema, spark_tmp_table_factory, {})
     assert_gpu_and_cpu_are_equal_collect(f, conf=updated_conf)
 

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -390,7 +390,8 @@ def test_basic_from_json(std_input_path, filename, schema, allow_non_numeric_num
         allow_numeric_leading_zeros, ansi_enabled, date_format):
     updated_conf = copy_and_update(_enable_all_types_conf,
         {'spark.sql.ansi.enabled': ansi_enabled,
-         'spark.sql.legacy.timeParserPolicy': 'CORRECTED'})
+         'spark.sql.legacy.timeParserPolicy': 'CORRECTED',
+         'spark.rapids.sql.json.read.datetime.enabled': 'true'})
     options = {"allowNonNumericNumbers": allow_non_numeric_numbers,
            "allowNumericLeadingZeros": allow_numeric_leading_zeros,
            }
@@ -1371,9 +1372,10 @@ def test_spark_from_json_timestamp_format_option_zoneid_but_default_format(zone_
     schema = StructType([StructField("t", TimestampType())])
     data = [[r'''{"t": "2016-01-01 00:00:00"}'''],
         [r'''{"t": "2023-07-27 12:21:05"}''']]
+    conf = copy_and_update(_enable_all_types_conf, {"spark.rapids.sql.json.read.datetime.enabled": "true"})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.createDataFrame(data, 'json STRING').select(f.col('json'), f.from_json(f.col('json'), schema, {'timeZone': zone_id})),
-        conf =_enable_all_types_conf)
+        conf =conf)
 
 # from_json with option (timestampFormat)
 # no timestamp format appears to actually work
@@ -1427,9 +1429,10 @@ def test_spark_from_json_date_with_format():
     data = [["""{"time": "26/08/2015"}"""],
             ["""{"time": "01/01/2024"}"""]]
     schema = StructType([StructField("d", DateType())])
+    conf = copy_and_update(_enable_all_types_conf, {"spark.rapids.sql.json.read.datetime.enabled": "true"})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.createDataFrame(data, 'json STRING').select(f.col('json'), f.from_json(f.col('json'), schema, {'dateFormat': 'dd/MM/yyyy'})),
-        conf =_enable_all_types_conf)
+        conf =conf)
 
 # TEST from_json missing columns
 @allow_non_gpu(*non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1152,7 +1152,6 @@ object GpuOverrides extends Logging {
         override val isFoldableNonLitAllowed: Boolean = true
         override def convertToGpu(): GpuExpression =
           GpuUnaryPositive(childExprs.head.convertToGpu())
-        
       }),
     expr[Year](
       "Returns the year from a date or timestamp",
@@ -1794,7 +1793,7 @@ object GpuOverrides extends Logging {
       ExprChecks.binaryProject(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
         ("timestamp", TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
         ("timezone", TypeSig.lit(TypeEnum.STRING)
-          .withPsNote(TypeEnum.STRING, 
+          .withPsNote(TypeEnum.STRING,
             "Only non-DST(Daylight Savings Time) timezones are supported"),
           TypeSig.lit(TypeEnum.STRING))),
       (a, conf, p, r) => new FromUTCTimestampExprMeta(a, conf, p, r)
@@ -1804,7 +1803,7 @@ object GpuOverrides extends Logging {
       ExprChecks.binaryProject(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
         ("timestamp", TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
         ("timezone", TypeSig.lit(TypeEnum.STRING)
-          .withPsNote(TypeEnum.STRING, 
+          .withPsNote(TypeEnum.STRING,
             "Only non-DST(Daylight Savings Time) timezones are supported"),
           TypeSig.lit(TypeEnum.STRING))),
       (a, conf, p, r) => new ToUTCTimestampExprMeta(a, conf, p, r)
@@ -2281,9 +2280,9 @@ object GpuOverrides extends Logging {
           ParamCheck("value", (TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP + TypeSig.BINARY
             + TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128).nested(),
             TypeSig.all),
-          ParamCheck("ordering", (TypeSig.commonCudfTypes - TypeSig.fp + TypeSig.DECIMAL_128 + 
+          ParamCheck("ordering", (TypeSig.commonCudfTypes - TypeSig.fp + TypeSig.DECIMAL_128 +
             TypeSig.NULL + TypeSig.STRUCT + TypeSig.ARRAY).nested(
-              TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + 
+              TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 +
               TypeSig.NULL + TypeSig.STRUCT + TypeSig.ARRAY),
             TypeSig.orderable))
       ),
@@ -2310,9 +2309,9 @@ object GpuOverrides extends Logging {
           ParamCheck("value", (TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP + TypeSig.BINARY
             + TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128).nested(),
             TypeSig.all),
-          ParamCheck("ordering", (TypeSig.commonCudfTypes - TypeSig.fp + TypeSig.DECIMAL_128 + 
+          ParamCheck("ordering", (TypeSig.commonCudfTypes - TypeSig.fp + TypeSig.DECIMAL_128 +
             TypeSig.NULL + TypeSig.STRUCT + TypeSig.ARRAY).nested(
-              TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + 
+              TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 +
               TypeSig.NULL + TypeSig.STRUCT + TypeSig.ARRAY),
             TypeSig.orderable))
       ),
@@ -3368,7 +3367,7 @@ object GpuOverrides extends Logging {
       ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("url", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("partToExtract", TypeSig.lit(TypeEnum.STRING).withPsNote(
-            TypeEnum.STRING, "only support partToExtract = PROTOCOL | HOST | QUERY | PATH"), 
+            TypeEnum.STRING, "only support partToExtract = PROTOCOL | HOST | QUERY | PATH"),
             TypeSig.STRING)),
           // Should really be an OptionalParam
           Some(RepeatingParamCheck("key", TypeSig.STRING, TypeSig.STRING))),
@@ -3377,9 +3376,9 @@ object GpuOverrides extends Logging {
           if (a.failOnError) {
             willNotWorkOnGpu("Fail on error is not supported on GPU when parsing urls.")
           }
-          
+
           extractStringLit(a.children(1)).map(_.toUpperCase) match {
-            // In Spark, the key in parse_url could act like a regex, but GPU will match the key 
+            // In Spark, the key in parse_url could act like a regex, but GPU will match the key
             // exactly. When key is literal, GPU will check if the key contains regex special and
             // fallbcak to CPU if it does, but we are not able to fallback when key is column.
             // see Spark issue: https://issues.apache.org/jira/browse/SPARK-44500
@@ -3388,7 +3387,7 @@ object GpuOverrides extends Logging {
                 if (key.value != null) {
                   val keyStr = key.value.asInstanceOf[UTF8String].toString
                   if (regexMetaChars.exists(keyStr.contains(_))) {
-                    willNotWorkOnGpu(s"Key $keyStr could act like a regex which is not " + 
+                    willNotWorkOnGpu(s"Key $keyStr could act like a regex which is not " +
                         "supported on GPU")
                   }
                 }
@@ -3780,6 +3779,11 @@ object GpuOverrides extends Logging {
             case _ => false
           })
 
+        def hasDateTimeType(dt: DataType): Boolean =
+          TrampolineUtil.dataTypeExistsRecursively(dt, t =>
+            t.isInstanceOf[DateType] || t.isInstanceOf[TimestampType]
+          )
+
         override def tagExprForGpu(): Unit = {
           a.schema match {
             case MapType(_: StringType, _: StringType, _) => ()
@@ -3788,7 +3792,11 @@ object GpuOverrides extends Logging {
                 willNotWorkOnGpu("from_json on GPU does not support duplicate field " +
                     "names in a struct")
               }
-              ()
+              if (hasDateTimeType(st) && !conf.isJsonDateTimeReadEnabled) {
+                willNotWorkOnGpu("from_json on GPU does not support DateType or TimestampType" +
+                  " by default due to compatibility. " +
+                  "Set `spark.rapids.sql.json.read.datetime.enabled` to true to enable them.")
+              }
             case _ =>
               willNotWorkOnGpu("from_json on GPU only supports MapType<StringType, StringType> " +
                 "or StructType schema")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -848,6 +848,8 @@ object GpuOverrides extends Logging {
   val jsonStructReadTypes: TypeSig = (TypeSig.STRUCT + TypeSig.ARRAY +
       TypeSig.STRING + TypeSig.integral + TypeSig.fp + TypeSig.DECIMAL_128 + TypeSig.BOOLEAN +
       TypeSig.DATE + TypeSig.TIMESTAMP).nested()
+    .withPsNote(TypeEnum.DATE, "DATE is not supported by default due to compatibility")
+    .withPsNote(TypeEnum.TIMESTAMP, "TIMESTAMP is not supported by default due to compatibility")
 
   lazy val fileFormats: Map[FileFormatType, Map[FileFormatOp, FileFormatChecks]] = Map(
     (CsvFormatType, FileFormatChecks(
@@ -3795,7 +3797,7 @@ object GpuOverrides extends Logging {
               if (hasDateTimeType(st) && !this.conf.isJsonDateTimeReadEnabled) {
                 willNotWorkOnGpu("from_json on GPU does not support DateType or TimestampType" +
                   " by default due to compatibility. " +
-                  "Set `spark.rapids.sql.json.read.datetime.enabled` to true to enable them.")
+                  "Set `spark.rapids.sql.json.read.datetime.enabled` to `true` to enable them.")
               }
             case _ =>
               willNotWorkOnGpu("from_json on GPU only supports MapType<StringType, StringType> " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3792,7 +3792,7 @@ object GpuOverrides extends Logging {
                 willNotWorkOnGpu("from_json on GPU does not support duplicate field " +
                     "names in a struct")
               }
-              if (hasDateTimeType(st) && !conf.isJsonDateTimeReadEnabled) {
+              if (hasDateTimeType(st) && !this.conf.isJsonDateTimeReadEnabled) {
                 willNotWorkOnGpu("from_json on GPU does not support DateType or TimestampType" +
                   " by default due to compatibility. " +
                   "Set `spark.rapids.sql.json.read.datetime.enabled` to true to enable them.")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1361,6 +1361,11 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .booleanConf
     .createWithDefault(true)
 
+  val ENABLE_READ_JSON_DATE_TIME = conf("spark.rapids.sql.json.read.datetime.enabled")
+    .doc("JSON reading is not 100% compatible when reading dates and timestamps.")
+    .booleanConf
+    .createWithDefault(false)
+
   val ENABLE_AVRO = conf("spark.rapids.sql.format.avro.enabled")
     .doc("When set to true enables all avro input and output acceleration. " +
       "(only input is currently supported anyways)")
@@ -2843,7 +2848,7 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isCombinedExpressionsEnabled: Boolean = get(ENABLE_COMBINED_EXPRESSIONS)
 
   lazy val isRlikeRegexRewriteEnabled: Boolean = get(ENABLE_RLIKE_REGEX_REWRITE)
-  
+
   lazy val isExpandPreprojectEnabled: Boolean = get(ENABLE_EXPAND_PREPROJECT)
 
   lazy val isCoalesceAfterExpandEnabled: Boolean = get(ENABLE_COALESCE_AFTER_EXPAND)
@@ -2950,6 +2955,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isJsonDoubleReadEnabled: Boolean = get(ENABLE_READ_JSON_DOUBLES)
 
   lazy val isJsonDecimalReadEnabled: Boolean = get(ENABLE_READ_JSON_DECIMALS)
+
+  lazy val isJsonDateTimeReadEnabled: Boolean = get(ENABLE_READ_JSON_DATE_TIME)
 
   lazy val isAvroEnabled: Boolean = get(ENABLE_AVRO)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -177,6 +177,12 @@ object GpuJsonScan {
     }
 
     if (hasDates || hasTimestamps) {
+      if (!meta.conf.isJsonDateTimeReadEnabled) {
+        meta.willNotWorkOnGpu("JsonScan on GPU does not support DateType or TimestampType" +
+          " by default due to compatibility. " +
+          "Set `spark.rapids.sql.json.read.datetime.enabled` to `true` to enable them.")
+      }
+
       if (!GpuOverrides.isUTCTimezone(parsedOptions.zoneId)) {
         meta.willNotWorkOnGpu(s"Not supported timezone type ${parsedOptions.zoneId}.")
       }


### PR DESCRIPTION
Add a config `spark.rapids.sql.json.read.datetime.enabled` with default to `false` to disable date/timestamp types when parsing JSON due to compatibility reason, as our GPU implementation cannot match 100% output with Apache Spark for these types.