### PR TITLE
Skip AQE-join-DPP tests for [databricks] 14.3

### DIFF
--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -341,7 +341,7 @@ aqe_join_with_dpp_fallback=["FilterExec"] if (is_databricks_runtime() or is_befo
 
 # Verify that DPP and AQE can coexist in even some odd cases involving multiple tables
 @pytest.mark.skipif(condition=is_databricks_version_or_later(14, 3),
-                    reason="https://github.com/NVIDIA/spark-rapids/issues/11527")
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/11643")
 @ignore_order(local=True)
 @allow_non_gpu(*aqe_join_with_dpp_fallback)
 def test_aqe_join_with_dpp(spark_tmp_path):

--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -19,7 +19,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_cpu_and_gpu_are
 from conftest import is_databricks_runtime, is_not_utc
 from data_gen import *
 from marks import ignore_order, allow_non_gpu
-from spark_session import with_cpu_session, is_databricks113_or_later, is_before_spark_330
+from spark_session import with_cpu_session, is_databricks113_or_later, is_before_spark_330, is_databricks_version_or_later
 
 # allow non gpu when time zone is non-UTC because of https://github.com/NVIDIA/spark-rapids/issues/9653'
 not_utc_aqe_allow=['ShuffleExchangeExec', 'HashAggregateExec'] if is_not_utc() else []
@@ -340,6 +340,8 @@ def test_aqe_join_executor_broadcast_enforce_single_batch():
 aqe_join_with_dpp_fallback=["FilterExec"] if (is_databricks_runtime() or is_before_spark_330()) else []
 
 # Verify that DPP and AQE can coexist in even some odd cases involving multiple tables
+@pytest.mark.skipif(condition=is_databricks_version_or_later(14, 3),
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/11527")
 @ignore_order(local=True)
 @allow_non_gpu(*aqe_join_with_dpp_fallback)
 def test_aqe_join_with_dpp(spark_tmp_path):
@@ -393,6 +395,8 @@ def test_aqe_join_with_dpp(spark_tmp_path):
     assert_gpu_and_cpu_are_equal_collect(run_test, conf=_adaptive_conf)
 
 # Verify that DPP and AQE can coexist in even some odd cases involving 2 tables with multiple columns
+@pytest.mark.skipif(condition=is_databricks_version_or_later(14, 3),
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/11527")
 @ignore_order(local=True)
 @allow_non_gpu(*aqe_join_with_dpp_fallback)
 def test_aqe_join_with_dpp_multi_columns(spark_tmp_path):

--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -396,7 +396,7 @@ def test_aqe_join_with_dpp(spark_tmp_path):
 
 # Verify that DPP and AQE can coexist in even some odd cases involving 2 tables with multiple columns
 @pytest.mark.skipif(condition=is_databricks_version_or_later(14, 3),
-                    reason="https://github.com/NVIDIA/spark-rapids/issues/11527")
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/11643")
 @ignore_order(local=True)
 @allow_non_gpu(*aqe_join_with_dpp_fallback)
 def test_aqe_join_with_dpp_multi_columns(spark_tmp_path):


### PR DESCRIPTION
Fixes #11527.

This is a temporary workaround to handle the failures in AQE/Join/DPP tests, as listed in #11527.

The AQE plan for broadcast hash join seems to have changed between 13.3 and 14.3 Databricks versions.
The actual fix for the problem will be tracked in #11643.  This commit disables the test so that the CI test can run through.