### PR TITLE
Deploy the sources and Javadoc JARs in the nightly CICD [skip ci]

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -176,7 +176,7 @@ if [[ $SKIP_DEPLOY != 'true' ]]; then
         mv ${TMP_PATH}/${ART_ID}-${ART_VER}-*.jar ${DIST_PATH}/target/
     fi
     # Deploy dist jars in the final step to ensure that the POM files are not overwritten
-    jenkins/deploy.sh
+    SERVER_URL=${SERVER_URL:-"$URM_URL"} SERVER_ID=${SERVER_ID:-"snapshots"} jenkins/deploy.sh
 fi
 
 # Parse Spark files from local mvn repo


### PR DESCRIPTION
For fixing: https://github.com/NVIDIA/spark-rapids/issues/11914


Deploy the sources and javadoc JARS to make sure nightly CICD includes all jars required by Sonatype release

Deploy dist jars in the final step to ensure that the POM files are not overwritten

