### PR TITLE
host watermark metric

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
@@ -55,12 +55,12 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
   }
 
   private def getHostAllocMetricsLogStr(metrics: GpuTaskMetrics): String = {
-    Option(TaskContext.get()).map({ context =>
+    Option(TaskContext.get()).map { context =>
       val taskId = context.taskAttemptId()
       val totalSize = metrics.getHostBytesAllocated
       val maxSize = metrics.getMaxHostBytesAllocated
       s"total size for task $taskId is $totalSize, max size is $maxSize"
-    }).getOrElse("allocated memory outside of a task context")
+    }.getOrElse("allocated memory outside of a task context")
   }
 
   private def releasePinned(ptr: Long, amount: Long): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
@@ -69,7 +69,7 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
     }
     val metrics = GpuTaskMetrics.get
     metrics.decHostBytesAllocated(amount)
-    logDebug(getHostAllocMetricsLogStr(metrics))
+    logTrace(getHostAllocMetricsLogStr(metrics))
     RmmSpark.cpuDeallocate(ptr, amount)
   }
 
@@ -79,7 +79,7 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
     }
     val metrics = GpuTaskMetrics.get
     metrics.decHostBytesAllocated(amount)
-    logDebug(getHostAllocMetricsLogStr(metrics))
+    logTrace(getHostAllocMetricsLogStr(metrics))
     RmmSpark.cpuDeallocate(ptr, amount)
   }
 
@@ -205,7 +205,7 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
       if (ret.isDefined) {
         val metrics = GpuTaskMetrics.get
         metrics.incHostBytesAllocated(amount)
-        logDebug(getHostAllocMetricsLogStr(metrics))
+        logTrace(getHostAllocMetricsLogStr(metrics))
         RmmSpark.postCpuAllocSuccess(ret.get.getAddress, amount, blocking, isRecursive)
       } else {
         // shouldRetry should indicate if spill did anything for us and we should try again.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -155,6 +155,9 @@ class GpuTaskMetrics extends Serializable {
 
   def decDiskBytesAllocated(bytes: Long): Unit = {
     diskBytesAllocated -= bytes
+    // For some reason it's possible for the task to start out by releasing resources,
+    // possibly from a previous task, in such case we probably should just ignore it.
+    diskBytesAllocated = diskBytesAllocated.max(0)
   }
 
   private val metrics = Map[String, AccumulatorV2[_, _]](

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -145,9 +145,6 @@ class GpuTaskMetrics extends Serializable {
 
   def decHostBytesAllocated(bytes: Long): Unit = {
     hostBytesAllocated -= bytes
-    // For some reason it's possible for the task to start out by releasing resources,
-    // possibly from a previous task, in such case we probably should just ignore it.
-    hostBytesAllocated = hostBytesAllocated.max(0)
   }
 
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -124,40 +124,35 @@ class GpuTaskMetrics extends Serializable {
   private val maxHostMemoryBytes = new HighWatermarkAccumulator
   private val maxDiskMemoryBytes = new HighWatermarkAccumulator
 
-  private var hostBytesAllocated: Long = 0
   private var maxHostBytesAllocated: Long = 0
 
-  private var diskBytesAllocated: Long = 0
   private var maxDiskBytesAllocated: Long = 0
 
-  def getDiskBytesAllocated: Long = diskBytesAllocated
+  def getDiskBytesAllocated: Long = GpuTaskMetrics.diskBytesAllocated
 
   def getMaxDiskBytesAllocated: Long = maxDiskBytesAllocated
 
-  def getHostBytesAllocated: Long = hostBytesAllocated
+  def getHostBytesAllocated: Long = GpuTaskMetrics.hostBytesAllocated
 
   def getMaxHostBytesAllocated: Long = maxHostBytesAllocated
 
   def incHostBytesAllocated(bytes: Long): Unit = {
-    hostBytesAllocated += bytes
-    maxHostBytesAllocated = maxHostBytesAllocated.max(hostBytesAllocated)
+    GpuTaskMetrics.incHostBytesAllocated(bytes)
+    maxHostBytesAllocated = maxHostBytesAllocated.max(GpuTaskMetrics.hostBytesAllocated)
   }
 
   def decHostBytesAllocated(bytes: Long): Unit = {
-    hostBytesAllocated -= bytes
+    GpuTaskMetrics.decHostBytesAllocated(bytes)
   }
 
 
   def incDiskBytesAllocated(bytes: Long): Unit = {
-    diskBytesAllocated += bytes
-    maxDiskBytesAllocated = maxDiskBytesAllocated.max(diskBytesAllocated)
+    GpuTaskMetrics.incDiskBytesAllocated(bytes)
+    maxDiskBytesAllocated = maxDiskBytesAllocated.max(GpuTaskMetrics.diskBytesAllocated)
   }
 
   def decDiskBytesAllocated(bytes: Long): Unit = {
-    diskBytesAllocated -= bytes
-    // For some reason it's possible for the task to start out by releasing resources,
-    // possibly from a previous task, in such case we probably should just ignore it.
-    diskBytesAllocated = diskBytesAllocated.max(0)
+    GpuTaskMetrics.decHostBytesAllocated(bytes)
   }
 
   private val metrics = Map[String, AccumulatorV2[_, _]](
@@ -275,6 +270,25 @@ class GpuTaskMetrics extends Serializable {
  */
 object GpuTaskMetrics extends Logging {
   private val taskLevelMetrics = mutable.Map[Long, GpuTaskMetrics]()
+
+  private var hostBytesAllocated: Long = 0
+  private var diskBytesAllocated: Long = 0
+
+  private def incHostBytesAllocated(bytes: Long): Unit = synchronized {
+    hostBytesAllocated += bytes
+  }
+
+  private def decHostBytesAllocated(bytes: Long): Unit = synchronized {
+    hostBytesAllocated -= bytes
+  }
+
+  def incDiskBytesAllocated(bytes: Long): Unit = synchronized {
+    diskBytesAllocated += bytes
+  }
+
+  def decDiskBytesAllocated(bytes: Long): Unit = synchronized {
+    diskBytesAllocated -= bytes
+  }
 
   def registerOnTask(metrics: GpuTaskMetrics): Unit = synchronized {
     val tc = TaskContext.get()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -155,9 +155,6 @@ class GpuTaskMetrics extends Serializable {
 
   def decDiskBytesAllocated(bytes: Long): Unit = {
     diskBytesAllocated -= bytes
-    // For some reason it's possible for the task to start out by releasing resources,
-    // possibly from a previous task, in such case we probably should just ignore it.
-    diskBytesAllocated = diskBytesAllocated.max(0)
   }
 
   private val metrics = Map[String, AccumulatorV2[_, _]](


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
Adds  watermark metric to track the max amount of memory allocated on the host per task.

Tested manually and verified the values look sane in the UI and in logs.