### PR TITLE
Workaround: Exclude cudf_log.txt in RAT check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ scalastyle-output.xml
 scalastyle.txt
 target/
 cufile.log
+cudf_log.txt
 build/*.class

--- a/pom.xml
+++ b/pom.xml
@@ -1645,6 +1645,7 @@ This will force full Scala code rebuild in downstream modules.
                         default, but there are some projects that are conditionally included.  -->
                         <exclude>**/target/**/*</exclude>
                         <exclude>**/cufile.log</exclude>
+                        <exclude>**/cudf_log.txt</exclude>
                         <exclude>thirdparty/parquet-testing/**</exclude>
                     </excludes>
                 </configuration>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1645,6 +1645,7 @@ This will force full Scala code rebuild in downstream modules.
                         default, but there are some projects that are conditionally included.  -->
                         <exclude>**/target/**/*</exclude>
                         <exclude>**/cufile.log</exclude>
+                        <exclude>**/cudf_log.txt</exclude>
                         <exclude>thirdparty/parquet-testing/**</exclude>
                     </excludes>
                 </configuration>


### PR DESCRIPTION
```
Printing headers for text files without a valid license header...
=====================================================
== File: /home/jenkins/agent/workspace/jenkins-rapids_premerge-github-10377/sql-plugin/cudf_log.txt
```

Currently the output of cudf logger is failing blossom-ci, 
try exclude it from the repo to unblock CI for now before we have an actual fix in JNI side