### PR TITLE
Support format 'yyyyMMdd HH:mm:ss' for legacy mode [databricks]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -655,17 +655,16 @@ guaranteed to produce the same results as the CPU:
 - `yyyymmdd`
 - `yyyy/MM/dd HH:mm:ss`
 - `yyyy-MM-dd HH:mm:ss`
+- `yyyyMMdd HH:mm:ss`
 
 LEGACY timeParserPolicy support has the following limitations when running on the GPU:
 
 - Only 4 digit years are supported
 - The proleptic Gregorian calendar is used instead of the hybrid Julian+Gregorian calendar
   that Spark uses in legacy mode
-- When format is `yyyyMMdd`, GPU only supports 8 digit strings. Spark supports like 7 digit
-  `2024101` string while GPU does not support. Only tested `UTC` and `Asia/Shanghai` timezones.
-- When format is `yyyymmdd`, GPU only supports 8 digit strings. Spark supports like 7 digit
-  `2024101` string while GPU does not support. Only tested `UTC` and `Asia/Shanghai` timezones.
-
+- When format is/contains `yyyyMMdd` or `yyyymmdd`, GPU only supports 8 digit strings for these formats.
+  Spark supports like 7 digit `2024101` string while GPU does not support. Only tested `UTC` and
+  `Asia/Shanghai` timezones.
 
 ## Formatting dates and timestamps as strings
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -641,6 +641,8 @@ object GpuToTimestamp {
       raw"\A\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
     "yyyy/MM/dd HH:mm:ss" -> ParseFormatMeta(Option('/'), isTimestamp = true,
       raw"\A\d{4}/\d{1,2}/\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
+    "yyyyMMdd HH:mm:ss" -> ParseFormatMeta(None, isTimestamp = true,
+      raw"\A\d{4}\d{1,2}\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
     "yyyyMMdd" -> ParseFormatMeta(None, isTimestamp = false,
       raw"\A\d{8}(\D|\s|\Z)"),
     "yyyymmdd" -> ParseFormatMeta(None, isTimestamp = false,


### PR DESCRIPTION
closes #11657

Support format 'yyyyMMdd HH:mm:ss' for legacy mode
Similar to this PR: https://github.com/NVIDIA/spark-rapids/pull/11493

Signed-off-by: Chong Gao <res_life@163.com>
