### PR TITLE
Fix bug: populate cache deps [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check/populate-daily-cache.sh
+++ b/.github/workflows/mvn-verify-check/populate-daily-cache.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex -o pipefail
+set -ex
 
 max_retry=3; delay=30; i=1
 if [[ $SCALA_VER == '2.12' ]]; then

--- a/.github/workflows/mvn-verify-check/populate-daily-cache.sh
+++ b/.github/workflows/mvn-verify-check/populate-daily-cache.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
+set -x -o pipefail
+
 max_retry=3; delay=30; i=1
 if [[ $SCALA_VER == '2.12' ]]; then
     pom='pom.xml'

--- a/.github/workflows/mvn-verify-check/populate-daily-cache.sh
+++ b/.github/workflows/mvn-verify-check/populate-daily-cache.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x -o pipefail
+set -ex -o pipefail
 
 max_retry=3; delay=30; i=1
 if [[ $SCALA_VER == '2.12' ]]; then

--- a/.github/workflows/mvn-verify-check/populate-daily-cache.sh
+++ b/.github/workflows/mvn-verify-check/populate-daily-cache.sh
@@ -23,7 +23,7 @@ elif [[ $SCALA_VER == '2.13' ]]; then
 fi
 while true; do
     {
-        python build/get_buildvers.py "no_snapshots.buildvers" $pom | tr -d ',' | \
+        python build/get_buildvers.py "no_snapshots" $pom | tr -d ',' | \
             xargs -n 1 -I {} bash -c \
                 "mvn $COMMON_MVN_FLAGS --file $pom -Dbuildver={} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies"
 

--- a/.github/workflows/mvn-verify-check/populate-daily-cache.sh
+++ b/.github/workflows/mvn-verify-check/populate-daily-cache.sh
@@ -24,7 +24,7 @@ elif [[ $SCALA_VER == '2.13' ]]; then
 fi
 while true; do
     {
-        python build/get_buildvers.py "no_snapshots" $pom | tr -d ',' | \
+        python build/get_buildvers.py "buildvers.no_snapshots" $pom | tr -d ',' | \
             xargs -n 1 -I {} bash -c \
                 "mvn $COMMON_MVN_FLAGS --file $pom -Dbuildver={} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies"
 


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

fix https://github.com/NVIDIA/spark-rapids/issues/11796

Corrected the argument of `build/get_buildvers.py` to fix bug of getting build versions.