### PR TITLE
Make sure that the chunked packer bounce buffer is realease after the synchronize

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
@@ -1719,7 +1719,7 @@ class ChunkedPacker(table: Table,
   }
 
   override def next(): (DeviceBounceBuffer, Long) = {
-    withResource(bounceBufferPool.nextBuffer()) { bounceBuffer =>
+    closeOnExcept(bounceBufferPool.nextBuffer()) { bounceBuffer =>
       if (closed) {
         throw new IllegalStateException(s"ChunkedPacker is closed")
       }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/11885

The issue this fixes is that the bounce buffer seen here cannot be closed (released back to the pool) before the stream synchronize that happens at the caller of `.next`. We need to return the bounce buffer and allow the caller to close, which can be done in the right order. 