### PR TITLE
Fix two potential OOM issues in GPU aggregate.

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DataTypeUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DataTypeUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,11 @@ import org.apache.spark.sql.types._
 object DataTypeUtils {
   def isNestedType(dataType: DataType): Boolean = dataType match {
     case _: ArrayType | _: MapType | _: StructType => true
+    case _ => false
+  }
+
+  def hasOffset(dataType: DataType): Boolean = dataType match {
+    case _: ArrayType | _: StringType | _: BinaryType => true
     case _ => false
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -435,9 +435,9 @@ object PreProjectSplitIterator {
             })
           }
         case otherType => // primitive types
-          val hasOffset = hasOffset(otherType)
-          if (nullable || hasOffset) {
-            getOrInitAt(depth, new LitMeta(nullable, hasOffset)).incRowsNum()
+          val hasOffsetBuf = hasOffset(otherType)
+          if (nullable || hasOffsetBuf) {
+            getOrInitAt(depth, new LitMeta(nullable, hasOffsetBuf)).incRowsNum()
           }
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -448,8 +448,18 @@ object PreProjectSplitIterator {
           metaInfos.append(null)
         }
         metaInfos.append(initMeta)
+        initMeta
+      } else {
+        val meta = metaInfos(pos)
+        if (meta == null) {
+          metaInfos(pos) = initMeta
+          initMeta
+        } else {
+          meta
+        }
+
       }
-      metaInfos(pos)
+
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/LiteralSizeEstimationTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/LiteralSizeEstimationTest.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.unit
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.{GpuScalar, GpuUnitTests, PreProjectSplitIterator}
+import com.nvidia.spark.rapids.Arm.withResource
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData}
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+/** These tests only cover nested type literals for the PreProjectSplitIterator case */
+class LiteralSizeEstimationTest extends GpuUnitTests {
+  private val numRows = 1000
+
+  private def testLiteralSizeEstimate(lit: Any, litType: DataType): Unit = {
+    val col = withResource(GpuScalar.from(lit, litType))(ColumnVector.fromScalar(_, numRows))
+    val actualSize = withResource(col)(_.getDeviceMemorySize)
+    val estimatedSize = PreProjectSplitIterator.calcSizeForLiteral(lit, litType, numRows)
+    assertResult(actualSize)(estimatedSize)
+  }
+
+  test("estimate the array(int) literal size") {
+    val litType = ArrayType(IntegerType, true)
+    val lit = ArrayData.toArrayData(Array(null, 1, 2, null))
+    testLiteralSizeEstimate(lit, litType)
+  }
+
+  test("estimate the array(string) literal size") {
+    val litType = ArrayType(StringType, true)
+    val lit = ArrayData.toArrayData(
+      Array(null, UTF8String.fromString("s1"), UTF8String.fromString("s2")))
+    testLiteralSizeEstimate(lit, litType)
+  }
+
+  test("estimate the array(array(array(int))) literal size") {
+    val litType = ArrayType(ArrayType(ArrayType(IntegerType, true), true), true)
+    val nestedElem1 = ArrayData.toArrayData(Array(null, 1, 2, null))
+    val nestedElem2 = ArrayData.toArrayData(Array(null))
+    val nestedElem3 = ArrayData.toArrayData(Array())
+    val elem1 = ArrayData.toArrayData(Array(nestedElem1, null))
+    val elem2 = ArrayData.toArrayData(Array(nestedElem2, null, nestedElem3))
+    val lit = ArrayData.toArrayData(Array(null, elem1, null, elem2, null))
+    testLiteralSizeEstimate(lit, litType)
+  }
+
+  test("estimate the array(array(array(string))) literal size") {
+    val litType = ArrayType(ArrayType(ArrayType(StringType, true), true), true)
+    val nestedElem1 = ArrayData.toArrayData(
+      Array(null, UTF8String.fromString("s1"), UTF8String.fromString("s2")))
+    val nestedElem2 = ArrayData.toArrayData(Array(null))
+    val nestedElem3 = ArrayData.toArrayData(Array())
+    val elem1 = ArrayData.toArrayData(Array(nestedElem1, null))
+    val elem2 = ArrayData.toArrayData(Array(nestedElem2, null, nestedElem3))
+    val lit = ArrayData.toArrayData(Array(null, elem1, null, elem2, null))
+    testLiteralSizeEstimate(lit, litType)
+  }
+
+  test("estimate the struct(int, string) literal size") {
+    val litType = StructType(Seq(
+      StructField("int1", IntegerType),
+      StructField("string2", StringType)
+    ))
+    // null
+    testLiteralSizeEstimate(InternalRow(null, null), litType)
+    // normal case
+    testLiteralSizeEstimate(InternalRow(1, UTF8String.fromString("s1")), litType)
+  }
+
+  test("estimate the struct(int, array(string)) literal size") {
+    val litType = StructType(Seq(
+        StructField("int1", IntegerType),
+        StructField("string2", ArrayType(StringType, true))
+    ))
+    testLiteralSizeEstimate(InternalRow(null, null), litType)
+    val arrayLit = ArrayData.toArrayData(
+      Array(null, UTF8String.fromString("s1"), UTF8String.fromString("s2")))
+    // normal case
+    testLiteralSizeEstimate(InternalRow(1, arrayLit), litType)
+  }
+
+  test("estimate the list(struct(int, array(string))) literal size") {
+    val litType = ArrayType(
+      StructType(Seq(
+        StructField("int1", IntegerType),
+        StructField("string2", ArrayType(StringType, true))
+      )), true)
+    val arrayLit = ArrayData.toArrayData(
+      Array(null, UTF8String.fromString("a1"), UTF8String.fromString("a2")))
+    val elem1 = InternalRow(1, arrayLit)
+    val elem2 = InternalRow(null, null)
+    val lit = ArrayData.toArrayData(Array(null, elem1, elem2))
+    testLiteralSizeEstimate(lit, litType)
+  }
+
+  test("estimate the map(int, array(string)) literal size") {
+    val litType = MapType(IntegerType, ArrayType(StringType, true), true)
+    val arrayLit = ArrayData.toArrayData(
+      Array(null, UTF8String.fromString("s1"), UTF8String.fromString("s2")))
+    val valueLit = ArrayData.toArrayData(Array(null, arrayLit))
+    val keyLit = ArrayData.toArrayData(Array(1, 2))
+    val lit = new ArrayBasedMapData(keyLit, valueLit)
+    testLiteralSizeEstimate(lit, litType)
+  }
+}


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11903

The first one is by taking the nested literals into account when calculating the output size for pre-split. See the linked issue above for more details.

The second one is by using the correct size for buffer size comparison when collecting the next bundle of batches in aggregate. The size return from the `batchesByBucket.last.size()` is not the actual buffer size in bytes,
but the element number of an array. It can not be used for the buffer size comparison.

I verified this PR locally by the toy query and it works well.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
