### PR TITLE
Fix `misc_expr_test` for [databricks] 14.3

### DIFF
--- a/integration_tests/src/main/python/misc_expr_test.py
+++ b/integration_tests/src/main/python/misc_expr_test.py
@@ -19,7 +19,7 @@ from data_gen import *
 from marks import incompat, approximate_float
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
-from spark_session import is_before_spark_400
+from spark_session import is_databricks_version_or_later, is_spark_400_or_later
 
 def test_mono_id():
     assert_gpu_and_cpu_are_equal_collect(
@@ -34,8 +34,8 @@ def test_part_id():
                 f.spark_partition_id()))
 
 
-@pytest.mark.skipif(condition=not is_before_spark_400(),
-                    reason="raise_error() not currently implemented for Spark 4.0. "
+@pytest.mark.skipif(condition=is_spark_400_or_later() or is_databricks_version_or_later(14, 3),
+                    reason="raise_error() not currently implemented for Spark 4.0, or Databricks 14.3. "
                            "See https://github.com/NVIDIA/spark-rapids/issues/10107.")
 def test_raise_error():
     data_gen = ShortGen(nullable=False, min_val=0, max_val=20, special_cases=[])


### PR DESCRIPTION
Fixes #11537.

This commit addresses the failure of the `test_raise_error` test in `misc_expr_test.py` for Databricks 14.3.

This is an extension of #11129, where this test was skipped for Apache Spark 4.0.  The failure on Databricks 14.3 shares the same cause as in Spark 4.0, i.e. a backward-incompatible Spark change in the signature of RaiseError, as introduced in
https://issues.apache.org/jira/browse/SPARK-44838.

The work to support SPARK-44838 in a Spark-RAPIDS shim will be tracked in #10969.  This test needs to be skipped until that work is completed.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
