### PR TITLE
Add metrics GpuPartitioning.CopyToHostTime

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -92,6 +92,7 @@ object GpuMetric extends Logging {
   val DELETION_VECTOR_SIZE = "deletionVectorSize"
   val CONCAT_HEADER_TIME = "concatHeaderTime"
   val CONCAT_BUFFER_TIME = "concatBufferTime"
+  val COPY_TO_HOST_TIME = "d2hMemCopyTime"
 
   // Metric Descriptions.
   val DESCRIPTION_BUFFER_TIME = "buffer time"
@@ -133,6 +134,7 @@ object GpuMetric extends Logging {
   val DESCRIPTION_DELETION_VECTOR_SIZE = "deletion vector size"
   val DESCRIPTION_CONCAT_HEADER_TIME = "concat header time"
   val DESCRIPTION_CONCAT_BUFFER_TIME = "concat buffer time"
+  val DESCRIPTION_COPY_TO_HOST_TIME = "deviceToHost memory copy time"
 
   def unwrap(input: GpuMetric): SQLMetric = input match {
     case w :WrappedGpuMetric => w.sqlMetric

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -135,12 +135,7 @@ trait GpuPartitioning extends Partitioning {
       }
     }
     withResource(hostPartColumns) { _ =>
-      lazy val memCpyNvtxRange = memCopyTime.map(
-          new NvtxWithMetrics("PartitionD2H", NvtxColor.CYAN, _))
-        .getOrElse(
-          new NvtxRange("PartitionD2H", NvtxColor.CYAN))
-      // Wait for copyToHostAsync
-      withResource(memCpyNvtxRange) { _ =>
+      withResource(new NvtxWithMetrics("PartitionD2H", NvtxColor.CYAN, memCopyTime)) { _ =>
         Cuda.DEFAULT_STREAM.sync()
       }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -256,15 +256,15 @@ trait GpuPartitioning extends Partitioning {
   private var memCopyTime: Option[GpuMetric] = None
 
   /**
-   * Setup Spark SQL Metrics for the details of GpuPartition. This method is expected to be called
-   * at the query planning stage for only once.
+   * Setup sub-metrics for the performance debugging of GpuPartition. This method is expected to
+   * be called at the query planning stage. Therefore, this method is NOT thread safe.
    */
-  def setupMetrics(metrics: Map[String, GpuMetric]): Unit = {
-    metrics.get(GpuPartitioning.CopyToHostTime).foreach { metric =>
-      // Check and set GpuPartitioning.CopyToHostTime
-      require(memCopyTime.isEmpty,
-        s"The GpuMetric[${GpuPartitioning.CopyToHostTime}] has already been set")
-      memCopyTime = Some(metric)
+  def setupDebugMetrics(metrics: Map[String, GpuMetric]): Unit = {
+    // Check and set GpuPartitioning.CopyToHostTime
+    if (memCopyTime.isEmpty) {
+      metrics.get(GpuPartitioning.CopyToHostTime).foreach { metric =>
+        memCopyTime = Some(metric)
+      }
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -260,11 +260,6 @@ trait GpuPartitioning extends Partitioning {
    * be called at the query planning stage. Therefore, this method is NOT thread safe.
    */
   def setupDebugMetrics(metrics: Map[String, GpuMetric]): Unit = {
-    // Check and set GpuPartitioning.CopyToHostTime
-    if (memCopyTime.isEmpty) {
-      metrics.get(GpuPartitioning.CopyToHostTime).foreach { metric =>
-        memCopyTime = Some(metric)
-      }
-    }
+    memCopyTime = metrics.get(GpuPartitioning.CopyToHostTime).getOrElse(NoopMetric)
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
@@ -368,10 +368,10 @@ object GpuShuffleExchangeExecBase {
       rdd
     }
     val partitioner: GpuExpression = getPartitioner(newRdd, outputAttributes, newPartitioning)
-    // Inject detailed Metrics, such as D2HTime before SliceOnCpu
+    // Inject debugging subMetrics, such as D2HTime before SliceOnCpu
     // The injected metrics will be serialized as the members of GpuPartitioning
     partitioner match {
-      case pt: GpuPartitioning => pt.setupMetrics(additionalMetrics)
+      case pt: GpuPartitioning => pt.setupDebugMetrics(additionalMetrics)
       case _ =>
     }
     val partitionTime: GpuMetric = metrics(METRIC_SHUFFLE_PARTITION_TIME)


### PR DESCRIPTION
Close #11878

This PR is to add the GpuMetric `GpuPartitioning.CopyToHostTime`.  Since `GpuPartitioning` is a GpuExpression rather than a GpuPlan, a specialized method `GpuPartitioning.setupMetrics` was created for the setup of detailed GpuPartitioning metrics during the planning time.

During the local test, the newly-added metric works well.
 
<img width="623" alt="image" src="https://github.com/user-attachments/assets/1ae706cb-2a90-4436-a5b1-345784c36874" />
