### PR TITLE
Do not package the Databricks 14.3 shim into the dist jar [skip ci]

### DIFF
--- a/build/get_buildvers.py
+++ b/build/get_buildvers.py
@@ -34,7 +34,7 @@ def _get_buildvers(buildvers, pom_file, logger=None):
         else:
             no_snapshots.append(release)
     excluded_shims = pom.find(".//pom:dyn.shim.excluded.releases", ns)
-    if excluded_shims:
+    if excluded_shims is not None:
         for removed_shim in [x.strip() for x in excluded_shims.text.split(",")]:
             if removed_shim in snapshots:
                 snapshots.remove(removed_shim)

--- a/pom.xml
+++ b/pom.xml
@@ -813,7 +813,7 @@
 
     <properties>
         <!-- start dyn.shim properties -->
-        <!-- TODO: will package 350db143 shim into the dist jar in branch-25.02 -->
+        <!-- TODO: will package 350db143 shim into the dist jar in branch-25.02, followed by https://github.com/NVIDIA/spark-rapids/issues/11749 -->
 	<dyn.shim.excluded.releases>350db143</dyn.shim.excluded.releases>
         <!-- end dyn.shim properties -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -813,7 +813,8 @@
 
     <properties>
         <!-- start dyn.shim properties -->
-	<dyn.shim.excluded.releases/>
+        <!-- TODO: will package 350db143 shim into the dist jar in branch-25.02 -->
+	<dyn.shim.excluded.releases>350db143</dyn.shim.excluded.releases>
         <!-- end dyn.shim properties -->
 
         <rapids.module>.</rapids.module>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -813,7 +813,7 @@
 
     <properties>
         <!-- start dyn.shim properties -->
-        <!-- TODO: will package 350db143 shim into the dist jar in branch-25.02 -->
+        <!-- TODO: will package 350db143 shim into the dist jar in branch-25.02, followed by https://github.com/NVIDIA/spark-rapids/issues/11749 -->
 	<dyn.shim.excluded.releases>350db143</dyn.shim.excluded.releases>
         <!-- end dyn.shim properties -->
 

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -813,7 +813,8 @@
 
     <properties>
         <!-- start dyn.shim properties -->
-	<dyn.shim.excluded.releases/>
+        <!-- TODO: will package 350db143 shim into the dist jar in branch-25.02 -->
+	<dyn.shim.excluded.releases>350db143</dyn.shim.excluded.releases>
         <!-- end dyn.shim properties -->
 
         <rapids.module>.</rapids.module>


### PR DESCRIPTION
The 350db143 shim will be packaged into the dist jar in branch-25.02
