### PR TITLE
Add NullIntolerantShim to adapt to Spark 4.0 removing NullIntolerant [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -27,11 +27,11 @@ import ai.rapids.cudf
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.{CastStrings, DecimalUtils, GpuTimeZoneDB}
-import com.nvidia.spark.rapids.shims.{AnsiUtil, GpuCastShims, GpuIntervalUtils, GpuTypeShims, SparkShimImpl, YearParseUtil}
+import com.nvidia.spark.rapids.shims.{AnsiUtil, GpuCastShims, GpuIntervalUtils, GpuTypeShims, NullIntolerantShim, SparkShimImpl, YearParseUtil}
 import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, NullIntolerant, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, TimeZoneAwareExpression}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_SECOND
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -41,8 +41,7 @@ import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 
 /** Meta-data for cast and ansi_cast. */
-final class CastExprMeta[
-      INPUT <: UnaryLike[Expression] with TimeZoneAwareExpression with NullIntolerant](
+final class CastExprMeta[INPUT <: UnaryLike[Expression] with TimeZoneAwareExpression](
     cast: INPUT,
     val evalMode: GpuEvalMode.Value,
     conf: RapidsConf,
@@ -1718,7 +1717,7 @@ case class GpuCast(
     timeZoneId: Option[String] = None,
     legacyCastComplexTypesToString: Boolean = false,
     stringToDateAnsiModeEnabled: Boolean = false)
-  extends GpuUnaryExpression with TimeZoneAwareExpression with NullIntolerant {
+  extends GpuUnaryExpression with TimeZoneAwareExpression with NullIntolerantShim {
 
   import GpuCast._
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -21,8 +21,9 @@ import ai.rapids.cudf.{ColumnView, Cuda, DataSource, DeviceMemoryBuffer, HostMem
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuUnaryExpression, HostAlloc}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.jni.JSONUtils
+import com.nvidia.spark.rapids.shims.NullIntolerantShim
 
-import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, NullIntolerant, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, TimeZoneAwareExpression}
 import org.apache.spark.sql.catalyst.json.JSONOptions
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -70,7 +71,7 @@ case class GpuJsonToStructs(
     child: Expression,
     timeZoneId: Option[String] = None)
     extends GpuUnaryExpression with TimeZoneAwareExpression with ExpectsInputTypes
-        with NullIntolerant {
+        with NullIntolerantShim {
   import GpuJsonReadCommon._
 
   private lazy val parsedOptions = new JSONOptions(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
@@ -21,16 +21,16 @@ import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuProjectExec, 
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.Hash
-import com.nvidia.spark.rapids.shims.{HashUtils, ShimExpression}
+import com.nvidia.spark.rapids.shims.{HashUtils, NullIntolerantShim, ShimExpression}
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, NullIntolerant}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class GpuMd5(child: Expression)
-  extends GpuUnaryExpression with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuUnaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
   override def toString: String = s"md5($child)"
   override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType)
   override def dataType: DataType = StringType

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -23,10 +23,10 @@ import ai.rapids.cudf.ast.BinaryOperator
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.shims.{DecimalMultiply128, GpuTypeShims, ShimExpression, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{DecimalMultiply128, GpuTypeShims, NullIntolerantShim, ShimExpression, SparkShimImpl}
 
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
-import org.apache.spark.sql.catalyst.expressions.{ComplexTypeMergingExpression, ExpectsInputTypes, Expression, NullIntolerant}
+import org.apache.spark.sql.catalyst.expressions.{ComplexTypeMergingExpression, ExpectsInputTypes, Expression}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
@@ -169,7 +169,7 @@ object GpuAnsi {
 }
 
 case class GpuUnaryMinus(child: Expression, failOnError: Boolean) extends GpuUnaryExpression
-    with ExpectsInputTypes with NullIntolerant {
+    with ExpectsInputTypes with NullIntolerantShim {
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection.NumericAndInterval)
 
   override def dataType: DataType = child.dataType
@@ -231,7 +231,7 @@ case class GpuUnaryMinus(child: Expression, failOnError: Boolean) extends GpuUna
 }
 
 case class GpuUnaryPositive(child: Expression) extends GpuUnaryExpression
-    with ExpectsInputTypes with NullIntolerant {
+    with ExpectsInputTypes with NullIntolerantShim {
   override def prettyName: String = "positive"
 
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection.NumericAndInterval)
@@ -248,7 +248,7 @@ case class GpuUnaryPositive(child: Expression) extends GpuUnaryExpression
 }
 
 case class GpuAbs(child: Expression, failOnError: Boolean) extends CudfUnaryExpression
-    with ExpectsInputTypes with NullIntolerant {
+    with ExpectsInputTypes with NullIntolerantShim {
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection.NumericAndInterval)
 
   override def dataType: DataType = child.dataType

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -25,10 +25,10 @@ import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.ArrayIndexUtils.firstIndexAndNumElementUnchecked
 import com.nvidia.spark.rapids.BoolUtils.isAllValidTrue
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.shims.{GetSequenceSize, ShimExpression}
+import com.nvidia.spark.rapids.shims.{GetSequenceSize, NullIntolerantShim, ShimExpression}
 
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
-import org.apache.spark.sql.catalyst.expressions.{ElementAt, ExpectsInputTypes, Expression, ImplicitCastInputTypes, NamedExpression, NullIntolerant, RowOrdering, Sequence, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.expressions.{ElementAt, ExpectsInputTypes, Expression, ImplicitCastInputTypes, NamedExpression, RowOrdering, Sequence, TimeZoneAwareExpression}
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
@@ -1065,7 +1065,7 @@ case class GpuArraysZip(children: Seq[Expression]) extends GpuExpression with Sh
 }
 
 // Base class for GpuArrayExcept, GpuArrayUnion, GpuArrayIntersect
-trait GpuArrayBinaryLike extends GpuComplexTypeMergingExpression with NullIntolerant {
+trait GpuArrayBinaryLike extends GpuComplexTypeMergingExpression with NullIntolerantShim {
   val left: Expression
   val right: Expression
 
@@ -1233,7 +1233,7 @@ case class GpuArrayUnion(left: Expression, right: Expression)
 }
 
 case class GpuArraysOverlap(left: Expression, right: Expression)
-    extends GpuBinaryExpression with ExpectsInputTypes with NullIntolerant {
+    extends GpuBinaryExpression with ExpectsInputTypes with NullIntolerantShim {
 
   override def inputTypes: Seq[AbstractDataType] = Seq(ArrayType, ArrayType)
 
@@ -1552,7 +1552,7 @@ case class GpuArrayRemove(left: Expression, right: Expression) extends GpuBinary
   }
 }
 
-case class GpuFlattenArray(child: Expression) extends GpuUnaryExpression with NullIntolerant {
+case class GpuFlattenArray(child: Expression) extends GpuUnaryExpression with NullIntolerantShim {
   private def childDataType: ArrayType = child.dataType.asInstanceOf[ArrayType]
   override def nullable: Boolean = child.nullable || childDataType.containsNull
   override def dataType: DataType = childDataType.elementType

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -35,7 +35,7 @@ case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[Strin
     extends ShimUnaryExpression
     with GpuExpression
     with ShimGetStructField
-    with NullIntolerant {
+    with NullIntolerantShim {
 
   lazy val childSchema: StructType = child.dataType.asInstanceOf[StructType]
 
@@ -200,7 +200,7 @@ case class GpuGetArrayItem(child: Expression, ordinal: Expression, failOnError: 
 }
 
 case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boolean)
-  extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
 
   private def keyType = child.dataType.asInstanceOf[MapType].keyType
 
@@ -269,7 +269,7 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
 /** Checks if the array (left) has the element (right)
 */
 case class GpuArrayContains(left: Expression, right: Expression)
-  extends GpuBinaryExpression with NullIntolerant {
+  extends GpuBinaryExpression with NullIntolerantShim {
 
   override def dataType: DataType = BooleanType
 
@@ -367,7 +367,7 @@ case class GpuGetArrayStructFields(
     numFields: Int,
     containsNull: Boolean) extends GpuUnaryExpression
     with ShimGetArrayStructFields
-    with NullIntolerant {
+    with NullIntolerantShim {
 
   override def dataType: DataType = ArrayType(field.dataType, containsNull)
   override def toString: String = s"$child.${field.name}"

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -25,9 +25,9 @@ import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.GpuOverrides.{extractStringLit, getTimeParserPolicy}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
-import com.nvidia.spark.rapids.shims.ShimBinaryExpression
+import com.nvidia.spark.rapids.shims.{NullIntolerantShim, ShimBinaryExpression}
 
-import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, ExpectsInputTypes, Expression, FromUnixTime, FromUTCTimestamp, ImplicitCastInputTypes, NullIntolerant, TimeZoneAwareExpression, ToUTCTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, ExpectsInputTypes, Expression, FromUnixTime, FromUTCTimestamp, ImplicitCastInputTypes, TimeZoneAwareExpression, ToUTCTimestamp}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -43,7 +43,7 @@ trait GpuDateUnaryExpression extends GpuUnaryExpression with ImplicitCastInputTy
 }
 
 trait GpuTimeUnaryExpression extends GpuUnaryExpression with TimeZoneAwareExpression
-   with ImplicitCastInputTypes with NullIntolerant {
+   with ImplicitCastInputTypes with NullIntolerantShim {
   override def inputTypes: Seq[AbstractDataType] = Seq(TimestampType)
 
   override def dataType: DataType = IntegerType
@@ -1137,7 +1137,7 @@ case class GpuFromUTCTimestamp(
     timestamp: Expression, timezone: Expression, zoneId: ZoneId)
   extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
-      with NullIntolerant {
+      with NullIntolerantShim {
 
   override def left: Expression = timestamp
   override def right: Expression = timezone
@@ -1180,7 +1180,7 @@ case class GpuToUTCTimestamp(
     timestamp: Expression, timezone: Expression, zoneId: ZoneId)
   extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
-      with NullIntolerant {
+      with NullIntolerantShim {
 
   override def left: Expression = timestamp
   override def right: Expression = timezone

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import ai.rapids.cudf._
 import ai.rapids.cudf.ast.BinaryOperator
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.shims.NullIntolerantShim
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions._
@@ -29,7 +30,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 
 case class GpuNot(child: Expression) extends CudfUnaryExpression
-    with Predicate with ImplicitCastInputTypes with NullIntolerant {
+    with Predicate with ImplicitCastInputTypes with NullIntolerantShim {
   override def toString: String = s"NOT $child"
 
   override def inputTypes: Seq[DataType] = Seq(BooleanType)
@@ -204,7 +205,7 @@ abstract class CudfBinaryComparison extends CudfBinaryOperator with Predicate {
  *  +-------------+------------+------------------+---------------+----+
  */
 case class GpuEqualTo(left: Expression, right: Expression) extends CudfBinaryComparison
-    with NullIntolerant {
+    with NullIntolerantShim {
   override def symbol: String = "="
   override def outputTypeOverride: DType = DType.BOOL8
   override def binaryOp: BinaryOp = BinaryOp.EQUAL
@@ -235,7 +236,7 @@ case class GpuEqualTo(left: Expression, right: Expression) extends CudfBinaryCom
 }
 
 case class GpuEqualNullSafe(left: Expression, right: Expression) extends CudfBinaryComparison
-  with NullIntolerant {
+  with NullIntolerantShim {
   override def symbol: String = "<=>"
   override def nullable: Boolean = false
   override def outputTypeOverride: DType = DType.BOOL8
@@ -263,7 +264,7 @@ case class GpuEqualNullSafe(left: Expression, right: Expression) extends CudfBin
  * where NaN != NaN (unlike most other cases) when pivoting on a float or double column.
  */
 case class GpuEqualToNoNans(left: Expression, right: Expression) extends CudfBinaryComparison
-    with NullIntolerant {
+    with NullIntolerantShim {
   override def symbol: String = "="
   override def outputTypeOverride: DType = DType.BOOL8
   override def binaryOp: BinaryOp = BinaryOp.EQUAL
@@ -287,7 +288,7 @@ case class GpuEqualToNoNans(left: Expression, right: Expression) extends CudfBin
  *  +-------------+------------+-----------------+---------------+----+
  */
 case class GpuGreaterThan(left: Expression, right: Expression) extends CudfBinaryComparison
-    with NullIntolerant {
+    with NullIntolerantShim {
   override def symbol: String = ">"
 
   override def outputTypeOverride: DType = DType.BOOL8
@@ -328,7 +329,7 @@ case class GpuGreaterThan(left: Expression, right: Expression) extends CudfBinar
  *  +-------------+------------+-----------------+---------------+-----+
  */
 case class GpuGreaterThanOrEqual(left: Expression, right: Expression) extends CudfBinaryComparison
-    with NullIntolerant {
+    with NullIntolerantShim {
   override def symbol: String = ">="
 
   override def outputTypeOverride: DType = DType.BOOL8
@@ -397,7 +398,7 @@ case class GpuGreaterThanOrEqual(left: Expression, right: Expression) extends Cu
  *  +-------------+------------+-----------------+---------------+-----+
  */
 case class GpuLessThan(left: Expression, right: Expression) extends CudfBinaryComparison
-    with NullIntolerant {
+    with NullIntolerantShim {
   override def symbol: String = "<"
 
   override def outputTypeOverride: DType = DType.BOOL8
@@ -438,7 +439,7 @@ case class GpuLessThan(left: Expression, right: Expression) extends CudfBinaryCo
  *  +-------------+------------+------------------+---------------+-----+
  */
 case class GpuLessThanOrEqual(left: Expression, right: Expression) extends CudfBinaryComparison
-    with NullIntolerant {
+    with NullIntolerantShim {
   override def symbol: String = "<="
 
   override def outputTypeOverride: DType = DType.BOOL8

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -29,7 +29,7 @@ import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.jni.GpuSubstringIndexUtils
 import com.nvidia.spark.rapids.jni.RegexRewriteUtils
-import com.nvidia.spark.rapids.shims.{ShimExpression, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{NullIntolerantShim, ShimExpression, SparkShimImpl}
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
@@ -158,7 +158,7 @@ case class GpuStartsWith(left: Expression, right: Expression)
   extends GpuBinaryExpressionArgsAnyScalar
       with Predicate
       with ImplicitCastInputTypes
-      with NullIntolerant {
+      with NullIntolerantShim {
 
   override def inputTypes: Seq[DataType] = Seq(StringType)
 
@@ -184,7 +184,7 @@ case class GpuEndsWith(left: Expression, right: Expression)
   extends GpuBinaryExpressionArgsAnyScalar
       with Predicate
       with ImplicitCastInputTypes
-      with NullIntolerant {
+      with NullIntolerantShim {
 
   override def inputTypes: Seq[DataType] = Seq(StringType)
 
@@ -391,7 +391,7 @@ case class GpuContains(left: Expression, right: Expression)
     extends GpuBinaryExpressionArgsAnyScalar
         with Predicate
         with ImplicitCastInputTypes
-        with NullIntolerant {
+        with NullIntolerantShim {
 
   override def inputTypes: Seq[DataType] = Seq(StringType)
 
@@ -414,7 +414,7 @@ case class GpuContains(left: Expression, right: Expression)
 }
 
 case class GpuSubstring(str: Expression, pos: Expression, len: Expression)
-  extends GpuTernaryExpression with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuTernaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def dataType: DataType = str.dataType
 
@@ -647,7 +647,7 @@ case class GpuInitCap(child: Expression) extends GpuUnaryExpression with Implici
 }
 
 case class GpuStringRepeat(input: Expression, repeatTimes: Expression)
-    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerant {
+    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
   override def left: Expression = input
   override def right: Expression = repeatTimes
   override def dataType: DataType = input.dataType
@@ -865,7 +865,7 @@ object CudfRegexp {
 case class GpuLike(left: Expression, right: Expression, escapeChar: Char)
   extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
-      with NullIntolerant  {
+      with NullIntolerantShim {
 
   def this(left: Expression, right: Expression) = this(left, right, '\\')
 
@@ -1109,7 +1109,7 @@ class GpuRLikeMeta(
 case class GpuRLike(left: Expression, right: Expression, pattern: String)
   extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
-      with NullIntolerant  {
+      with NullIntolerantShim {
 
   override def toString: String = s"$left gpurlike $right"
 
@@ -1130,7 +1130,7 @@ case class GpuRLike(left: Expression, right: Expression, pattern: String)
 }
 
 case class GpuMultipleContains(input: Expression, searchList: Seq[String])
-  extends GpuUnaryExpression with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuUnaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def dataType: DataType = BooleanType
 
@@ -1158,7 +1158,7 @@ case class GpuMultipleContains(input: Expression, searchList: Seq[String])
 
 case class GpuLiteralRangePattern(left: Expression, right: Expression, 
     length: Int, start: Int, end: Int)
-  extends GpuBinaryExpressionArgsAnyScalar with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuBinaryExpressionArgsAnyScalar with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def dataType: DataType = BooleanType
 
@@ -1371,7 +1371,7 @@ case class GpuRegExpExtract(
     subject: Expression,
     regexp: Expression,
     idx: Expression)(cudfRegexPattern: String)
-  extends GpuRegExpTernaryBase with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuRegExpTernaryBase with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def otherCopyArgs: Seq[AnyRef] = cudfRegexPattern :: Nil
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType, IntegerType)
@@ -1500,7 +1500,7 @@ case class GpuRegExpExtractAll(
     str: Expression,
     regexp: Expression,
     idx: Expression)(cudfRegexPattern: String)
-  extends GpuRegExpTernaryBase with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuRegExpTernaryBase with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def otherCopyArgs: Seq[AnyRef] = cudfRegexPattern :: Nil
   override def dataType: DataType = ArrayType(StringType, containsNull = true)
@@ -1633,7 +1633,7 @@ case class GpuSubstringIndex(strExpr: Expression,
 trait BasePad
     extends GpuTernaryExpressionArgsAnyScalarScalar
         with ImplicitCastInputTypes
-        with NullIntolerant {
+        with NullIntolerantShim {
   val str: Expression
   val len: Expression
   val pad: Expression
@@ -2002,7 +2002,7 @@ object GpuStringInstr {
 case class GpuStringInstr(str: Expression, substr: Expression)
   extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
-      with NullIntolerant  {
+      with NullIntolerantShim {
   // Locate the position of the first occurrence of substr column in the given string.
   // returns null if one of the arguments is null
   // returns zero if not found
@@ -2132,7 +2132,7 @@ case class GpuConv(num: Expression, fromBase: Expression, toBase: Expression)
 }
 
 case class GpuFormatNumber(x: Expression, d: Expression)
-    extends GpuBinaryExpression with ExpectsInputTypes with NullIntolerant {
+    extends GpuBinaryExpression with ExpectsInputTypes with NullIntolerantShim {
   
   override def left: Expression = x
   override def right: Expression = d

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/NullIntolerantShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/NullIntolerantShim.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.expressions.NullIntolerant
+
+trait NullIntolerantShim extends NullIntolerant

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -32,13 +32,13 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids
 
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.shims.ShimExpression
+import com.nvidia.spark.rapids.shims.{NullIntolerantShim, ShimExpression}
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, NullIntolerant}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolerant {
+abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolerantShim {
 
   protected val failOnError: Boolean
 

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/GpuAscii.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/GpuAscii.scala
@@ -27,12 +27,13 @@ package org.apache.spark.sql.rapids.shims
 import ai.rapids.cudf.{ColumnVector, DType, Scalar}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm._
+import com.nvidia.spark.rapids.shims.NullIntolerantShim
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
 
 case class GpuAscii(child: Expression) extends GpuUnaryExpression with ImplicitCastInputTypes 
-    with NullIntolerant {
+    with NullIntolerantShim {
 
   override def dataType: DataType = IntegerType
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType)

--- a/sql-plugin/src/main/spark323/scala/org/apache/spark/sql/rapids/shims/GpuAscii.scala
+++ b/sql-plugin/src/main/spark323/scala/org/apache/spark/sql/rapids/shims/GpuAscii.scala
@@ -42,12 +42,13 @@ package org.apache.spark.sql.rapids.shims
 import ai.rapids.cudf.{ColumnVector, DType, Scalar}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm._
+import com.nvidia.spark.rapids.shims.NullIntolerantShim
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
 
 case class GpuAscii(child: Expression) extends GpuUnaryExpression with ImplicitCastInputTypes 
-    with NullIntolerant {
+    with NullIntolerantShim {
 
   override def dataType: DataType = IntegerType
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType)

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
@@ -44,8 +44,9 @@ import java.math.BigInteger
 import ai.rapids.cudf.{BinaryOperable, ColumnVector, ColumnView, DType, RoundMode, Scalar}
 import com.nvidia.spark.rapids.{BoolUtils, GpuBinaryExpression, GpuColumnVector, GpuScalar}
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.shims.NullIntolerantShim
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, NullIntolerant}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.rapids.GpuDivModLike.makeZeroScalar
 import org.apache.spark.sql.types._
 
@@ -336,7 +337,8 @@ object IntervalUtils {
  */
 case class GpuMultiplyYMInterval(
     interval: Expression,
-    num: Expression) extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerant {
+    num: Expression)
+    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def left: Expression = interval
 
@@ -410,7 +412,7 @@ case class GpuMultiplyYMInterval(
 case class GpuMultiplyDTInterval(
     interval: Expression,
     num: Expression)
-    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerant {
+    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def left: Expression = interval
 
@@ -473,7 +475,8 @@ case class GpuMultiplyDTInterval(
  */
 case class GpuDivideYMInterval(
     interval: Expression,
-    num: Expression) extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerant {
+    num: Expression)
+    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def left: Expression = interval
 
@@ -540,7 +543,7 @@ case class GpuDivideYMInterval(
 case class GpuDivideDTInterval(
     interval: Expression,
     num: Expression)
-    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerant {
+    extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
 
   override def left: Expression = interval
 

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -38,16 +38,17 @@ import ai.rapids.cudf._
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.shims.NullIntolerantShim
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.{Expression, NullIntolerant}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolerant {
+abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolerantShim {
 
   protected val failOnError: Boolean
 

--- a/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/NullIntolerantShim.scala
+++ b/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/NullIntolerantShim.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "400"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+trait NullIntolerantShim extends Expression {
+  override def nullIntolerant: Boolean = true
+}


### PR DESCRIPTION
Fixes #11722.  Adds NullIntolerantShim which is a trivial extension of NullIntolerant on anything except Spark 4.  For Spark 4, the shim overrides the new nullIntolerant Expression method instead.