### PR TITLE
Add throttle time metrics for async write

### DIFF
--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeltaWrite.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeltaWrite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy, UnaryExecNode}
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
-import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.rapids.GpuWriteJobStatsTracker
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -106,11 +105,11 @@ case class GpuRapidsDeltaWriteExec(child: SparkPlan) extends V2CommandExec
     with UnaryExecNode with GpuExec {
   override def output: Seq[Attribute] = child.output
 
-  lazy val basicMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.basicMetrics
-  lazy val taskMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.taskMetrics
+  lazy val basicMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.basicMetrics
+  lazy val taskMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.taskMetrics
 
   override lazy val allMetrics: Map[String, GpuMetric] =
-    GpuMetric.wrap(basicMetrics ++ taskMetrics)
+    basicMetrics ++ taskMetrics
 
   override def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {
     // This is just a stub node for planning purposes and does not actually perform

--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -179,8 +179,8 @@ class GpuOptimisticTransaction
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -179,8 +179,8 @@ class GpuOptimisticTransaction
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -201,8 +201,8 @@ class GpuOptimisticTransaction
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-23x/src/main/scala/org/apache/spark/sql/delta/rapids/delta23x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-23x/src/main/scala/org/apache/spark/sql/delta/rapids/delta23x/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -201,8 +201,8 @@ class GpuOptimisticTransaction
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -203,8 +203,8 @@ class GpuOptimisticTransaction
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -220,8 +220,8 @@ class GpuOptimisticTransaction(
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -217,8 +217,8 @@ class GpuOptimisticTransaction(
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-spark341db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark341db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -219,8 +219,8 @@ class GpuOptimisticTransaction(
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/delta-lake/delta-spark350db143/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark350db143/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -219,8 +219,8 @@ class GpuOptimisticTransaction(
         val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
           serializableHadoopConf,
-          BasicWriteJobStatsTracker.metrics)
-        registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
+          GpuMetric.wrap(BasicWriteJobStatsTracker.metrics))
+        registerSQLMetrics(spark, GpuMetric.unwrap(basicWriteJobStatsTracker.driverSideMetrics))
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
           val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataWritingCommandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataWritingCommandExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,10 @@ import org.apache.spark.util.SerializableConfiguration
  * An extension of `DataWritingCommand` that allows columnar execution.
  */
 trait GpuDataWritingCommand extends DataWritingCommand with ShimUnaryCommand {
-  lazy val basicMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.basicMetrics
-  lazy val taskMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.taskMetrics
+  lazy val basicMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.basicMetrics
+  lazy val taskMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.taskMetrics
 
-  override lazy val metrics: Map[String, SQLMetric] = basicMetrics ++ taskMetrics
+  override lazy val metrics: Map[String, SQLMetric] = GpuMetric.unwrap(basicMetrics ++ taskMetrics)
 
   override final def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {
     Arm.withResource(runColumnar(sparkSession, child)) { batches =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,12 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.immutable.TreeMap
-
-import ai.rapids.cudf.NvtxColor
-import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.filecache.FileCacheConf
 import com.nvidia.spark.rapids.lore.{GpuLore, GpuLoreDumpRDD}
 import com.nvidia.spark.rapids.lore.GpuLore.{loreIdOf, LORE_DUMP_PATH_TAG, LORE_DUMP_RDD_TAG}
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.rapids.LocationPreservingMapPartitionsRDD
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
@@ -34,245 +29,9 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Exp
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.rapids.GpuTaskMetrics
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
-sealed class MetricsLevel(val num: Integer) extends Serializable {
-  def >=(other: MetricsLevel): Boolean =
-    num >= other.num
-}
-
-object MetricsLevel {
-  def apply(str: String): MetricsLevel = str match {
-    case "ESSENTIAL" => GpuMetric.ESSENTIAL_LEVEL
-    case "MODERATE" => GpuMetric.MODERATE_LEVEL
-    case _ => GpuMetric.DEBUG_LEVEL
-  }
-}
-
-object GpuMetric extends Logging {
-  // Metric names.
-  val BUFFER_TIME = "bufferTime"
-  val COPY_BUFFER_TIME = "copyBufferTime"
-  val GPU_DECODE_TIME = "gpuDecodeTime"
-  val NUM_INPUT_ROWS = "numInputRows"
-  val NUM_INPUT_BATCHES = "numInputBatches"
-  val NUM_OUTPUT_ROWS = "numOutputRows"
-  val NUM_OUTPUT_BATCHES = "numOutputBatches"
-  val PARTITION_SIZE = "partitionSize"
-  val NUM_PARTITIONS = "numPartitions"
-  val OP_TIME = "opTime"
-  val COLLECT_TIME = "collectTime"
-  val CONCAT_TIME = "concatTime"
-  val SORT_TIME = "sortTime"
-  val REPARTITION_TIME = "repartitionTime"
-  val AGG_TIME = "computeAggTime"
-  val JOIN_TIME = "joinTime"
-  val FILTER_TIME = "filterTime"
-  val BUILD_DATA_SIZE = "buildDataSize"
-  val BUILD_TIME = "buildTime"
-  val STREAM_TIME = "streamTime"
-  val NUM_TASKS_FALL_BACKED = "numTasksFallBacked"
-  val NUM_TASKS_REPARTITIONED = "numTasksRepartitioned"
-  val NUM_TASKS_SKIPPED_AGG = "numTasksSkippedAgg"
-  val READ_FS_TIME = "readFsTime"
-  val WRITE_BUFFER_TIME = "writeBufferTime"
-  val FILECACHE_FOOTER_HITS = "filecacheFooterHits"
-  val FILECACHE_FOOTER_HITS_SIZE = "filecacheFooterHitsSize"
-  val FILECACHE_FOOTER_MISSES = "filecacheFooterMisses"
-  val FILECACHE_FOOTER_MISSES_SIZE = "filecacheFooterMissesSize"
-  val FILECACHE_DATA_RANGE_HITS = "filecacheDataRangeHits"
-  val FILECACHE_DATA_RANGE_HITS_SIZE = "filecacheDataRangeHitsSize"
-  val FILECACHE_DATA_RANGE_MISSES = "filecacheDataRangeMisses"
-  val FILECACHE_DATA_RANGE_MISSES_SIZE = "filecacheDataRangeMissesSize"
-  val FILECACHE_FOOTER_READ_TIME = "filecacheFooterReadTime"
-  val FILECACHE_DATA_RANGE_READ_TIME = "filecacheDataRangeReadTime"
-  val DELETION_VECTOR_SCATTER_TIME = "deletionVectorScatterTime"
-  val DELETION_VECTOR_SIZE = "deletionVectorSize"
-  val CONCAT_HEADER_TIME = "concatHeaderTime"
-  val CONCAT_BUFFER_TIME = "concatBufferTime"
-  val COPY_TO_HOST_TIME = "d2hMemCopyTime"
-
-  // Metric Descriptions.
-  val DESCRIPTION_BUFFER_TIME = "buffer time"
-  val DESCRIPTION_COPY_BUFFER_TIME = "copy buffer time"
-  val DESCRIPTION_GPU_DECODE_TIME = "GPU decode time"
-  val DESCRIPTION_NUM_INPUT_ROWS = "input rows"
-  val DESCRIPTION_NUM_INPUT_BATCHES = "input columnar batches"
-  val DESCRIPTION_NUM_OUTPUT_ROWS = "output rows"
-  val DESCRIPTION_NUM_OUTPUT_BATCHES = "output columnar batches"
-  val DESCRIPTION_PARTITION_SIZE = "partition data size"
-  val DESCRIPTION_NUM_PARTITIONS = "partitions"
-  val DESCRIPTION_OP_TIME = "op time"
-  val DESCRIPTION_COLLECT_TIME = "collect batch time"
-  val DESCRIPTION_CONCAT_TIME = "concat batch time"
-  val DESCRIPTION_SORT_TIME = "sort time"
-  val DESCRIPTION_REPARTITION_TIME = "repartition time"
-  val DESCRIPTION_AGG_TIME = "aggregation time"
-  val DESCRIPTION_JOIN_TIME = "join time"
-  val DESCRIPTION_FILTER_TIME = "filter time"
-  val DESCRIPTION_BUILD_DATA_SIZE = "build side size"
-  val DESCRIPTION_BUILD_TIME = "build time"
-  val DESCRIPTION_STREAM_TIME = "stream time"
-  val DESCRIPTION_NUM_TASKS_FALL_BACKED = "number of sort fallback tasks"
-  val DESCRIPTION_NUM_TASKS_REPARTITIONED = "number of tasks repartitioned for agg"
-  val DESCRIPTION_NUM_TASKS_SKIPPED_AGG = "number of tasks skipped aggregation"
-  val DESCRIPTION_READ_FS_TIME = "time to read fs data"
-  val DESCRIPTION_WRITE_BUFFER_TIME = "time to write data to buffer"
-  val DESCRIPTION_FILECACHE_FOOTER_HITS = "cached footer hits"
-  val DESCRIPTION_FILECACHE_FOOTER_HITS_SIZE = "cached footer hits size"
-  val DESCRIPTION_FILECACHE_FOOTER_MISSES = "cached footer misses"
-  val DESCRIPTION_FILECACHE_FOOTER_MISSES_SIZE = "cached footer misses size"
-  val DESCRIPTION_FILECACHE_DATA_RANGE_HITS = "cached data hits"
-  val DESCRIPTION_FILECACHE_DATA_RANGE_HITS_SIZE = "cached data hits size"
-  val DESCRIPTION_FILECACHE_DATA_RANGE_MISSES = "cached data misses"
-  val DESCRIPTION_FILECACHE_DATA_RANGE_MISSES_SIZE = "cached data misses size"
-  val DESCRIPTION_FILECACHE_FOOTER_READ_TIME = "cached footer read time"
-  val DESCRIPTION_FILECACHE_DATA_RANGE_READ_TIME = "cached data read time"
-  val DESCRIPTION_DELETION_VECTOR_SCATTER_TIME = "deletion vector scatter time"
-  val DESCRIPTION_DELETION_VECTOR_SIZE = "deletion vector size"
-  val DESCRIPTION_CONCAT_HEADER_TIME = "concat header time"
-  val DESCRIPTION_CONCAT_BUFFER_TIME = "concat buffer time"
-  val DESCRIPTION_COPY_TO_HOST_TIME = "deviceToHost memory copy time"
-
-  def unwrap(input: GpuMetric): SQLMetric = input match {
-    case w :WrappedGpuMetric => w.sqlMetric
-    case i => throw new IllegalArgumentException(s"found unsupported GpuMetric ${i.getClass}")
-  }
-
-  def unwrap(input: Map[String, GpuMetric]): Map[String, SQLMetric] = {
-    val ret = input.collect {
-      // remove the metrics that are not registered
-      case (k, w) if w != NoopMetric => (k, unwrap(w))
-    }
-    val companions = input.collect {
-      // add the companions
-      case (k, w) if w.companionGpuMetric.isDefined =>
-        (k + "_exSemWait", unwrap(w.companionGpuMetric.get))
-    }
-
-    TreeMap.apply((ret ++ companions).toSeq: _*)
-  }
-
-  def wrap(input: SQLMetric): GpuMetric = WrappedGpuMetric(input)
-
-  def wrap(input: Map[String, SQLMetric]): Map[String, GpuMetric] = input.map {
-    case (k, v) => (k, wrap(v))
-  }
-
-  def ns[T](metrics: GpuMetric*)(f: => T): T = {
-    val start = System.nanoTime()
-    try {
-      f
-    } finally {
-      val taken = System.nanoTime() - start
-      metrics.foreach(_.add(taken))
-    }
-  }
-
-  object DEBUG_LEVEL extends MetricsLevel(0)
-  object MODERATE_LEVEL extends MetricsLevel(1)
-  object ESSENTIAL_LEVEL extends MetricsLevel(2)
-}
-
-sealed abstract class GpuMetric extends Serializable {
-  def value: Long
-  def set(v: Long): Unit
-  def +=(v: Long): Unit
-  def add(v: Long): Unit
-
-  private var isTimerActive = false
-
-  // For timing GpuMetrics, we additionally create a companion GpuMetric to track elapsed time
-  // excluding semaphore wait time
-  var companionGpuMetric: Option[GpuMetric] = None
-  private var semWaitTimeWhenActivated = 0L
-
-  final def tryActivateTimer(): Boolean = {
-    if (!isTimerActive) {
-      isTimerActive = true
-      semWaitTimeWhenActivated = GpuTaskMetrics.get.getSemWaitTime()
-      true
-    } else {
-      false
-    }
-  }
-
-  final def deactivateTimer(duration: Long): Unit = {
-    if (isTimerActive) {
-      isTimerActive = false
-      companionGpuMetric.foreach(c =>
-        c.add(duration - (GpuTaskMetrics.get.getSemWaitTime() - semWaitTimeWhenActivated)))
-      semWaitTimeWhenActivated = 0L
-      add(duration)
-    }
-  }
-
-  final def ns[T](f: => T): T = {
-    if (tryActivateTimer()) {
-      val start = System.nanoTime()
-      try {
-        f
-      } finally {
-        deactivateTimer(System.nanoTime() - start)
-      }
-    } else {
-      f
-    }
-  }
-}
-
-object NoopMetric extends GpuMetric {
-  override def +=(v: Long): Unit = ()
-  override def add(v: Long): Unit = ()
-  override def set(v: Long): Unit = ()
-  override def value: Long = 0
-}
-
-final case class WrappedGpuMetric(sqlMetric: SQLMetric, withMetricsExclSemWait: Boolean = false)
-  extends GpuMetric {
-
-  if (withMetricsExclSemWait) {
-    //  SQLMetrics.NS_TIMING_METRIC and SQLMetrics.TIMING_METRIC is private,
-    //  so we have to use the string directly
-    if (sqlMetric.metricType == "nsTiming") {
-      companionGpuMetric = Some(WrappedGpuMetric.apply(SQLMetrics.createNanoTimingMetric(
-        SparkSession.getActiveSession.get.sparkContext, sqlMetric.name.get + " (excl. SemWait)")))
-    }
-  }
-
-  def +=(v: Long): Unit = sqlMetric.add(v)
-  def add(v: Long): Unit = sqlMetric.add(v)
-  override def set(v: Long): Unit = sqlMetric.set(v)
-  override def value: Long = sqlMetric.value
-}
-
-/** A GPU metric class that just accumulates into a variable without implicit publishing. */
-final class LocalGpuMetric extends GpuMetric {
-  private var lval = 0L
-  override def value: Long = lval
-  override def set(v: Long): Unit = { lval = v }
-  override def +=(v: Long): Unit = { lval += v }
-  override def add(v: Long): Unit = { lval += v }
-}
-
-class CollectTimeIterator[T](
-    nvtxName: String,
-    it: Iterator[T],
-    collectTime: GpuMetric) extends Iterator[T] {
-  override def hasNext: Boolean = {
-    withResource(new NvtxWithMetrics(nvtxName, NvtxColor.BLUE, collectTime)) { _ =>
-      it.hasNext
-    }
-  }
-
-  override def next(): T = {
-    withResource(new NvtxWithMetrics(nvtxName, NvtxColor.BLUE, collectTime)) { _ =>
-      it.next
-    }
-  }
-}
 
 object GpuExec {
   def outputBatching(sp: SparkPlan): CoalesceGoal = sp match {
@@ -318,31 +77,20 @@ trait GpuExec extends SparkPlan {
    */
   def outputBatching: CoalesceGoal = null
 
-  private [this] lazy val metricsConf = MetricsLevel(RapidsConf.METRICS_LEVEL.get(conf))
-
-  private [this] def createMetricInternal(level: MetricsLevel, f: => SQLMetric): GpuMetric = {
-    if (level >= metricsConf) {
-      // only enable companion metrics (excluding semaphore wait time) for DEBUG_LEVEL
-      WrappedGpuMetric(f, withMetricsExclSemWait = GpuMetric.DEBUG_LEVEL >= metricsConf)
-    } else {
-      NoopMetric
-    }
-  }
-
   def createMetric(level: MetricsLevel, name: String): GpuMetric =
-    createMetricInternal(level, SQLMetrics.createMetric(sparkContext, name))
+    GpuMetric.create(level, name)
 
   def createNanoTimingMetric(level: MetricsLevel, name: String): GpuMetric =
-    createMetricInternal(level, SQLMetrics.createNanoTimingMetric(sparkContext, name))
+    GpuMetric.createNanoTimingMetric(level, name)
 
   def createSizeMetric(level: MetricsLevel, name: String): GpuMetric =
-    createMetricInternal(level, SQLMetrics.createSizeMetric(sparkContext, name))
+    GpuMetric.createSizeMetric(level, name)
 
   def createAverageMetric(level: MetricsLevel, name: String): GpuMetric =
-    createMetricInternal(level, SQLMetrics.createAverageMetric(sparkContext, name))
+    GpuMetric.createAverageMetric(level, name)
 
   def createTimingMetric(level: MetricsLevel, name: String): GpuMetric =
-    createMetricInternal(level, SQLMetrics.createTimingMetric(sparkContext, name))
+    GpuMetric.createTimingMetric(level, name)
 
   protected def createFileCacheMetrics(): Map[String, GpuMetric] = {
     if (FileCacheConf.FILECACHE_ENABLED.get(conf)) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -44,6 +44,7 @@ object GpuExec {
 
 trait GpuExec extends SparkPlan {
   import GpuMetric._
+
   def sparkSession: SparkSession = {
     SparkShimImpl.sessionFromPlan(this)
   }
@@ -77,20 +78,23 @@ trait GpuExec extends SparkPlan {
    */
   def outputBatching: CoalesceGoal = null
 
+  @transient private [this] lazy val metricFactory = new GpuMetricFactory(
+    MetricsLevel(RapidsConf.METRICS_LEVEL.get(conf)), sparkContext)
+
   def createMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.create(level, name)
+    metricFactory.create(level, name)
 
   def createNanoTimingMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createNanoTiming(level, name)
+    metricFactory.createNanoTiming(level, name)
 
   def createSizeMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createSize(level, name)
+    metricFactory.createSize(level, name)
 
   def createAverageMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createAverage(level, name)
+    metricFactory.createAverage(level, name)
 
   def createTimingMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createTiming(level, name)
+    metricFactory.createTiming(level, name)
 
   protected def createFileCacheMetrics(): Map[String, GpuMetric] = {
     if (FileCacheConf.FILECACHE_ENABLED.get(conf)) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -81,16 +81,16 @@ trait GpuExec extends SparkPlan {
     GpuMetric.create(level, name)
 
   def createNanoTimingMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createNanoTimingMetric(level, name)
+    GpuMetric.createNanoTiming(level, name)
 
   def createSizeMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createSizeMetric(level, name)
+    GpuMetric.createSize(level, name)
 
   def createAverageMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createAverageMetric(level, name)
+    GpuMetric.createAverage(level, name)
 
   def createTimingMetric(level: MetricsLevel, name: String): GpuMetric =
-    GpuMetric.createTimingMetric(level, name)
+    GpuMetric.createTiming(level, name)
 
   protected def createFileCacheMetrics(): Map[String, GpuMetric] = {
     if (FileCacheConf.FILECACHE_ENABLED.get(conf)) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids;
+
+import scala.collection.immutable.TreeMap
+
+import ai.rapids.cudf.NvtxColor
+import com.nvidia.spark.rapids.Arm.withResource
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.GpuTaskMetrics
+
+sealed class MetricsLevel(val num: Integer) extends Serializable {
+  def >=(other: MetricsLevel): Boolean =
+    num >= other.num
+}
+
+object MetricsLevel {
+  def apply(str: String): MetricsLevel = str match {
+    case "ESSENTIAL" => GpuMetric.ESSENTIAL_LEVEL
+    case "MODERATE" => GpuMetric.MODERATE_LEVEL
+    case _ => GpuMetric.DEBUG_LEVEL
+  }
+}
+
+object GpuMetric extends Logging with SQLConfHelper {
+  // Metric names.
+  val BUFFER_TIME = "bufferTime"
+  val COPY_BUFFER_TIME = "copyBufferTime"
+  val GPU_DECODE_TIME = "gpuDecodeTime"
+  val NUM_INPUT_ROWS = "numInputRows"
+  val NUM_INPUT_BATCHES = "numInputBatches"
+  val NUM_OUTPUT_ROWS = "numOutputRows"
+  val NUM_OUTPUT_BATCHES = "numOutputBatches"
+  val PARTITION_SIZE = "partitionSize"
+  val NUM_PARTITIONS = "numPartitions"
+  val OP_TIME = "opTime"
+  val COLLECT_TIME = "collectTime"
+  val CONCAT_TIME = "concatTime"
+  val SORT_TIME = "sortTime"
+  val REPARTITION_TIME = "repartitionTime"
+  val AGG_TIME = "computeAggTime"
+  val JOIN_TIME = "joinTime"
+  val FILTER_TIME = "filterTime"
+  val BUILD_DATA_SIZE = "buildDataSize"
+  val BUILD_TIME = "buildTime"
+  val STREAM_TIME = "streamTime"
+  val NUM_TASKS_FALL_BACKED = "numTasksFallBacked"
+  val NUM_TASKS_REPARTITIONED = "numTasksRepartitioned"
+  val NUM_TASKS_SKIPPED_AGG = "numTasksSkippedAgg"
+  val READ_FS_TIME = "readFsTime"
+  val WRITE_BUFFER_TIME = "writeBufferTime"
+  val FILECACHE_FOOTER_HITS = "filecacheFooterHits"
+  val FILECACHE_FOOTER_HITS_SIZE = "filecacheFooterHitsSize"
+  val FILECACHE_FOOTER_MISSES = "filecacheFooterMisses"
+  val FILECACHE_FOOTER_MISSES_SIZE = "filecacheFooterMissesSize"
+  val FILECACHE_DATA_RANGE_HITS = "filecacheDataRangeHits"
+  val FILECACHE_DATA_RANGE_HITS_SIZE = "filecacheDataRangeHitsSize"
+  val FILECACHE_DATA_RANGE_MISSES = "filecacheDataRangeMisses"
+  val FILECACHE_DATA_RANGE_MISSES_SIZE = "filecacheDataRangeMissesSize"
+  val FILECACHE_FOOTER_READ_TIME = "filecacheFooterReadTime"
+  val FILECACHE_DATA_RANGE_READ_TIME = "filecacheDataRangeReadTime"
+  val DELETION_VECTOR_SCATTER_TIME = "deletionVectorScatterTime"
+  val DELETION_VECTOR_SIZE = "deletionVectorSize"
+  val CONCAT_HEADER_TIME = "concatHeaderTime"
+  val CONCAT_BUFFER_TIME = "concatBufferTime"
+  val COPY_TO_HOST_TIME = "d2hMemCopyTime"
+
+  // Metric Descriptions.
+  val DESCRIPTION_BUFFER_TIME = "buffer time"
+  val DESCRIPTION_COPY_BUFFER_TIME = "copy buffer time"
+  val DESCRIPTION_GPU_DECODE_TIME = "GPU decode time"
+  val DESCRIPTION_NUM_INPUT_ROWS = "input rows"
+  val DESCRIPTION_NUM_INPUT_BATCHES = "input columnar batches"
+  val DESCRIPTION_NUM_OUTPUT_ROWS = "output rows"
+  val DESCRIPTION_NUM_OUTPUT_BATCHES = "output columnar batches"
+  val DESCRIPTION_PARTITION_SIZE = "partition data size"
+  val DESCRIPTION_NUM_PARTITIONS = "partitions"
+  val DESCRIPTION_OP_TIME = "op time"
+  val DESCRIPTION_COLLECT_TIME = "collect batch time"
+  val DESCRIPTION_CONCAT_TIME = "concat batch time"
+  val DESCRIPTION_SORT_TIME = "sort time"
+  val DESCRIPTION_REPARTITION_TIME = "repartition time"
+  val DESCRIPTION_AGG_TIME = "aggregation time"
+  val DESCRIPTION_JOIN_TIME = "join time"
+  val DESCRIPTION_FILTER_TIME = "filter time"
+  val DESCRIPTION_BUILD_DATA_SIZE = "build side size"
+  val DESCRIPTION_BUILD_TIME = "build time"
+  val DESCRIPTION_STREAM_TIME = "stream time"
+  val DESCRIPTION_NUM_TASKS_FALL_BACKED = "number of sort fallback tasks"
+  val DESCRIPTION_NUM_TASKS_REPARTITIONED = "number of tasks repartitioned for agg"
+  val DESCRIPTION_NUM_TASKS_SKIPPED_AGG = "number of tasks skipped aggregation"
+  val DESCRIPTION_READ_FS_TIME = "time to read fs data"
+  val DESCRIPTION_WRITE_BUFFER_TIME = "time to write data to buffer"
+  val DESCRIPTION_FILECACHE_FOOTER_HITS = "cached footer hits"
+  val DESCRIPTION_FILECACHE_FOOTER_HITS_SIZE = "cached footer hits size"
+  val DESCRIPTION_FILECACHE_FOOTER_MISSES = "cached footer misses"
+  val DESCRIPTION_FILECACHE_FOOTER_MISSES_SIZE = "cached footer misses size"
+  val DESCRIPTION_FILECACHE_DATA_RANGE_HITS = "cached data hits"
+  val DESCRIPTION_FILECACHE_DATA_RANGE_HITS_SIZE = "cached data hits size"
+  val DESCRIPTION_FILECACHE_DATA_RANGE_MISSES = "cached data misses"
+  val DESCRIPTION_FILECACHE_DATA_RANGE_MISSES_SIZE = "cached data misses size"
+  val DESCRIPTION_FILECACHE_FOOTER_READ_TIME = "cached footer read time"
+  val DESCRIPTION_FILECACHE_DATA_RANGE_READ_TIME = "cached data read time"
+  val DESCRIPTION_DELETION_VECTOR_SCATTER_TIME = "deletion vector scatter time"
+  val DESCRIPTION_DELETION_VECTOR_SIZE = "deletion vector size"
+  val DESCRIPTION_CONCAT_HEADER_TIME = "concat header time"
+  val DESCRIPTION_CONCAT_BUFFER_TIME = "concat buffer time"
+  val DESCRIPTION_COPY_TO_HOST_TIME = "deviceToHost memory copy time"
+
+  private final val session = Option(SparkSession.getActiveSession.orNull)
+
+  private def sparkContext = {
+    if (session.isDefined) {
+      session.get.sparkContext
+    } else {
+      throw new IllegalStateException("No active SparkSession")
+    }
+  }
+
+  override def conf: SQLConf = {
+    session.map(_.sessionState.conf).getOrElse(super.conf)
+  }
+
+  private [this] lazy val metricsConf = MetricsLevel(RapidsConf.METRICS_LEVEL.get(conf))
+
+  private [this] def createInternal(level: MetricsLevel, f: => SQLMetric): GpuMetric = {
+    if (level >= metricsConf) {
+      // only enable companion metrics (excluding semaphore wait time) for DEBUG_LEVEL
+      WrappedGpuMetric(f, withMetricsExclSemWait = GpuMetric.DEBUG_LEVEL >= metricsConf)
+    } else {
+      NoopMetric
+    }
+  }
+
+  def create(level: MetricsLevel, name: String): GpuMetric =
+    createInternal(level, SQLMetrics.createMetric(sparkContext, name))
+
+  def createNanoTimingMetric(level: MetricsLevel, name: String): GpuMetric =
+    createInternal(level, SQLMetrics.createNanoTimingMetric(sparkContext, name))
+
+  def createSizeMetric(level: MetricsLevel, name: String): GpuMetric =
+    createInternal(level, SQLMetrics.createSizeMetric(sparkContext, name))
+
+  def createAverageMetric(level: MetricsLevel, name: String): GpuMetric =
+    createInternal(level, SQLMetrics.createAverageMetric(sparkContext, name))
+
+  def createTimingMetric(level: MetricsLevel, name: String): GpuMetric =
+    createInternal(level, SQLMetrics.createTimingMetric(sparkContext, name))
+
+  def unwrap(input: GpuMetric): SQLMetric = input match {
+    case w :WrappedGpuMetric => w.sqlMetric
+    case i => throw new IllegalArgumentException(s"found unsupported GpuMetric ${i.getClass}")
+  }
+
+  def unwrap(input: Map[String, GpuMetric]): Map[String, SQLMetric] = {
+    val ret = input.collect {
+      // remove the metrics that are not registered
+      case (k, w) if w != NoopMetric => (k, unwrap(w))
+    }
+    val companions = input.collect {
+      // add the companions
+      case (k, w) if w.companionGpuMetric.isDefined =>
+        (k + "_exSemWait", unwrap(w.companionGpuMetric.get))
+    }
+
+    TreeMap.apply((ret ++ companions).toSeq: _*)
+  }
+
+  def wrap(input: SQLMetric): GpuMetric = WrappedGpuMetric(input)
+
+  def wrap(input: Map[String, SQLMetric]): Map[String, GpuMetric] = input.map {
+    case (k, v) => (k, wrap(v))
+  }
+
+  def ns[T](metrics: GpuMetric*)(f: => T): T = {
+    val start = System.nanoTime()
+    try {
+      f
+    } finally {
+      val taken = System.nanoTime() - start
+      metrics.foreach(_.add(taken))
+    }
+  }
+
+  object DEBUG_LEVEL extends MetricsLevel(0)
+  object MODERATE_LEVEL extends MetricsLevel(1)
+  object ESSENTIAL_LEVEL extends MetricsLevel(2)
+}
+
+sealed abstract class GpuMetric extends Serializable {
+  def value: Long
+  def set(v: Long): Unit
+  def +=(v: Long): Unit
+  def add(v: Long): Unit
+
+  private var isTimerActive = false
+
+  // For timing GpuMetrics, we additionally create a companion GpuMetric to track elapsed time
+  // excluding semaphore wait time
+  var companionGpuMetric: Option[GpuMetric] = None
+  private var semWaitTimeWhenActivated = 0L
+
+  final def tryActivateTimer(): Boolean = {
+    if (!isTimerActive) {
+      isTimerActive = true
+      semWaitTimeWhenActivated = GpuTaskMetrics.get.getSemWaitTime()
+      true
+    } else {
+      false
+    }
+  }
+
+  final def deactivateTimer(duration: Long): Unit = {
+    if (isTimerActive) {
+      isTimerActive = false
+      companionGpuMetric.foreach(c =>
+        c.add(duration - (GpuTaskMetrics.get.getSemWaitTime() - semWaitTimeWhenActivated)))
+      semWaitTimeWhenActivated = 0L
+      add(duration)
+    }
+  }
+
+  final def ns[T](f: => T): T = {
+    if (tryActivateTimer()) {
+      val start = System.nanoTime()
+      try {
+        f
+      } finally {
+        deactivateTimer(System.nanoTime() - start)
+      }
+    } else {
+      f
+    }
+  }
+}
+
+object NoopMetric extends GpuMetric {
+  override def +=(v: Long): Unit = ()
+  override def add(v: Long): Unit = ()
+  override def set(v: Long): Unit = ()
+  override def value: Long = 0
+}
+
+final case class WrappedGpuMetric(sqlMetric: SQLMetric, withMetricsExclSemWait: Boolean = false)
+  extends GpuMetric {
+
+  if (withMetricsExclSemWait) {
+    //  SQLMetrics.NS_TIMING_METRIC and SQLMetrics.TIMING_METRIC is private,
+    //  so we have to use the string directly
+    if (sqlMetric.metricType == "nsTiming") {
+      companionGpuMetric = Some(WrappedGpuMetric.apply(SQLMetrics.createNanoTimingMetric(
+        SparkSession.getActiveSession.get.sparkContext, sqlMetric.name.get + " (excl. SemWait)")))
+    }
+  }
+
+  def +=(v: Long): Unit = sqlMetric.add(v)
+  def add(v: Long): Unit = sqlMetric.add(v)
+  override def set(v: Long): Unit = sqlMetric.set(v)
+  override def value: Long = sqlMetric.value
+}
+
+/** A GPU metric class that just accumulates into a variable without implicit publishing. */
+final class LocalGpuMetric extends GpuMetric {
+  private var lval = 0L
+  override def value: Long = lval
+  override def set(v: Long): Unit = { lval = v }
+  override def +=(v: Long): Unit = { lval += v }
+  override def add(v: Long): Unit = { lval += v }
+}
+
+class CollectTimeIterator[T](
+    nvtxName: String,
+    it: Iterator[T],
+    collectTime: GpuMetric) extends Iterator[T] {
+  override def hasNext: Boolean = {
+    withResource(new NvtxWithMetrics(nvtxName, NvtxColor.BLUE, collectTime)) { _ =>
+      it.hasNext
+    }
+  }
+
+  override def next(): T = {
+    withResource(new NvtxWithMetrics(nvtxName, NvtxColor.BLUE, collectTime)) { _ =>
+      it.next
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
@@ -154,16 +154,16 @@ object GpuMetric extends Logging with SQLConfHelper {
   def create(level: MetricsLevel, name: String): GpuMetric =
     createInternal(level, SQLMetrics.createMetric(sparkContext, name))
 
-  def createNanoTimingMetric(level: MetricsLevel, name: String): GpuMetric =
+  def createNanoTiming(level: MetricsLevel, name: String): GpuMetric =
     createInternal(level, SQLMetrics.createNanoTimingMetric(sparkContext, name))
 
-  def createSizeMetric(level: MetricsLevel, name: String): GpuMetric =
+  def createSize(level: MetricsLevel, name: String): GpuMetric =
     createInternal(level, SQLMetrics.createSizeMetric(sparkContext, name))
 
-  def createAverageMetric(level: MetricsLevel, name: String): GpuMetric =
+  def createAverage(level: MetricsLevel, name: String): GpuMetric =
     createInternal(level, SQLMetrics.createAverageMetric(sparkContext, name))
 
-  def createTimingMetric(level: MetricsLevel, name: String): GpuMetric =
+  def createTiming(level: MetricsLevel, name: String): GpuMetric =
     createInternal(level, SQLMetrics.createTimingMetric(sparkContext, name))
 
   def unwrap(input: GpuMetric): SQLMetric = input match {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRunnableCommandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRunnableCommandExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,10 @@ import org.apache.spark.util.SerializableConfiguration
  * An extension of `RunnableCommand` that allows columnar execution.
  */
 trait GpuRunnableCommand extends RunnableCommand with ShimUnaryCommand {
-  lazy val basicMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.basicMetrics
-  lazy val taskMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.taskMetrics
+  lazy val basicMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.basicMetrics
+  lazy val taskMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.taskMetrics
 
-  override lazy val metrics: Map[String, SQLMetric] = basicMetrics ++ taskMetrics
+  override lazy val metrics: Map[String, SQLMetric] = GpuMetric.unwrap(basicMetrics ++ taskMetrics)
 
   override final def run(sparkSession: SparkSession): Seq[Row] =
     throw new UnsupportedOperationException(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,36 @@ package com.nvidia.spark.rapids.io.async
 
 import java.util.concurrent.{Callable, ExecutorService, Future, TimeUnit}
 
+import org.apache.spark.sql.rapids.{ColumnarWriteTaskStatsTracker, GpuWriteTaskStatsTracker}
+
 /**
  * Thin wrapper around an ExecutorService that adds throttling.
  *
  * The given executor is owned by this class and will be shutdown when this class is shutdown.
  */
-class ThrottlingExecutor(
-    val executor: ExecutorService, throttler: TrafficController) {
+class ThrottlingExecutor(executor: ExecutorService, throttler: TrafficController,
+    statsTrackers: Seq[ColumnarWriteTaskStatsTracker]) {
+
+  private var numTasksScheduled = 0
+  private var accumulatedThrottleTimeNs = 0L
+  private var minThrottleTime = Long.MaxValue
+  private var maxThrottleTime = 0L
+
+  private def blockUntilTaskRunnable(task: Task[_]): Unit = {
+    val blockStart = System.nanoTime()
+    throttler.blockUntilRunnable(task)
+    val blockTimeNs = System.nanoTime() - blockStart
+    accumulatedThrottleTimeNs += blockTimeNs
+    minThrottleTime = Math.min(minThrottleTime, blockTimeNs)
+    maxThrottleTime = Math.max(maxThrottleTime, blockTimeNs)
+    numTasksScheduled += 1
+    updateMetrics()
+  }
 
   def submit[T](callable: Callable[T], hostMemoryBytes: Long): Future[T] = {
     val task = new Task[T](hostMemoryBytes, callable)
-    throttler.blockUntilRunnable(task)
+    blockUntilTaskRunnable(task)
+
     executor.submit(() => {
       try {
         task.call()
@@ -38,7 +57,21 @@ class ThrottlingExecutor(
     })
   }
 
+  def updateMetrics(): Unit = {
+    val avgThrottleTime = if (numTasksScheduled > 0) {
+      accumulatedThrottleTimeNs / numTasksScheduled
+    } else {
+      0
+    }
+    statsTrackers.foreach {
+      case gpuStatsTracker: GpuWriteTaskStatsTracker => gpuStatsTracker.setAsyncWriteThrottleTimes(
+        avgThrottleTime, minThrottleTime, maxThrottleTime)
+      case _ =>
+    }
+  }
+
   def shutdownNow(timeout: Long, timeUnit: TimeUnit): Unit = {
+    updateMetrics()
     executor.shutdownNow()
     executor.awaitTermination(timeout, timeUnit)
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
@@ -24,8 +24,8 @@ import scala.collection.mutable
 import com.nvidia.spark.rapids.{GpuMetric, GpuMetricFactory, MetricsLevel, RapidsConf}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.{SparkContext, TaskContext}
 
+import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.WriteTaskStats

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
@@ -241,15 +241,15 @@ object BasicColumnarWriteJobStatsTracker {
     Map(
       NUM_FILES_KEY -> GpuMetric.create(GpuMetric.ESSENTIAL_LEVEL,
         "number of written files"),
-      NUM_OUTPUT_BYTES_KEY -> GpuMetric.createSizeMetric(GpuMetric.ESSENTIAL_LEVEL,
+      NUM_OUTPUT_BYTES_KEY -> GpuMetric.createSize(GpuMetric.ESSENTIAL_LEVEL,
         "written output"),
       NUM_OUTPUT_ROWS_KEY -> GpuMetric.create(GpuMetric.ESSENTIAL_LEVEL,
         "number of output rows"),
       NUM_PARTS_KEY -> GpuMetric.create(GpuMetric.ESSENTIAL_LEVEL,
         "number of dynamic part"),
-      TASK_COMMIT_TIME -> GpuMetric.createTimingMetric(GpuMetric.ESSENTIAL_LEVEL,
+      TASK_COMMIT_TIME -> GpuMetric.createTiming(GpuMetric.ESSENTIAL_LEVEL,
         "task commit time"),
-      JOB_COMMIT_TIME -> GpuMetric.createTimingMetric(GpuMetric.ESSENTIAL_LEVEL,
+      JOB_COMMIT_TIME -> GpuMetric.createTiming(GpuMetric.ESSENTIAL_LEVEL,
         "job commit time")
     )
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
 
+import com.nvidia.spark.rapids.GpuMetric
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
@@ -28,7 +29,7 @@ import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.WriteTaskStats
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SerializableConfiguration
@@ -52,7 +53,7 @@ case class BasicColumnarWriteTaskStats(
  */
 class BasicColumnarWriteTaskStatsTracker(
     hadoopConf: Configuration,
-    taskCommitTimeMetric: Option[SQLMetric])
+    taskCommitTimeMetric: Option[GpuMetric])
     extends ColumnarWriteTaskStatsTracker with Logging {
   private[this] var numPartitions: Int = 0
   private[this] var numFiles: Int = 0
@@ -184,13 +185,13 @@ class BasicColumnarWriteTaskStatsTracker(
  */
 class BasicColumnarWriteJobStatsTracker(
     serializableHadoopConf: SerializableConfiguration,
-    @transient val driverSideMetrics: Map[String, SQLMetric],
-    taskCommitTimeMetric: SQLMetric)
+    @transient val driverSideMetrics: Map[String, GpuMetric],
+    taskCommitTimeMetric: GpuMetric)
   extends ColumnarWriteJobStatsTracker {
 
   def this(
       serializableHadoopConf: SerializableConfiguration,
-      metrics: Map[String, SQLMetric]) = {
+      metrics: Map[String, GpuMetric]) = {
     this(serializableHadoopConf, metrics - TASK_COMMIT_TIME, metrics(TASK_COMMIT_TIME))
   }
 
@@ -221,7 +222,8 @@ class BasicColumnarWriteJobStatsTracker(
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.NUM_PARTS_KEY).add(numPartitions)
 
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, driverSideMetrics.values.toList)
+    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId,
+      GpuMetric.unwrap(driverSideMetrics).values.toList)
   }
 }
 
@@ -235,15 +237,20 @@ object BasicColumnarWriteJobStatsTracker {
   /** XAttr key of the data length header added in HADOOP-17414. */
   val FILE_LENGTH_XATTR = "header.x-hadoop-s3a-magic-data-length"
 
-  def metrics: Map[String, SQLMetric] = {
-    val sparkContext = SparkContext.getActive.get
+  def metrics: Map[String, GpuMetric] = {
     Map(
-      NUM_FILES_KEY -> SQLMetrics.createMetric(sparkContext, "number of written files"),
-      NUM_OUTPUT_BYTES_KEY -> SQLMetrics.createSizeMetric(sparkContext, "written output"),
-      NUM_OUTPUT_ROWS_KEY -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
-      NUM_PARTS_KEY -> SQLMetrics.createMetric(sparkContext, "number of dynamic part"),
-      TASK_COMMIT_TIME -> SQLMetrics.createTimingMetric(sparkContext, "task commit time"),
-      JOB_COMMIT_TIME -> SQLMetrics.createTimingMetric(sparkContext, "job commit time")
+      NUM_FILES_KEY -> GpuMetric.create(GpuMetric.ESSENTIAL_LEVEL,
+        "number of written files"),
+      NUM_OUTPUT_BYTES_KEY -> GpuMetric.createSizeMetric(GpuMetric.ESSENTIAL_LEVEL,
+        "written output"),
+      NUM_OUTPUT_ROWS_KEY -> GpuMetric.create(GpuMetric.ESSENTIAL_LEVEL,
+        "number of output rows"),
+      NUM_PARTS_KEY -> GpuMetric.create(GpuMetric.ESSENTIAL_LEVEL,
+        "number of dynamic part"),
+      TASK_COMMIT_TIME -> GpuMetric.createTimingMetric(GpuMetric.ESSENTIAL_LEVEL,
+        "task commit time"),
+      JOB_COMMIT_TIME -> GpuMetric.createTimingMetric(GpuMetric.ESSENTIAL_LEVEL,
+        "job commit time")
     )
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ abstract class GpuFileFormatDataWriter(
 
   protected final def writeUpdateMetricsAndClose(scb: SpillableColumnarBatch,
       writerStatus: WriterAndStatus): Unit = {
-    writerStatus.recordsInFile += writerStatus.writer.writeSpillableAndClose(scb, statsTrackers)
+    writerStatus.recordsInFile += writerStatus.writer.writeSpillableAndClose(scb)
   }
 
   /** Release all resources. Public for testing */
@@ -257,6 +257,7 @@ class GpuSingleDirectoryDataWriter(
       path = currentPath,
       dataSchema = description.dataColumns.toStructType,
       context = taskAttemptContext,
+      statsTrackers = statsTrackers,
       debugOutputPath = debugOutputPath)
 
     statsTrackers.foreach(_.newFile(currentPath))
@@ -599,6 +600,7 @@ class GpuDynamicPartitionDataSingleWriter(
       path = currentPath,
       dataSchema = description.dataColumns.toStructType,
       context = taskAttemptContext,
+      statsTrackers = statsTrackers,
       debugOutputPath = debugOutputPath)
 
     statsTrackers.foreach(_.newFile(currentPath))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,9 +190,10 @@ class GpuOrcFileFormat extends ColumnarFileFormat with Logging {
       override def newInstance(path: String,
                                dataSchema: StructType,
                                context: TaskAttemptContext,
+          statsTrackers: Seq[ColumnarWriteTaskStatsTracker],
                                debugOutputPath: Option[String]): ColumnarOutputWriter = {
-        new GpuOrcWriter(path, dataSchema, context, debugOutputPath, holdGpuBetweenBatches,
-          asyncOutputWriteEnabled)
+        new GpuOrcWriter(path, dataSchema, context, statsTrackers, debugOutputPath,
+          holdGpuBetweenBatches, asyncOutputWriteEnabled)
       }
 
       override def getFileExtension(context: TaskAttemptContext): String = {
@@ -215,10 +216,11 @@ class GpuOrcWriter(
     override val path: String,
     dataSchema: StructType,
     context: TaskAttemptContext,
+    statsTrackers: Seq[ColumnarWriteTaskStatsTracker],
     debugOutputPath: Option[String],
     holdGpuBetweenBatches: Boolean,
     useAsyncWrite: Boolean)
-  extends ColumnarOutputWriter(context, dataSchema, "ORC", true, debugOutputPath,
+  extends ColumnarOutputWriter(context, dataSchema, "ORC", true, statsTrackers, debugOutputPath,
     holdGpuBetweenBatches, useAsyncWrite) {
 
   override val tableWriter: TableWriter = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
@@ -81,17 +81,17 @@ object GpuWriteJobStatsTracker {
 
   def taskMetrics: Map[String, GpuMetric] = {
     Map(
-      GPU_TIME_KEY -> GpuMetric.createNanoTimingMetric(GpuMetric.ESSENTIAL_LEVEL, "GPU time"),
-      WRITE_TIME_KEY -> GpuMetric.createNanoTimingMetric(GpuMetric.ESSENTIAL_LEVEL,
+      GPU_TIME_KEY -> GpuMetric.createNanoTiming(GpuMetric.ESSENTIAL_LEVEL, "GPU time"),
+      WRITE_TIME_KEY -> GpuMetric.createNanoTiming(GpuMetric.ESSENTIAL_LEVEL,
         "write time"),
       TASK_COMMIT_TIME -> basicMetrics(TASK_COMMIT_TIME),
-      ASYNC_WRITE_TOTAL_THROTTLE_TIME_KEY -> GpuMetric.createNanoTimingMetric(
+      ASYNC_WRITE_TOTAL_THROTTLE_TIME_KEY -> GpuMetric.createNanoTiming(
         GpuMetric.DEBUG_LEVEL, "total throttle time"),
-      ASYNC_WRITE_AVG_THROTTLE_TIME_KEY -> GpuMetric.createNanoTimingMetric(
+      ASYNC_WRITE_AVG_THROTTLE_TIME_KEY -> GpuMetric.createNanoTiming(
         GpuMetric.DEBUG_LEVEL, "avg throttle time per async write"),
-      ASYNC_WRITE_MIN_THROTTLE_TIME_KEY -> GpuMetric.createNanoTimingMetric(
+      ASYNC_WRITE_MIN_THROTTLE_TIME_KEY -> GpuMetric.createNanoTiming(
         GpuMetric.DEBUG_LEVEL, "min throttle time per async write"),
-      ASYNC_WRITE_MAX_THROTTLE_TIME_KEY -> GpuMetric.createNanoTimingMetric(
+      ASYNC_WRITE_MAX_THROTTLE_TIME_KEY -> GpuMetric.createNanoTiming(
         GpuMetric.DEBUG_LEVEL, "max throttle time per async write")
     )
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
@@ -18,8 +18,8 @@ package org.apache.spark.sql.rapids
 
 import com.nvidia.spark.rapids.{GpuDataWritingCommand, GpuMetric, GpuMetricFactory, MetricsLevel, RapidsConf}
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.SparkContext
 
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker.TASK_COMMIT_TIME
 import org.apache.spark.util.SerializableConfiguration
 

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/execution/datasources/GpuWriteFiles.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/execution/datasources/GpuWriteFiles.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/execution/datasources/GpuWriteFiles.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/execution/datasources/GpuWriteFiles.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,8 +286,7 @@ object GpuFileFormatWriter extends Logging {
             committer,
             iterator = iter,
             concurrentOutputWriterSpec = concurrentOutputWriterSpec,
-            baseDebugOutputPath = baseDebugOutputPath
-          )
+            baseDebugOutputPath = baseDebugOutputPath)
         },
         rddWithNonEmptyPartitions.partitions.indices,
         (index, res: WriteTaskResult) => {

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,7 +286,8 @@ object GpuFileFormatWriter extends Logging {
             committer,
             iterator = iter,
             concurrentOutputWriterSpec = concurrentOutputWriterSpec,
-            baseDebugOutputPath = baseDebugOutputPath)
+            baseDebugOutputPath = baseDebugOutputPath
+          )
         },
         rddWithNonEmptyPartitions.partitions.indices,
         (index, res: WriteTaskResult) => {

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
     new AsyncOutputStream(() => {
       val file = File.createTempFile("async-write-test", "tmp")
       new BufferedOutputStream(new FileOutputStream(file))
-    }, trafficController)
+    }, trafficController, Seq.empty)
   }
 
   test("open, write, and close") {
@@ -108,7 +108,7 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test("write after error") {
-    val os = new AsyncOutputStream(() => new ThrowingOutputStream, trafficController)
+    val os = new AsyncOutputStream(() => new ThrowingOutputStream, trafficController, Seq.empty)
 
     // The first call to `write` should succeed
     os.write(buf)
@@ -134,7 +134,7 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test("flush after error") {
-    val os = new AsyncOutputStream(() => new ThrowingOutputStream, trafficController)
+    val os = new AsyncOutputStream(() => new ThrowingOutputStream, trafficController, Seq.empty)
 
     // The first write should succeed
     os.write(buf)
@@ -151,7 +151,7 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test("close after error") {
-    val os = new AsyncOutputStream(() => new ThrowingOutputStream, trafficController)
+    val os = new AsyncOutputStream(() => new ThrowingOutputStream, trafficController, Seq.empty)
 
     os.write(buf)
 

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,13 @@ package com.nvidia.spark.rapids.io.async
 
 import java.util.concurrent.{Callable, CountDownLatch, ExecutionException, Executors, Future, RejectedExecutionException, TimeUnit}
 
+import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.rapids.{GpuWriteJobStatsTracker, GpuWriteTaskStatsTracker}
 
 class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
 
@@ -30,6 +35,13 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
   var throttle: HostMemoryThrottle = _
   var trafficController: TrafficController = _
   var executor: ThrottlingExecutor = _
+
+  // Initialize SparkContext which is needed in GpuWriteJobStatsTracker.taskMetrics()
+  val sparkConf = new SparkConf()
+  sparkConf.set("spark.master", "local")
+  sparkConf.set("spark.app.name", "ThrottlingExecutorSuite")
+  SparkContext.getOrCreate(sparkConf)
+  val taskMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.taskMetrics
 
   class TestTask extends Callable[Unit] {
     val latch = new CountDownLatch(1)
@@ -43,7 +55,8 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
     trafficController = new TrafficController(throttle)
     executor = new ThrottlingExecutor(
       Executors.newSingleThreadExecutor(),
-      trafficController
+      trafficController,
+      Seq(new GpuWriteTaskStatsTracker(new Configuration(), taskMetrics))
     )
   }
 
@@ -141,5 +154,58 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
     assertCause(e1, classOf[InterruptedException])
     val e2 = intercept[ExecutionException](future2.get())
     assertCause(e2, classOf[RejectedExecutionException])
+  }
+
+  test("test task metrics") {
+    val exec = Executors.newSingleThreadExecutor()
+    // Run a task. Note that the first task never waits in ThrottlingExecutor.
+    var runningTask = new TestTask
+    exec.submit(new Runnable {
+      override def run(): Unit = executor.submit(runningTask, 100)
+    })
+    var taskCount = 1
+
+    for (i <- 0 to 9) {
+      val sleepTimeMs = (i + 1) * 10L
+      val waitingTask = new TestTask
+      // Latch indicating that the Runnable has been submitted.
+      val runnableSubmitted = new CountDownLatch(1)
+      // Latch indicating that waitingTask has been submitted to ThrottlingExecutor.
+      val waitingTaskSubmitted = new CountDownLatch(1)
+      exec.submit(new Runnable {
+        override def run(): Unit = {
+          runnableSubmitted.countDown()
+          executor.submit(waitingTask, 100)
+          waitingTaskSubmitted.countDown()
+        }
+      })
+      taskCount += 1
+      // Wait until the Runnable is submitted, and then sleep.
+      // This is to ensure that the waitingTask will wait for at least sleepTimeMs.
+      runnableSubmitted.await(longTimeoutSec, TimeUnit.SECONDS)
+      // Let the waitingTask wait for sleepTimeMs.
+      Thread.sleep(sleepTimeMs)
+      // Finish the running task.
+      runningTask.latch.countDown()
+      // Wait until the waitingTask is submitted.
+      waitingTaskSubmitted.await(longTimeoutSec, TimeUnit.SECONDS)
+      executor.updateMetrics()
+
+      // Skip the check on the min throttle time as the first task never waits.
+
+      assert(TimeUnit.MILLISECONDS.toNanos(sleepTimeMs) <=
+        taskMetrics(GpuWriteJobStatsTracker.ASYNC_WRITE_MAX_THROTTLE_TIME_KEY).value
+      )
+
+      runningTask = waitingTask
+    }
+
+    // Finish the last task.
+    runningTask.latch.countDown()
+
+    // Verify the average throttle time.
+    executor.updateMetrics()
+    assert(Seq.range(0, 10).sum * TimeUnit.MILLISECONDS.toNanos(10).toDouble / taskCount <=
+      taskMetrics(GpuWriteJobStatsTracker.ASYNC_WRITE_AVG_THROTTLE_TIME_KEY).value)
   }
 }

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.io.async
 
 import java.util.concurrent.{Callable, CountDownLatch, ExecutionException, Executors, Future, RejectedExecutionException, TimeUnit}
 
-import com.nvidia.spark.rapids.GpuMetric
+import com.nvidia.spark.rapids.{GpuMetric, RapidsConf}
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
@@ -40,7 +40,7 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
   SparkSession.builder
        .master("local")
        .appName("ThrottlingExecutorSuite")
-       .config("spark.rapids.sql.metrics.level", "DEBUG")
+       .config(RapidsConf.METRICS_LEVEL.key, "DEBUG")
        .getOrCreate()
 
   val taskMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.taskMetrics

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
@@ -18,12 +18,12 @@ package com.nvidia.spark.rapids.io.async
 
 import java.util.concurrent.{Callable, CountDownLatch, ExecutionException, Executors, Future, RejectedExecutionException, TimeUnit}
 
+import com.nvidia.spark.rapids.GpuMetric
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.rapids.{GpuWriteJobStatsTracker, GpuWriteTaskStatsTracker}
 
 class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
@@ -41,7 +41,7 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
   sparkConf.set("spark.master", "local")
   sparkConf.set("spark.app.name", "ThrottlingExecutorSuite")
   SparkContext.getOrCreate(sparkConf)
-  val taskMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.taskMetrics
+  val taskMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.taskMetrics
 
   class TestTask extends Callable[Unit] {
     val latch = new CountDownLatch(1)

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/ThrottlingExecutorSuite.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.rapids.{GpuWriteJobStatsTracker, GpuWriteTaskStatsTracker}
 
 class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
@@ -36,11 +36,13 @@ class ThrottlingExecutorSuite extends AnyFunSuite with BeforeAndAfterEach {
   var trafficController: TrafficController = _
   var executor: ThrottlingExecutor = _
 
-  // Initialize SparkContext which is needed in GpuWriteJobStatsTracker.taskMetrics()
-  val sparkConf = new SparkConf()
-  sparkConf.set("spark.master", "local")
-  sparkConf.set("spark.app.name", "ThrottlingExecutorSuite")
-  SparkContext.getOrCreate(sparkConf)
+  // Initialize SparkSession to initialize the GpuMetrics.
+  SparkSession.builder
+       .master("local")
+       .appName("ThrottlingExecutorSuite")
+       .config("spark.rapids.sql.metrics.level", "DEBUG")
+       .getOrCreate()
+
   val taskMetrics: Map[String, GpuMetric] = GpuWriteJobStatsTracker.taskMetrics
 
   class TestTask extends Callable[Unit] {


### PR DESCRIPTION
![Screenshot 2025-01-07 at 2 38 25 PM](https://github.com/user-attachments/assets/799bc726-b5c4-4e64-b38e-db30f69d9b4b)


The async write added in https://github.com/NVIDIA/spark-rapids/pull/11730 supports throttling based on the number in-flight bytes to write. Knowing how much time the query spends on waiting in the throttle would be useful to understand query performance. This PR adds these new metrics which are also seen in the screenshot above:

- total throttle time: total throttle time in a task
- avg/min/max throttle time per async write: average/min/max throttle time per async write request

The new metrics are added as debug metrics. To do so, The `create*Metrics()` in `GpuExec` has been moved to `GpuMetric` so that they can be used in other places than `GpuExec`. To put related things together, `GpuMetric` and `MetricsLevel` have been moved to a new `GpuMetrics.scala` file.