### PR TITLE
Use the new host memory allocation API

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -281,6 +281,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     @Override
     protected ai.rapids.cudf.ColumnVector buildAndPutOnDevice(int builderIndex) {
       ai.rapids.cudf.ColumnVector cv = builders[builderIndex].buildAndPutOnDevice();
+      builders[builderIndex].close();
       builders[builderIndex] = null;
       return cv;
     }
@@ -295,6 +296,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       for (int i = 0; i < builders.length; i++) {
         if (builders[i] != null && wipHostColumns[i] == null) {
           wipHostColumns[i] = builders[i].build();
+          builders[i].close();
           builders[i] = null;
         } else if (builders[i] == null && wipHostColumns[i] == null) {
           throw new IllegalStateException("buildHostColumns cannot be called more than once");

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnBuilder.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnBuilder.java
@@ -126,6 +126,7 @@ public final class RapidsHostColumnBuilder implements AutoCloseable {
     }
     HostColumnVector hostColumnVector = new HostColumnVector(type, rows,
         Optional.of(nullCount), data, valid, offsets, hostColumnVectorCoreList);
+    //TODO get rid of built and do refcounting instead...
     built = true;
     return hostColumnVector;
   }

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnBuilder.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnBuilder.java
@@ -49,7 +49,6 @@ public final class RapidsHostColumnBuilder implements AutoCloseable {
   private long estimatedRows;
   private long rowCapacity = 0L;
   private long validCapacity = 0L;
-  private boolean built = false;
   private List<RapidsHostColumnBuilder> childBuilders = new ArrayList<>();
   private Runnable nullHandler;
 
@@ -117,31 +116,76 @@ public final class RapidsHostColumnBuilder implements AutoCloseable {
 
   public HostColumnVector build() {
     List<HostColumnVectorCore> hostColumnVectorCoreList = new ArrayList<>();
-    for (RapidsHostColumnBuilder childBuilder : childBuilders) {
-      hostColumnVectorCoreList.add(childBuilder.buildNestedInternal());
+    HostColumnVector hostColumnVector = null;
+    try {
+      for (RapidsHostColumnBuilder childBuilder : childBuilders) {
+        hostColumnVectorCoreList.add(childBuilder.buildNestedInternal());
+      }
+      // Aligns the valid buffer size with other buffers in terms of row size, because it grows lazily.
+      if (valid != null) {
+        growValidBuffer();
+      }
+      // Increment the reference counts before creating the HostColumnVector, so we can
+      // keep track of them properly
+      if (data != null) {
+        data.incRefCount();
+      }
+      if (valid != null) {
+        valid.incRefCount();
+      }
+      if (offsets != null) {
+        offsets.incRefCount();
+      }
+      hostColumnVector = new HostColumnVector(type, rows,
+          Optional.of(nullCount), data, valid, offsets, hostColumnVectorCoreList);
+    } finally {
+      if (hostColumnVector == null) {
+        // Something bad happened, and we need to clean up after ourselves
+        for (HostColumnVectorCore hcv : hostColumnVectorCoreList) {
+          if (hcv != null) {
+            hcv.close();
+          }
+        }
+      }
     }
-    // Aligns the valid buffer size with other buffers in terms of row size, because it grows lazily.
-    if (valid != null) {
-      growValidBuffer();
-    }
-    HostColumnVector hostColumnVector = new HostColumnVector(type, rows,
-        Optional.of(nullCount), data, valid, offsets, hostColumnVectorCoreList);
-    //TODO get rid of built and do refcounting instead...
-    built = true;
     return hostColumnVector;
   }
 
   private HostColumnVectorCore buildNestedInternal() {
     List<HostColumnVectorCore> hostColumnVectorCoreList = new ArrayList<>();
-    for (RapidsHostColumnBuilder childBuilder : childBuilders) {
-      hostColumnVectorCoreList.add(childBuilder.buildNestedInternal());
+    HostColumnVectorCore ret = null;
+    try {
+      for (RapidsHostColumnBuilder childBuilder : childBuilders) {
+        hostColumnVectorCoreList.add(childBuilder.buildNestedInternal());
+      }
+      // Aligns the valid buffer size with other buffers in terms of row size, because it grows lazily.
+      if (valid != null) {
+        growValidBuffer();
+      }
+      // Increment the reference counts before creating the HostColumnVector, so we can
+      // keep track of them properly
+      if (data != null) {
+        data.incRefCount();
+      }
+      if (valid != null) {
+        valid.incRefCount();
+      }
+      if (offsets != null) {
+        offsets.incRefCount();
+      }
+      ret = new HostColumnVectorCore(type, rows, Optional.of(nullCount), data, valid,
+          offsets, hostColumnVectorCoreList);
+    } finally {
+      if (ret == null) {
+        // Something bad happened, and we need to clean up after ourselves
+        for (HostColumnVectorCore hcv : hostColumnVectorCoreList) {
+          if (hcv != null) {
+            hcv.close();
+          }
+        }
+      }
     }
-    // Aligns the valid buffer size with other buffers in terms of row size, because it grows lazily.
-    if (valid != null) {
-      growValidBuffer();
-    }
-    return new HostColumnVectorCore(type, rows, Optional.of(nullCount), data, valid,
-        offsets, hostColumnVectorCoreList);
+    return ret;
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -651,23 +695,20 @@ public final class RapidsHostColumnBuilder implements AutoCloseable {
 
   @Override
   public void close() {
-    if (!built) {
-      if (data != null) {
-        data.close();
-        data = null;
-      }
-      if (valid != null) {
-        valid.close();
-        valid = null;
-      }
-      if (offsets != null) {
-        offsets.close();
-        offsets = null;
-      }
-      for (RapidsHostColumnBuilder childBuilder : childBuilders) {
-        childBuilder.close();
-      }
-      built = true;
+    if (data != null) {
+      data.close();
+      data = null;
+    }
+    if (valid != null) {
+      valid.close();
+      valid = null;
+    }
+    if (offsets != null) {
+      offsets.close();
+      offsets = null;
+    }
+    for (RapidsHostColumnBuilder childBuilder : childBuilders) {
+      childBuilder.close();
     }
   }
 
@@ -686,7 +727,6 @@ public final class RapidsHostColumnBuilder implements AutoCloseable {
         ", nullCount=" + nullCount +
         ", estimatedRows=" + estimatedRows +
         ", populatedRows=" + rows +
-        ", built=" + built +
         '}';
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
@@ -82,12 +82,12 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
       synchronized {
         currentNonPinnedAllocated += amount
       }
-      Some(HostMemoryBuffer.allocate(amount, false))
+      Some(HostMemoryBuffer.allocateRaw(amount))
     } else {
       synchronized {
         if ((currentNonPinnedAllocated + amount) <= nonPinnedLimit) {
           currentNonPinnedAllocated += amount
-          Some(HostMemoryBuffer.allocate(amount, false))
+          Some(HostMemoryBuffer.allocateRaw(amount))
         } else {
           None
         }


### PR DESCRIPTION
This is step 2 in getting all host memory allocations to go through a single API. https://github.com/rapidsai/cudf/pull/17197 added in a new raw allocation API. This starts to use that new API. I will then put up another PR to CUDF that will switch HostMemoryBuffer.allocate to always call the default allocator's allocate API, which should make it so that effectively all large host memory allocations go through our default allocator `HostAlloc`.

After that I will start to clean up the code and remove places where we pass in HostAlloc as a separate allocation API to CUDF APIs.