### PR TITLE
Fix a NPE issue in GpuRand

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
@@ -49,16 +49,16 @@ case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpres
    */
   @transient protected var rng: RapidsXORShiftRandom = _
 
-  @transient protected lazy val seed: Long = child match {
+  private lazy val seed: Long = child match {
     case GpuLiteral(s, IntegerType) => s.asInstanceOf[Int]
     case GpuLiteral(s, LongType) => s.asInstanceOf[Long]
     case _ => throw new RapidsAnalysisException(
       s"Input argument to $prettyName must be an integer, long or null literal.")
   }
 
-  @transient protected var previousPartition: Int = 0
+  private var previousPartition: Int = 0
 
-  @transient protected var curXORShiftRandomSeed: Option[Long] = None
+  private var curXORShiftRandomSeed: Option[Long] = None
 
   private def wasInitialized: Boolean = rng != null
 


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11646

`curXORShiftRandomSeed ` is marked as `transient`, so it will be null on executors without retry-restore context, leading to this NPE.
This fix removes the `transient` for `curXORShiftRandomSeed`, `seed` and `previousPartition` that will be used by the computation on executors.

I verified it by the customer case, and it works well. The fix is simple so i don't add any tests.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
