### PR TITLE
Support invalid partToExtract for parse_url

### DIFF
--- a/integration_tests/src/main/python/url_test.py
+++ b/integration_tests/src/main/python/url_test.py
@@ -148,7 +148,7 @@ edge_cases_gen = SetValuesGen(StringType(), edge_cases)
 
 url_gen = StringGen(url_pattern)
 
-supported_parts = ['PROTOCOL', 'HOST', 'QUERY', 'PATH']
+supported_parts = ['PROTOCOL', 'HOST', 'QUERY', 'PATH', 'invalid', 'path']
 unsupported_parts = ['REF', 'FILE', 'AUTHORITY', 'USERINFO']
     
 @pytest.mark.parametrize('data_gen', [url_gen, edge_cases_gen], ids=idfn)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3379,7 +3379,7 @@ object GpuOverrides extends Logging {
             willNotWorkOnGpu("Fail on error is not supported on GPU when parsing urls.")
           }
 
-          extractStringLit(a.children(1)).map(_.toUpperCase) match {
+          extractStringLit(a.children(1)) match {
             // In Spark, the key in parse_url could act like a regex, but GPU will match the key
             // exactly. When key is literal, GPU will check if the key contains regex special and
             // fallbcak to CPU if it does, but we are not able to fallback when key is column.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
@@ -40,10 +40,10 @@ object GpuParseUrl {
 
   def isSupportedPart(part: String): Boolean = {
     part match {
-      case PROTOCOL | HOST | QUERY | PATH =>
-        true
-      case _ =>
+      case REF | FILE | AUTHORITY | USERINFO =>
         false
+      case _ => // PROTOCOL, HOST, QUERY, PATH and invalid parts are supported
+        true
     }
   }
 }
@@ -73,7 +73,7 @@ case class GpuParseUrl(children: Seq[Expression])
         throw new UnsupportedOperationException(s"$this is not supported partToExtract=$part. " +
             s"Only PROTOCOL, HOST, QUERY and PATH are supported")
       case _ =>
-        throw new IllegalArgumentException(s"Invalid partToExtract: $partToExtract")
+        return GpuColumnVector.columnVectorFromNull(url.getRowCount.toInt, StringType)
     }
   }
 


### PR DESCRIPTION
Closes #11659 

In parse_url we used to fallback to cpu if the `partToExtract` was not valid. However, the behaviour of cpu is just to always return null, we can also do that easily.

But in customer case #11659, it did run on gpu because `GpuOverrides` thought lowercase `path` was valid, which is not, so it went to a defensive branch which threw an exception.

This pr supports invalid partToExtract in parse_url running on gpu, and fixes the bug in its override.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
