### PR TITLE
Update rapids JNI and private dependency to 25.02.0-SNAPSHOT

### DIFF
--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -20,8 +20,7 @@
 
 set -ex
 
-# TODO: https://github.com/NVIDIA/spark-rapids/issues/11755
-CUDF_VER=${CUDF_VER:-24.12}
+CUDF_VER=${CUDF_VER:-25.02}
 CUDA_VER=${CUDA_VER:-11.8}
 
 # Need to explicitly add conda into PATH environment, to activate conda environment.

--- a/pom.xml
+++ b/pom.xml
@@ -828,9 +828,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <!-- TODO: https://github.com/NVIDIA/spark-rapids/issues/11755 -->
-        <spark-rapids-jni.version>24.12.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.12.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>25.02.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>25.02.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -828,9 +828,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <!-- TODO: https://github.com/NVIDIA/spark-rapids/issues/11755 -->
-        <spark-rapids-jni.version>24.12.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.12.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>25.02.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>25.02.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.13</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/spark-rapids/issues/11755
Wait for the pre-merge CI job to SUCCEED