### PR TITLE
Print out the current attempt object when OOM inside a retry block

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
@@ -62,9 +62,7 @@ object PartitionRowData {
 case class BatchWithPartitionData(
     inputBatch: SpillableColumnarBatch,
     partitionedRowsData: Array[PartitionRowData],
-    partitionSchema: StructType) extends AutoCloseable with RetrySizeAwareable {
-
-  override def sizeInBytes: Long = inputBatch.sizeInBytes
+    partitionSchema: StructType) extends AutoCloseable {
 
   /**
    * Merges the partitioned data with the input ColumnarBatch.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
@@ -62,7 +62,9 @@ object PartitionRowData {
 case class BatchWithPartitionData(
     inputBatch: SpillableColumnarBatch,
     partitionedRowsData: Array[PartitionRowData],
-    partitionSchema: StructType) extends AutoCloseable {
+    partitionSchema: StructType) extends AutoCloseable with RetrySizeAwareable {
+
+  override def sizeInBytes: Long = inputBatch.sizeInBytes
 
   /**
    * Merges the partitioned data with the input ColumnarBatch.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -688,12 +688,15 @@ abstract class AbstractGpuCoalesceIterator(
  * @param batches a sequence of `SpillableColumnarBatch` to manage.
  */
 case class BatchesToCoalesce(batches: Array[SpillableColumnarBatch])
-    extends AutoCloseable with RetrySizeAwareable {
+    extends AutoCloseable {
   override def close(): Unit = {
     batches.safeClose()
   }
 
-  override def sizeInBytes: Long = batches.map(_.sizeInBytes).sum
+  override def toString: String = {
+    val totalSize = batches.map(_.sizeInBytes).sum
+    s"BatchesToCoalesce totalSize:$totalSize, batches:[${batches.mkString(";")}]"
+  }
 }
 
 class GpuCoalesceIterator(iter: Iterator[ColumnarBatch],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -688,10 +688,12 @@ abstract class AbstractGpuCoalesceIterator(
  * @param batches a sequence of `SpillableColumnarBatch` to manage.
  */
 case class BatchesToCoalesce(batches: Array[SpillableColumnarBatch])
-    extends AutoCloseable {
+    extends AutoCloseable with RetrySizeAwareable {
   override def close(): Unit = {
     batches.safeClose()
   }
+
+  override def sizeInBytes: Long = batches.map(_.sizeInBytes).sum
 }
 
 class GpuCoalesceIterator(iter: Iterator[ColumnarBatch],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -949,10 +949,12 @@ case class GpuGenerateExec(
 }
 
 class BatchToGenerate(val fixUpOffset: Long, val spillable: SpillableColumnarBatch)
-  extends AutoCloseable {
+  extends AutoCloseable with RetrySizeAwareable {
   override def close(): Unit = {
     spillable.close()
   }
+
+  override def sizeInBytes: Long = spillable.sizeInBytes
 }
 
 class GpuGenerateIterator(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -949,12 +949,13 @@ case class GpuGenerateExec(
 }
 
 class BatchToGenerate(val fixUpOffset: Long, val spillable: SpillableColumnarBatch)
-  extends AutoCloseable with RetrySizeAwareable {
+  extends AutoCloseable {
   override def close(): Unit = {
     spillable.close()
   }
 
-  override def sizeInBytes: Long = spillable.sizeInBytes
+  override def toString: String =
+    s"BatchToGenerate fixUpOffset:$fixUpOffset, spillable:$spillable"
 }
 
 class GpuGenerateIterator(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -774,7 +774,11 @@ object RmmRapidsRetryIterator extends Logging {
  * `CpuSplitAndRetryOOM`, a split policy like `splitTargetSizeInHalfGpu` or
  * `splitTargetSizeInHalfCpu` can be used to retry the block with a smaller target size.
  */
-case class AutoCloseableTargetSize(targetSize: Long, minSize: Long) extends AutoCloseable {
+case class AutoCloseableTargetSize(targetSize: Long, minSize: Long) extends AutoCloseable
+  with RetrySizeAwareable {
+
+  override def sizeInBytes: Long = targetSize
+
   override def close(): Unit = ()
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -464,6 +464,7 @@ object RmmRapidsRetryIterator extends Logging {
       if (splitPolicy == null) {
         val message = s"could not split inputs and retry. The current attempt: " +
           s"{${attemptStack.head}}"
+        logWarning(message)
         if (isFromGpuOom) {
           throw new GpuSplitAndRetryOOM(s"GPU OutOfMemory: $message")
         } else {
@@ -482,22 +483,25 @@ object RmmRapidsRetryIterator extends Logging {
           // This looks a little odd, because we can not change the type of root exception.
           // Otherwise, some unit tests will fail due to the wrong exception type returned.
         case go: GpuRetryOOM =>
+          logWarning(s"1Could not split the current attempt: {$attemptAsString}")
           throw new GpuRetryOOM(
             s"GPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(go)
         case go: GpuSplitAndRetryOOM =>
+          logWarning(s"2Could not split the current attempt: {$attemptAsString}")
           throw new GpuSplitAndRetryOOM(
             s"GPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(go)
         case co: CpuRetryOOM =>
+          logWarning(s"3Could not split the current attempt: {$attemptAsString}")
           throw new CpuRetryOOM(
             s"CPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(co)
         case co: CpuSplitAndRetryOOM =>
+          logWarning(s"4Could not split the current attempt: {$attemptAsString}")
           throw new CpuSplitAndRetryOOM(
             s"CPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(co)
-        case ex: Throwable => throw ex
       }
       // the splitted sequence needs to be inserted in reverse order
       // so we try the first item first.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -464,7 +464,6 @@ object RmmRapidsRetryIterator extends Logging {
       if (splitPolicy == null) {
         val message = s"could not split inputs and retry. The current attempt: " +
           s"{${attemptStack.head}}"
-        logWarning(message)
         if (isFromGpuOom) {
           throw new GpuSplitAndRetryOOM(s"GPU OutOfMemory: $message")
         } else {
@@ -483,22 +482,18 @@ object RmmRapidsRetryIterator extends Logging {
           // This looks a little odd, because we can not change the type of root exception.
           // Otherwise, some unit tests will fail due to the wrong exception type returned.
         case go: GpuRetryOOM =>
-          logWarning(s"1Could not split the current attempt: {$attemptAsString}")
           throw new GpuRetryOOM(
             s"GPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(go)
         case go: GpuSplitAndRetryOOM =>
-          logWarning(s"2Could not split the current attempt: {$attemptAsString}")
           throw new GpuSplitAndRetryOOM(
             s"GPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(go)
         case co: CpuRetryOOM =>
-          logWarning(s"3Could not split the current attempt: {$attemptAsString}")
           throw new CpuRetryOOM(
             s"CPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(co)
         case co: CpuSplitAndRetryOOM =>
-          logWarning(s"4Could not split the current attempt: {$attemptAsString}")
           throw new CpuSplitAndRetryOOM(
             s"CPU OutOfMemory: Could not split the current attempt: {$attemptAsString}"
           ).initCause(co)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -301,7 +301,7 @@ object RmmRapidsRetryIterator extends Logging {
    * @tparam T the type of the items in `ts`
    */
   private case class AutoCloseableSeqInternal[T <: AutoCloseable](ts: Seq[T])
-      extends Seq[T] with AutoCloseable {
+      extends Seq[T] with AutoCloseable with RetrySizeAwareable {
     override def close(): Unit = {
       ts.foreach(_.safeClose())
     }
@@ -311,6 +311,11 @@ object RmmRapidsRetryIterator extends Logging {
     override def iterator: Iterator[T] = ts.iterator
 
     override def apply(idx: Int): T = ts.apply(idx)
+
+    override def sizeInBytes: Long = ts.map {
+      case sizeAware: RetrySizeAwareable => sizeAware.sizeInBytes
+      case _ => 0L
+    }.sum
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -428,11 +428,7 @@ class SpillableHostBuffer(
     }
   }
 
-  override def sizeInBytes: Long = {
-    withResource(catalog.acquireBuffer(handle)) { rapidsBuffer =>
-      rapidsBuffer.memoryUsedBytes
-    }
-  }
+  override def sizeInBytes: Long = length
 }
 
 object SpillableBuffer {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 /**
  * Holds a ColumnarBatch that the backing buffers on it can be spilled.
  */
-trait SpillableColumnarBatch extends AutoCloseable {
+trait SpillableColumnarBatch extends AutoCloseable with RetrySizeAwareable {
   /**
    * The number of rows stored in this batch.
    */
@@ -51,8 +51,6 @@ trait SpillableColumnarBatch extends AutoCloseable {
    *       with decompressing the data if necessary.
    */
   def getColumnarBatch(): ColumnarBatch
-
-  def sizeInBytes: Long
 
   def dataTypes: Array[DataType]
 }


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/11732

This PR adds the support to print out the current attempt object being processed when OOM happens in the retry block.
This is designed for the better OOM issues triage.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
