### PR TITLE
Support group-limit optimization for `ROW_NUMBER`

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2107,7 +2107,9 @@ def test_window_aggs_for_batched_finite_row_windows_fallback(data_gen):
                             'DENSE_RANK() OVER (PARTITION BY a ORDER BY b, c) ',
                             'RANK() OVER (ORDER BY a,b,c) ',
                             'DENSE_RANK() OVER (ORDER BY a,b,c) ',
-                        ])
+                            # ROW_NUMBER() on an un-partitioned window does not invoke WindowGroupLimit optimization.
+                            'ROW_NUMBER() OVER (PARTITION BY a ORDER BY b,c) ',
+])
 def test_window_group_limits_for_ranking_functions(data_gen, batch_size, rank_clause):
     """
     This test verifies that window group limits are applied for queries with ranking-function based
@@ -2130,39 +2132,6 @@ def test_window_group_limits_for_ranking_functions(data_gen, batch_size, rank_cl
         lambda spark: gen_df(spark, data_gen, length=4096),
         "window_agg_table",
         query,
-        conf=conf)
-
-
-@allow_non_gpu('WindowGroupLimitExec')
-@pytest.mark.skipif(condition=not (is_spark_350_or_later() or is_databricks133_or_later()),
-                    reason="WindowGroupLimit not available for spark.version < 3.5 "
-                           " and Databricks version < 13.3")
-@ignore_order(local=True)
-@approximate_float
-def test_window_group_limits_fallback_for_row_number():
-    """
-    This test verifies that window group limits are applied for queries with ranking-function based
-    row filters.
-    This test covers RANK() and DENSE_RANK(), for window function with and without `PARTITIONED BY`
-    clauses.
-    """
-    conf = {'spark.rapids.sql.batchSizeBytes': '1g',
-            'spark.rapids.sql.castFloatToDecimal.enabled': True}
-
-    data_gen = _grpkey_longs_with_no_nulls
-    query = """
-        SELECT * FROM (
-          SELECT *, ROW_NUMBER() OVER (PARTITION BY a ORDER BY b, c) AS rnk
-          FROM window_agg_table
-        )
-        WHERE rnk < 3
-     """
-
-    assert_gpu_sql_fallback_collect(
-        lambda spark: gen_df(spark, data_gen, length=512),
-        cpu_fallback_class_name="WindowGroupLimitExec",
-        table_name="window_agg_table",
-        sql=query,
         conf=conf)
 
 

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuWindowGroupLimitExec.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuWindowGroupLimitExec.scala
@@ -304,8 +304,8 @@ case class GpuWindowGroupLimitExec(
     case GpuDenseRank(_) => DenseRankFunction
     case GpuRowNumber => RowNumberFunction
     case _ =>
-      throw new UnsupportedOperationException("Only rank, dense_rank and " +
-                                              "row_number are currently supported for group limits")
+      throw new UnsupportedOperationException("Only rank, dense_rank and row_number are " +
+                                              "currently supported for group limits")
   }
 
   override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {


### PR DESCRIPTION
Fixes #10505.

This is a follow-up to #10500, which added support for WindowGroupLimit optimizations for `RANK` and `DENSE_RANK` window functions.  The same optimization was not extended to `ROW_NUMBER` at that time.

This commit now allows the output from `ROW_NUMBER` to be filtered map-side, in case there is a `<` predicate on its return value. The following is an example of the kind of query that is affected by this change:
```sql
SELECT * FROM (
  SELECT *,
         ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS rn
  FROM mytable )
WHERE rn < 10;
```

This is per the optimization in [SPARK-37099](https://issues.apache.org/jira/browse/SPARK-37099) in Apache Spark.  With this, the output from the window function could potentially be drastically smaller than the input, thus saving on shuffle traffic.

Note that this optimization does not kick in on Apache Spark or in `spark-rapids` if the `ROW_NUMBER` phrase does not include a `PARTITION BY` clause.  `spark-rapids` remains consistent with Apache Spark in this regard.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
