### PR TITLE
Minor change: Make Hybrid version a separate config like priviate repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,6 +842,7 @@
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>25.02.0-SNAPSHOT</spark-rapids-jni.version>
         <spark-rapids-private.version>25.02.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-hybrid.version>25.02.0-SNAPSHOT</spark-rapids-hybrid.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.12.15</scala.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -842,6 +842,7 @@
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>25.02.0-SNAPSHOT</spark-rapids-jni.version>
         <spark-rapids-private.version>25.02.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-hybrid.version>25.02.0-SNAPSHOT</spark-rapids-hybrid.version>
         <scala.binary.version>2.13</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.13.14</scala.version>

--- a/scala2.13/sql-plugin/pom.xml
+++ b/scala2.13/sql-plugin/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-hybrid_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
+            <version>${spark-rapids-hybrid.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-hybrid_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
+            <version>${spark-rapids-hybrid.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This is a follow-up PR for https://github.com/NVIDIA/spark-rapids/pull/11720, 
to fix the issue: https://github.com/NVIDIA/spark-rapids/issues/11975

Like spark-rapids-private repo, Hybrid has its own repo.
Like spark-rapids-private, define a config `spark-rapids-private.version` to switch version.
Hybrid also should have a similar config.  Release process require third-party jar has a version config.



Signed-off-by: Chong Gao <res_life@163.com>