### PR TITLE
Fix the task count check in TrafficController

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutor.scala
@@ -20,6 +20,8 @@ import java.util.concurrent.{Callable, ExecutorService, Future, TimeUnit}
 
 /**
  * Thin wrapper around an ExecutorService that adds throttling.
+ *
+ * The given executor is owned by this class and will be shutdown when this class is shutdown.
  */
 class ThrottlingExecutor(
     val executor: ExecutorService, throttler: TrafficController) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
@@ -102,7 +102,7 @@ class TrafficController protected[rapids] (@GuardedBy("lock") throttle: Throttle
     lock.lockInterruptibly()
     try {
       while (numTasks > 0 && !throttle.canAccept(task)) {
-        condition.await()
+        canBeScheduled.await()
       }
       numTasks += 1
       throttle.taskScheduled(task)
@@ -116,7 +116,7 @@ class TrafficController protected[rapids] (@GuardedBy("lock") throttle: Throttle
     try {
       numTasks -= 1
       throttle.taskCompleted(task)
-      condition.signal()
+      canBeScheduled.signal()
     } finally {
       lock.unlock()
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
@@ -101,10 +101,8 @@ class TrafficController protected[rapids] (@GuardedBy("lock") throttle: Throttle
   def blockUntilRunnable[T](task: Task[T]): Unit = {
     lock.lockInterruptibly()
     try {
-      if (numTasks > 0) {
-        while (!throttle.canAccept(task) && numTasks > 0) {
-          condition.await()
-        }
+      while (numTasks > 0 && !throttle.canAccept(task)) {
+        condition.await()
       }
       numTasks += 1
       throttle.taskScheduled(task)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids.io.async
 
 import java.util.concurrent.Callable
+import java.util.concurrent.locks.ReentrantLock
 import javax.annotation.concurrent.GuardedBy
 
 import com.nvidia.spark.rapids.RapidsConf
@@ -85,38 +86,57 @@ class HostMemoryThrottle(val maxInFlightHostMemoryBytes: Long) extends Throttle 
  *
  * This class is thread-safe as it is used by multiple tasks.
  */
-class TrafficController protected[rapids] (throttle: Throttle) {
+class TrafficController protected[rapids] (@GuardedBy("lock") throttle: Throttle) {
 
-  @GuardedBy("this")
+  @GuardedBy("lock")
   private var numTasks: Int = 0
+
+  private val lock = new ReentrantLock()
+  private val condition = lock.newCondition()
 
   /**
    * Blocks the task from being scheduled until the throttle allows it. If there is no task
    * currently scheduled, the task is scheduled immediately even if the throttle is exceeded.
    */
-  def blockUntilRunnable[T](task: Task[T]): Unit = synchronized {
-    if (numTasks > 0) {
-      while (!throttle.canAccept(task)) {
-        wait(100)
+  def blockUntilRunnable[T](task: Task[T]): Unit = {
+    lock.lockInterruptibly()
+    try {
+      if (numTasks > 0) {
+        while (!throttle.canAccept(task) && numTasks > 0) {
+          condition.await()
+        }
       }
+      numTasks += 1
+      throttle.taskScheduled(task)
+    } finally {
+      lock.unlock()
     }
-    numTasks += 1
-    throttle.taskScheduled(task)
   }
 
-  def taskCompleted[T](task: Task[T]): Unit = synchronized {
-    numTasks -= 1
-    throttle.taskCompleted(task)
-    notify()
+  def taskCompleted[T](task: Task[T]): Unit = {
+    lock.lockInterruptibly()
+    try {
+      numTasks -= 1
+      throttle.taskCompleted(task)
+      condition.signal()
+    } finally {
+      lock.unlock()
+    }
   }
 
-  def numScheduledTasks: Int = synchronized {
-    numTasks
+  def numScheduledTasks: Int = {
+    lock.lockInterruptibly()
+    try {
+      numTasks
+    } finally {
+      lock.unlock()
+    }
   }
 }
 
 object TrafficController {
 
+  @GuardedBy("this")
   private var instance: TrafficController = _
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
@@ -92,7 +92,7 @@ class TrafficController protected[rapids] (@GuardedBy("lock") throttle: Throttle
   private var numTasks: Int = 0
 
   private val lock = new ReentrantLock()
-  private val condition = lock.newCondition()
+  private val canBeScheduled = lock.newCondition()
 
   /**
    * Blocks the task from being scheduled until the throttle allows it. If there is no task

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
@@ -73,17 +73,17 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
     assertResult(0)(throttle.getTotalHostMemoryBytes)
   }
 
-  test("tasks submission fails if total weight exceeds maxWeight") {
+  test("tasks submission fails if totalHostMemoryBytes exceeds maxHostMemoryBytes") {
     val task1 = new TestTask
     val future1 = executor.submit(task1, 10)
     assertResult(1)(trafficController.numScheduledTasks)
     assertResult(10)(throttle.getTotalHostMemoryBytes)
 
     val task2 = new TestTask
-    val task2Weight = 100
+    val task2HostMemory = 100
     val exec = Executors.newSingleThreadExecutor()
     val future2 = exec.submit(new Runnable {
-      override def run(): Unit = executor.submit(task2, task2Weight)
+      override def run(): Unit = executor.submit(task2, task2HostMemory)
     })
     Thread.sleep(100)
     assert(!future2.isDone)
@@ -94,10 +94,10 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
     future1.get(longTimeoutSec, TimeUnit.SECONDS)
     future2.get(longTimeoutSec, TimeUnit.SECONDS)
     assertResult(1)(trafficController.numScheduledTasks)
-    assertResult(task2Weight)(throttle.getTotalHostMemoryBytes)
+    assertResult(task2HostMemory)(throttle.getTotalHostMemoryBytes)
   }
 
-  test("submit one task heavier than maxWeight") {
+  test("submit one task heavier than maxHostMemoryBytes") {
     val future = executor.submit(() => Thread.sleep(10), throttle.maxInFlightHostMemoryBytes + 1)
     future.get(longTimeoutSec, TimeUnit.SECONDS)
     assert(future.isDone)
@@ -105,7 +105,7 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
     assertResult(0)(throttle.getTotalHostMemoryBytes)
   }
 
-  test("submit multiple tasks such that total weight does not exceed maxWeight") {
+  test("submit multiple tasks such that totalHostMemoryBytes does not exceed maxHostMemoryBytes") {
     val numTasks = 10
     val taskRunTime = 10
     var future: Future[Unit] = null
@@ -125,10 +125,10 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
     assertResult(10)(throttle.getTotalHostMemoryBytes)
 
     val task2 = new TestTask
-    val task2Weight = 100
+    val task2HostMemory = 100
     val exec = Executors.newSingleThreadExecutor()
     val future2 = exec.submit(new Runnable {
-      override def run(): Unit = executor.submit(task2, task2Weight)
+      override def run(): Unit = executor.submit(task2, task2HostMemory)
     })
     executor.shutdownNow(longTimeoutSec, TimeUnit.SECONDS)
 


### PR DESCRIPTION
A follow-up to https://github.com/NVIDIA/spark-rapids/pull/11730. If that is the only task at the moment, the `TrafficController` should allow the task to process regardless of how much host memory it uses. However, this check was missing in the loop below, which would have all subsequent tasks hung if a task that uses a large memory is submitted while there are some tasks running.

```scala
        while (!throttle.canAccept(task)) { // <= task count check is missing
          condition.await()
        }
```

This PR fixes this bug. Additionally, it improves the `TrafficController` to use the condition variable instead of polling as suggested in https://github.com/NVIDIA/spark-rapids/pull/11730#discussion_r1854492036. Finally, the terminology in `ThrottlingExecutorSuite` has been fixed as suggested in https://github.com/NVIDIA/spark-rapids/pull/11730#discussion_r1857408629.