### PR TITLE
Add integration test for parquet async writer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
@@ -73,13 +73,14 @@ abstract class ColumnarOutputWriter(context: TaskAttemptContext,
     dataSchema: StructType,
     rangeName: String,
     includeRetry: Boolean,
-    holdGpuBetweenBatches: Boolean = false) extends HostBufferConsumer with Logging {
+    holdGpuBetweenBatches: Boolean = false,
+    useAsyncWrite: Boolean = false) extends HostBufferConsumer with Logging {
 
   protected val tableWriter: TableWriter
 
   protected val conf: Configuration = context.getConfiguration
 
-  private val trafficController: Option[TrafficController] = TrafficController.getInstance
+  private val trafficController: TrafficController = TrafficController.getInstance
 
   private def openOutputStream(): OutputStream = {
     val hadoopPath = new Path(path)
@@ -90,10 +91,12 @@ abstract class ColumnarOutputWriter(context: TaskAttemptContext,
   // This is implemented as a method to make it easier to subclass
   // ColumnarOutputWriter in the tests, and override this behavior.
   protected def getOutputStream: OutputStream = {
-    trafficController.map(controller => {
+    if (useAsyncWrite) {
       logWarning("Async output write enabled")
-      new AsyncOutputStream(() => openOutputStream(), controller)
-    }).getOrElse(openOutputStream())
+      new AsyncOutputStream(() => openOutputStream(), trafficController)
+    } else {
+      openOutputStream()
+    }
   }
 
   protected val outputStream: OutputStream = getOutputStream

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -283,7 +283,7 @@ class GpuParquetFileFormat extends ColumnarFileFormat with Logging {
           context: TaskAttemptContext): ColumnarOutputWriter = {
         new GpuParquetWriter(path, dataSchema, compressionType, outputTimestampType.toString,
           dateTimeRebaseMode, timestampRebaseMode, context, parquetFieldIdWriteEnabled,
-          holdGpuBetweenBatches)
+          holdGpuBetweenBatches, asyncOutputWriteEnabled)
       }
 
       override def getFileExtension(context: TaskAttemptContext): String = {
@@ -306,8 +306,10 @@ class GpuParquetWriter(
     timestampRebaseMode: DateTimeRebaseMode,
     context: TaskAttemptContext,
     parquetFieldIdEnabled: Boolean,
-    holdGpuBetweenBatches: Boolean)
-  extends ColumnarOutputWriter(context, dataSchema, "Parquet", true, holdGpuBetweenBatches) {
+    holdGpuBetweenBatches: Boolean,
+    useAsyncWrite: Boolean)
+  extends ColumnarOutputWriter(context, dataSchema, "Parquet", true, holdGpuBetweenBatches,
+    useAsyncWrite) {
   override def throwIfRebaseNeededInExceptionMode(batch: ColumnarBatch): Unit = {
     val cols = GpuColumnVector.extractBases(batch)
     cols.foreach { col =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/TrafficController.scala
@@ -142,14 +142,14 @@ object TrafficController {
    * This is called once per executor.
    */
   def initialize(conf: RapidsConf): Unit = synchronized {
-    if (conf.isAsyncOutputWriteEnabled && instance == null) {
+    if (instance == null) {
       instance = new TrafficController(
         new HostMemoryThrottle(conf.asyncWriteMaxInFlightHostMemoryBytes))
     }
   }
 
-  def getInstance: Option[TrafficController] = synchronized {
-    Option(instance)
+  def getInstance: TrafficController = synchronized {
+    instance
   }
 
   def shutdown(): Unit = synchronized {


### PR DESCRIPTION
A follow-up to https://github.com/NVIDIA/spark-rapids/pull/11730. This PR adds an integration test for the async writer for Parquet. In addition, it fixes a bug that the `spark.rapids.sql.asyncWrite.queryOutput.enabled` config was effective per `SparkContext`. It did not allow turning the async write on/off per query within the same `SparkContext`. It should instead be per-query basis, so that each query can be optimized individually.