### PR TITLE
Change order of initialization so pinned pool is available for spill framework buffers

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -284,10 +284,29 @@ object GpuDeviceManager extends Logging {
 
   private var memoryEventHandler: DeviceMemoryEventHandler = _
 
-  private def initializeRmm(gpuId: Int, rapidsConf: Option[RapidsConf]): Unit = {
-    if (!Rmm.isInitialized) {
-      val conf = rapidsConf.getOrElse(new RapidsConf(SparkEnv.get.conf))
+  private def initializeSpillAndMemoryEvents(conf: RapidsConf): Unit = {
+    SpillFramework.initialize(conf)
 
+    memoryEventHandler = new DeviceMemoryEventHandler(
+      SpillFramework.stores.deviceStore,
+      conf.gpuOomDumpDir,
+      conf.gpuOomMaxRetries)
+
+    if (conf.sparkRmmStateEnable) {
+      val debugLoc = if (conf.sparkRmmDebugLocation.isEmpty) {
+        null
+      } else {
+        conf.sparkRmmDebugLocation
+      }
+      RmmSpark.setEventHandler(memoryEventHandler, debugLoc)
+    } else {
+      logWarning("SparkRMM retry has been disabled")
+      Rmm.setEventHandler(memoryEventHandler)
+    }
+  }
+
+  private def initializeRmmGpuPool(gpuId: Int, conf: RapidsConf): Unit = {
+    if (!Rmm.isInitialized) {
       val poolSize = conf.chunkedPackPoolSize
       chunkedPackMemoryResource =
         if (poolSize > 0) {
@@ -391,30 +410,10 @@ object GpuDeviceManager extends Logging {
         }
       }
 
-      SpillFramework.initialize(conf)
-
-      memoryEventHandler = new DeviceMemoryEventHandler(
-        SpillFramework.stores.deviceStore,
-        conf.gpuOomDumpDir,
-        conf.gpuOomMaxRetries)
-
-      if (conf.sparkRmmStateEnable) {
-        val debugLoc = if (conf.sparkRmmDebugLocation.isEmpty) {
-          null
-        } else {
-          conf.sparkRmmDebugLocation
-        }
-        RmmSpark.setEventHandler(memoryEventHandler, debugLoc)
-      } else {
-        logWarning("SparkRMM retry has been disabled")
-        Rmm.setEventHandler(memoryEventHandler)
-      }
-      GpuShuffleEnv.init(conf)
     }
   }
 
-  private def initializeOffHeapLimits(gpuId: Int, rapidsConf: Option[RapidsConf]): Unit = {
-    val conf = rapidsConf.getOrElse(new RapidsConf(SparkEnv.get.conf))
+  private def initializePinnedPoolAndOffHeapLimits(gpuId: Int, conf: RapidsConf): Unit = {
     val setCuioDefaultResource = conf.pinnedPoolCuioDefault
     val (pinnedSize, nonPinnedLimit) = if (conf.offHeapLimitEnabled) {
       logWarning("OFF HEAP MEMORY LIMITS IS ENABLED. " +
@@ -508,8 +507,13 @@ object GpuDeviceManager extends Logging {
             "Cannot initialize memory due to previous shutdown failing")
         } else if (singletonMemoryInitialized == Uninitialized) {
           val gpu = gpuId.getOrElse(findGpuAndAcquire())
-          initializeRmm(gpu, rapidsConf)
-          initializeOffHeapLimits(gpu, rapidsConf)
+          val conf = rapidsConf.getOrElse(new RapidsConf(SparkEnv.get.conf))
+          initializePinnedPoolAndOffHeapLimits(gpu, conf)
+          initializeRmmGpuPool(gpu, conf)
+          // we want to initialize this last because we want to take advantage
+          // of pinned memory if it is configured
+          initializeSpillAndMemoryEvents(conf)
+          GpuShuffleEnv.init(conf)
           singletonMemoryInitialized = Initialized
         }
       }

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,9 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.util.MapData
 import org.apache.spark.sql.types._
 
-class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite
-    with RmmSparkRetrySuiteBase {
+class InternalColumnarRDDConverterSuite extends RmmSparkRetrySuiteBase {
 
-  def compareMapAndMapDate[K,V](map: collection.Map[K, V], mapData: MapData): Assertion = {
+  def compareMapAndMapDate[K, V](map: collection.Map[K, V], mapData: MapData): Assertion = {
     assert(map.size == mapData.numElements())
     val outputMap = mutable.Map[Any, Any]()
     // Only String now, TODO: support other data types in Map
@@ -66,12 +65,12 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite
   }
 
   test("transform boolean, byte, short, int, float, long, double, date, timestamp data" +
-      " back and forth between Row and Columnar") {
+    " back and forth between Row and Columnar") {
     val schema = StructType(Seq(
       StructField("Boolean", BooleanType),
       StructField("BinaryNotNull", BooleanType, nullable = false),
       StructField("Byte", ByteType),
-      StructField("ByteNotNull",ByteType, nullable = false),
+      StructField("ByteNotNull", ByteType, nullable = false),
       StructField("Short", ShortType),
       StructField("ShortNotNull", ShortType, nullable = false),
       StructField("Int", IntegerType),
@@ -86,8 +85,8 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite
       StructField("DateNotNull", DateType, nullable = false),
       StructField("Timestamp", TimestampType),
       StructField("TimestampNotNull", TimestampType, nullable = false),
-      StructField("Decimal", DecimalType(20,10)),
-      StructField("DecimalNotNull", DecimalType(20,10), nullable = false)
+      StructField("Decimal", DecimalType(20, 10)),
+      StructField("DecimalNotNull", DecimalType(20, 10), nullable = false)
     ))
     val numRows = 100
     val rows = GpuBatchUtilsSuite.createExternalRows(schema, numRows)
@@ -113,7 +112,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite
             } else {
               if (f.dataType.isInstanceOf[DecimalType]) {
                 assert(input.get(i) == output.get(i, f.dataType)
-                    .asInstanceOf[Decimal].toJavaBigDecimal)
+                  .asInstanceOf[Decimal].toJavaBigDecimal)
               } else {
                 assert(input.get(i) == output.get(i, f.dataType))
               }
@@ -272,7 +271,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite
               assert(outputStructRow.isNullAt(2))
             } else {
               assert(inputStructRow.getSeq(2) sameElements outputStructRow.getArray(2)
-                  .toDoubleArray())
+                .toDoubleArray())
             }
           }
         }
@@ -280,7 +279,11 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite
       }
     }
   }
+}
 
+// these tests are separated out because they are really just spark tests, and they should skip
+// the initialization done in `RmmSparkRetrySuiteBase`
+class InternalColumnarRDDConverterSparkSessionSuite extends SparkQueryCompareTestSuite {
   test("InternalColumnarRddConverter should extractRDDTable RDD[ColumnarBatch]") {
     withGpuSparkSession(spark => {
       val path = TestResourceFinder.getResourcePath("disorder-read-schema.parquet")
@@ -308,5 +311,4 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite
       assert(result.forall(_ == true))
     }, new SparkConf().set("spark.rapids.sql.test.allowedNonGpu", "DeserializeToObjectExec"))
   }
-
 }


### PR DESCRIPTION
While collecting traces for https://github.com/NVIDIA/spark-rapids/issues/11888, I realized that the bounce buffers I am using are pageable, which is pretty bad. If I change the order of initialization, the pinned pool can be initialized before the spill framework, so we can then use pinned memory for the d2h and h2d bounced copies.

Renamed init functions slightly, as their names are not matching their function currently.