### PR TITLE
Increase the pre-merge CI timeout to 6 hours

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -190,7 +190,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     steps {
                         script {
                             container('gpu') {
-                                timeout(time: 4, unit: 'HOURS') { // step only timeout for test run
+                                timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
                                     try {
                                         sh "$PREMERGE_SCRIPT mvn_verify"
                                         step([$class                : 'JacocoPublisher',
@@ -228,7 +228,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         script {
                             unstash "source_tree"
                             container('gpu') {
-                                timeout(time: 4, unit: 'HOURS') {
+                                timeout(time: 6, unit: 'HOURS') {
                                     try {
                                         sh "$PREMERGE_SCRIPT ci_2"
                                     } finally {
@@ -260,7 +260,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         script {
                             unstash "source_tree"
                             container('gpu') {
-                                timeout(time: 4, unit: 'HOURS') {
+                                timeout(time: 6, unit: 'HOURS') {
                                     try {
                                         sh "$PREMERGE_SCRIPT ci_scala213"
                                     } finally {


### PR DESCRIPTION
I've seen several cases of PRs timing out after 4 hours though we've done a re-balance for 25.02 recently https://github.com/NVIDIA/spark-rapids/pull/11826

![image](https://github.com/user-attachments/assets/b10f4e52-c24a-423a-a670-c0e4839f4b54)

We'll make additional efforts to balance the pre-merge CI's duration.

Let's increase the timeout to 6 hours first.

We'll continue to work on balancing the pre-merge CI's duration



