### PR TITLE
Remove 350db143 shim's build [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -91,7 +91,7 @@ pipeline {
                         // 'name' and 'value' only supprt literal string in the declarative Jenkins
                         // Refer to Jenkins issue https://issues.jenkins.io/browse/JENKINS-62127
                         name 'DB_RUNTIME'
-                        values '11.3', '12.2', '13.3', '14.3'
+                        values '11.3', '12.2', '13.3'
                     }
                 }
                 stages {


### PR DESCRIPTION
Skip the build of the 350db143 shim, as v24.12.0 will not contain the 350db143 shim

Moreover, the v24.12.0 private dependency jar is not released.

To fix below error:

    [ERROR] Failed to execute goal on project rapids-4-spark-sql_2.12: Could not resolve dependencies for
     project com.nvidia:rapids-4-spark-sql_2.12:jar:24.12.0: Failure to find com.nvidia:rapids-4-spark-private_2.12:jar:spark350db143:24.12.0
     in https://repo1.maven.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced


