### PR TITLE
Support `raise_error()` on [databricks] 14.3, Spark 4.

### DIFF
--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
@@ -20,7 +20,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids.{ExprRule, GpuOverrides}
-import com.nvidia.spark.rapids.{ExprChecks, GpuExpression, TypeSig, BinaryExprMeta}
+import com.nvidia.spark.rapids.{BinaryExprMeta, ExprChecks, GpuExpression, TypeSig}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RaiseError}
 import org.apache.spark.sql.rapids.shims.GpuRaiseError

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
@@ -38,7 +38,7 @@ object RaiseErrorShim {
       ),
       (a, conf, p, r) => new BinaryExprMeta[RaiseError](a, conf, p, r) {
         override def convertToGpu(lhsErrorClass: Expression, rhsErrorParams: Expression)
-          : GpuExpression = GpuRaiseError(lhsErrorClass, rhsErrorParams)
+          : GpuExpression = GpuRaiseError(lhsErrorClass, rhsErrorParams, a.dataType)
       })).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
   }
 }

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
@@ -37,16 +37,16 @@ object RaiseErrorShim {
       (a, conf, p, r) => new BinaryExprMeta[RaiseError](a, conf, p, r) {
 
         override def tagExprForGpu(): Unit = {
-          // In Databricks 14.3 and Spark 4.0, RaiseError forwards the lhs expression (i.e. the error-class)
-          // as a scalar value.  A vector/column here would be surprising.
+          // In Databricks 14.3 and Spark 4.0, RaiseError forwards the lhs expression
+          // (i.e. the error-class) as a scalar value.  A vector/column here would be surprising.
           a.errorClass match {
             case _: Literal => // Supported.
             case _ => willNotWorkOnGpu(s"expected error-class to be a STRING literal")
           }
         }
 
-        override def convertToGpu(lhsErrorClass: Expression, rhsErrorParams: Expression): GpuExpression =
-          GpuRaiseError(lhsErrorClass, rhsErrorParams)
+        override def convertToGpu(lhsErrorClass: Expression, rhsErrorParams: Expression)
+          : GpuExpression = GpuRaiseError(lhsErrorClass, rhsErrorParams)
       })).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
   }
 }

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
@@ -20,10 +20,10 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids.{ExprRule, GpuOverrides}
-import com.nvidia.spark.rapids.{BinaryExprMeta, ExprChecks, GpuExpression, TypeEnum, TypeSig}
+import com.nvidia.spark.rapids.{ExprChecks, TypeEnum, TypeSig}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, RaiseError}
-import org.apache.spark.sql.rapids.shims.GpuRaiseError
+import org.apache.spark.sql.rapids.shims.RaiseErrorMeta
 
 object RaiseErrorShim {
   val exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
@@ -36,9 +36,7 @@ object RaiseErrorShim {
         ("errorClass", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING),
         ("errorParams", TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.STRING)),
       ),
-      (a, conf, p, r) => new BinaryExprMeta[RaiseError](a, conf, p, r) {
-        override def convertToGpu(lhsErrorClass: Expression, rhsErrorParams: Expression)
-          : GpuExpression = GpuRaiseError(lhsErrorClass, rhsErrorParams, a.dataType)
-      })).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
+      (a, conf, p, r) => new RaiseErrorMeta(a, conf, p, r)
+    )).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
   }
 }

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/RaiseErrorShim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,34 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.ExprRule
+import com.nvidia.spark.rapids.{ExprRule, GpuOverrides}
+import com.nvidia.spark.rapids.{ExprChecks, GpuExpression, TypeSig, BinaryExprMeta}
 
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RaiseError}
+import org.apache.spark.sql.rapids.shims.GpuRaiseError
 
 object RaiseErrorShim {
-  val exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Map.empty
+  val exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
+    Seq(GpuOverrides.expr[RaiseError](
+      "Throw an exception",
+      ExprChecks.binaryProject(
+        TypeSig.NULL, TypeSig.NULL,
+        ("errorClass", TypeSig.STRING, TypeSig.STRING),
+        ("errorParams", TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.STRING)),
+      ),
+      (a, conf, p, r) => new BinaryExprMeta[RaiseError](a, conf, p, r) {
+
+        override def tagExprForGpu(): Unit = {
+          // In Databricks 14.3 and Spark 4.0, RaiseError forwards the lhs expression (i.e. the error-class)
+          // as a scalar value.  A vector/column here would be surprising.
+          a.errorClass match {
+            case _: Literal => // Supported.
+            case _ => willNotWorkOnGpu(s"expected error-class to be a STRING literal")
+          }
+        }
+
+        override def convertToGpu(lhsErrorClass: Expression, rhsErrorParams: Expression): GpuExpression =
+          GpuRaiseError(lhsErrorClass, rhsErrorParams)
+      })).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
+  }
 }

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
@@ -20,7 +20,7 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, Scalar}
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuBinaryExpression, GpuMapUtils, GpuScalar}
+import com.nvidia.spark.rapids.{GpuBinaryExpression, GpuColumnVector, GpuMapUtils, GpuScalar}
 import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
@@ -75,8 +75,9 @@ case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryE
                             // All testing indicates a map with 1 entry.
     val mapSize = listOfStructs.getRowCount
 
-    if (mapSize > THRESHOLD)
+    if (mapSize > THRESHOLD) {
       throw new UnsupportedOperationException("Unexpectedly large error-parameter map")
+    }
 
     val outputKeys: Array[UTF8String] =
       withResource(GpuMapUtils.getKeysAsListView(listOfStructs)) { listOfKeys =>

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
@@ -31,11 +31,12 @@ import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Implements `raise_error()` for Databricks 14.3 and Spark 4.0.
- * Note that while the arity `raise_error()` remains 1 for all user-facing APIs (SQL, Scala, Python).
- * But internally, the implementation uses a binary expression, where the first argument indicates
- * the "error-class" for the error being raised.
+ * Note that while the arity `raise_error()` remains 1 for all user-facing APIs
+ * (SQL, Scala, Python). But internally, the implementation uses a binary expression,
+ * where the first argument indicates the "error-class" for the error being raised.
  */
-case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryExpression with ExpectsInputTypes {
+case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryExpression
+  with ExpectsInputTypes {
 
   val errorClass: Expression = left
   val errorParams: Expression = right
@@ -70,7 +71,8 @@ case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryE
   }
 
   private def makeMapData(listOfStructs: ColumnView): MapData = {
-    val THRESHOLD: Int = 10 // Avoiding surprises with large maps.  All testing indicates a map with 1 entry.
+    val THRESHOLD: Int = 10 // Avoiding surprises with large maps.
+                            // All testing indicates a map with 1 entry.
     val mapSize = listOfStructs.getRowCount
 
     if (mapSize > THRESHOLD)
@@ -96,7 +98,8 @@ case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryE
   override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
     if (rhs.getRowCount <= 0) {
       // For the case: when(condition, raise_error(col("a"))
-      // When `condition` selects no rows, a vector of nulls should be returned, instead of throwing.
+      // When `condition` selects no rows, a vector of nulls should be returned,
+      // instead of throwing.
       return GpuColumnVector.columnVectorFromNull(0, NullType)
     }
 
@@ -113,7 +116,8 @@ case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryE
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
       if (numRows <= 0) {
         // For the case: when(condition, raise_error(col("a"))
-        // When `condition` selects no rows, a vector of nulls should be returned, instead of throwing.
+        // When `condition` selects no rows, a vector of nulls should be returned,
+        // instead of throwing.
         return GpuColumnVector.columnVectorFromNull(0, NullType)
       }
 

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
@@ -35,13 +35,12 @@ import org.apache.spark.unsafe.types.UTF8String
  * (SQL, Scala, Python). But internally, the implementation uses a binary expression,
  * where the first argument indicates the "error-class" for the error being raised.
  */
-case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryExpression
-  with ExpectsInputTypes {
+case class GpuRaiseError(left: Expression, right: Expression, dataType: DataType)
+  extends GpuBinaryExpression with ExpectsInputTypes {
 
   val errorClass: Expression = left
   val errorParams: Expression = right
 
-  override def dataType: DataType = NullType
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
   override def toString: String = s"raise_error($errorClass, $errorParams)"
 

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "350db143"}
+{"spark": "400"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import ai.rapids.cudf.{ColumnVector, ColumnView, Scalar}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuBinaryExpression, GpuMapUtils, GpuScalar}
+import com.nvidia.spark.rapids.Arm.withResource
+
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, MapData}
+import org.apache.spark.sql.errors.QueryExecutionErrors.raiseError
+import org.apache.spark.sql.types.{AbstractDataType, DataType, NullType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * Implements `raise_error()` for Databricks 14.3 and Spark 4.0.
+ * Note that while the arity `raise_error()` remains 1 for all user-facing APIs (SQL, Scala, Python).
+ * But internally, the implementation uses a binary expression, where the first argument indicates
+ * the "error-class" for the error being raised.
+ */
+case class GpuRaiseError(left: Expression, right: Expression) extends GpuBinaryExpression with ExpectsInputTypes {
+
+  val errorClass: Expression = left
+  val errorParams: Expression = right
+
+  override def dataType: DataType = NullType
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
+  override def toString: String = s"raise_error($errorClass, $errorParams)"
+
+  /** Could evaluating this expression cause side-effects, such as throwing an exception? */
+  override def hasSideEffects: Boolean = true
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException("Expected errorClass (lhs) to be a String literal")
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector =
+    throw new UnsupportedOperationException("Expected errorClass (lhs) to be a String literal")
+
+  private def extractScalaUTF8String(stringScalar: Scalar): UTF8String = {
+    // This is guaranteed to be a string scalar.
+    GpuScalar.extract(stringScalar).asInstanceOf[UTF8String]
+  }
+
+  private def extractStrings(stringsColumn: ColumnView): Array[UTF8String] = {
+    val size = stringsColumn.getRowCount.asInstanceOf[Int] // Already checked if exceeds threshold.
+    val output: Array[UTF8String] = new Array[UTF8String](size)
+    for (i <- 0 until size) {
+      output(i) = withResource(stringsColumn.getScalarElement(i)) {
+        extractScalaUTF8String(_)
+      }
+    }
+    output
+  }
+
+  private def makeMapData(listOfStructs: ColumnView): MapData = {
+    val THRESHOLD: Int = 10 // Avoiding surprises with large maps.  All testing indicates a map with 1 entry.
+    val mapSize = listOfStructs.getRowCount
+
+    if (mapSize > THRESHOLD)
+      throw new UnsupportedOperationException("Unexpectedly large error-parameter map")
+
+    val outputKeys: Array[UTF8String] =
+      withResource(GpuMapUtils.getKeysAsListView(listOfStructs)) { listOfKeys =>
+        withResource(listOfKeys.getChildColumnView(0)) { // Strings child of LIST column.
+          extractStrings(_)
+        }
+      }
+
+    val outputVals: Array[UTF8String] =
+      withResource(GpuMapUtils.getValuesAsListView(listOfStructs)) { listOfVals =>
+        withResource(listOfVals.getChildColumnView(0)) { // Strings child of LIST column.
+          extractStrings(_)
+        }
+      }
+
+    ArrayBasedMapData(outputKeys, outputVals)
+  }
+
+  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
+    if (rhs.getRowCount <= 0) {
+      // For the case: when(condition, raise_error(col("a"))
+      // When `condition` selects no rows, a vector of nulls should be returned, instead of throwing.
+      return GpuColumnVector.columnVectorFromNull(0, NullType)
+    }
+
+    val lhsErrorClass = lhs.getValue.asInstanceOf[UTF8String]
+
+    val rhsMapData = withResource(rhs.getBase.slice(0,1)) { slices =>
+      val firstRhsRow = slices(0)
+      makeMapData(firstRhsRow)
+    }
+
+    throw raiseError(lhsErrorClass, rhsMapData)
+  }
+
+  override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
+      if (numRows <= 0) {
+        // For the case: when(condition, raise_error(col("a"))
+        // When `condition` selects no rows, a vector of nulls should be returned, instead of throwing.
+        return GpuColumnVector.columnVectorFromNull(0, NullType)
+      }
+
+      val errorClass = lhs.getValue.asInstanceOf[UTF8String]
+      val errorParams = rhs.getValue.asInstanceOf[MapData]
+      throw raiseError(errorClass, errorParams)
+  }
+}

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/sql/rapids/shims/misc.scala
@@ -122,6 +122,10 @@ case class GpuRaiseError(left: Expression, right: Expression, dataType: DataType
       }
 
       val errorClass = lhs.getValue.asInstanceOf[UTF8String]
+      // TODO (future):  Check if the map-data needs to be extracted differently.
+      // All testing indicates that the host value of the map literal is set always pre-set.
+      // But if it isn't, then GpuScalar.getValue might extract it incorrectly.
+      // https://github.com/NVIDIA/spark-rapids/issues/11974
       val errorParams = rhs.getValue.asInstanceOf[MapData]
       throw raiseError(errorClass, errorParams)
   }

--- a/tools/generated_files/400/operatorsScore.csv
+++ b/tools/generated_files/400/operatorsScore.csv
@@ -218,6 +218,7 @@ PythonUDAF,4
 PythonUDF,4
 Quarter,4
 RLike,4
+RaiseError,4
 Rand,4
 Rank,4
 RegExpExtract,4

--- a/tools/generated_files/400/supportedExprs.csv
+++ b/tools/generated_files/400/supportedExprs.csv
@@ -461,7 +461,7 @@ Quarter,S,`quarter`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RLike,S,`regexp_like`; `regexp`; `rlike`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RLike,S,`regexp_like`; `regexp`; `rlike`,None,project,regexp,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RLike,S,`regexp_like`; `regexp`; `rlike`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
-RaiseError,S, ,None,project,errorClass,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RaiseError,S, ,None,project,errorClass,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RaiseError,S, ,None,project,errorParams,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA
 RaiseError,S, ,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 Rand,S,`rand`; `random`,None,project,seed,NA,NA,NA,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tools/generated_files/400/supportedExprs.csv
+++ b/tools/generated_files/400/supportedExprs.csv
@@ -461,6 +461,9 @@ Quarter,S,`quarter`,None,project,result,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RLike,S,`regexp_like`; `regexp`; `rlike`,None,project,str,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RLike,S,`regexp_like`; `regexp`; `rlike`,None,project,regexp,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 RLike,S,`regexp_like`; `regexp`; `rlike`,None,project,result,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RaiseError,S, ,None,project,errorClass,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+RaiseError,S, ,None,project,errorParams,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA
+RaiseError,S, ,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA
 Rand,S,`rand`; `random`,None,project,seed,NA,NA,NA,S,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Rand,S,`rand`; `random`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Rank,S,`rank`,None,window,ordering,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,NS,NS,NS,NS,NS,NS


### PR DESCRIPTION
Fixes #10969.

This commit adds support for `raise_error()` on Databricks 14.3 and Spark 4.0.

On these new Spark versions, the `RaiseError` expression (that powers the `raise_error()` API function) was changed from a Unary expression to a Binary one.  This was done without modifying the arity of `raise_error()`.  The ostensible reason seems to have been to eventually allow user-code to raise custom errors via `raise_error()`.

This commit allows `raise_error()` to work on the GPU as it currently does on the CPU:  as a unary function powered by a binary expression in the background.

The tests have been modified to verify both the new behaviour and the legacy one on new platforms, while continuing to run as before on legacy platforms.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
