### PR TITLE
Try to fix Scala 2.13 nightly failure: can not find version-def.sh

### DIFF
--- a/jenkins/hybrid_execution.sh
+++ b/jenkins/hybrid_execution.sh
@@ -17,7 +17,7 @@
 
 set -ex
 
-. jenkins/version-def.sh
+source "${WORKSPACE}/jenkins/version-def.sh"
 
 export GLUTEN_BUNDLE_JAR
 export HYBRID_JAR

--- a/jenkins/hybrid_execution.sh
+++ b/jenkins/hybrid_execution.sh
@@ -17,11 +17,8 @@
 
 set -ex
 
-source "${WORKSPACE}/jenkins/version-def.sh"
-
-export GLUTEN_BUNDLE_JAR
-export HYBRID_JAR
-export GLUTEN_THIRDPARTY_JAR
+# Explicitly export HYBRID_BACKEND_JARS for hybrid execution tests.
+export HYBRID_BACKEND_JARS
 
 hybrid_prepare(){
     echo "Checking hybrid exeicution tests environmet..."
@@ -41,10 +38,5 @@ hybrid_prepare(){
     wget -q -O /tmp/$GLUTEN_BUNDLE_JAR $URM_URL/com/nvidia/gluten-velox-bundle/$GLUTEN_VERSION/$GLUTEN_BUNDLE_JAR
     wget -q -O /tmp/$HYBRID_JAR $URM_URL/com/nvidia/rapids-4-spark-hybrid_${SCALA_BINARY_VER}/$PROJECT_VER/$HYBRID_JAR
     wget -q -O /tmp/$GLUTEN_THIRDPARTY_JAR  $URM_URL/com/nvidia/gluten-thirdparty-lib/$GLUTEN_VERSION/$GLUTEN_THIRDPARTY_JAR
-}
-
-hybrid_test() {
-    echo "Run hybrid execution tests..."
-    LOAD_HYBRID_BACKEND=1 HYBRID_BACKEND_JARS=/tmp/${HYBRID_JAR},/tmp/${GLUTEN_BUNDLE_JAR},/tmp/${GLUTEN_THIRDPARTY_JAR} \
-        integration_tests/run_pyspark_from_build.sh -m hybrid_test
+    HYBRID_BACKEND_JARS=/tmp/${HYBRID_JAR},/tmp/${GLUTEN_BUNDLE_JAR},/tmp/${GLUTEN_THIRDPARTY_JAR}
 }

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -113,7 +113,7 @@ mvn_verify() {
     # test Hybrid feature
     source "${WORKSPACE}/jenkins/hybrid_execution.sh"
     if hybrid_prepare ; then
-        hybrid_test
+        LOAD_HYBRID_BACKEND=1 ./integration_tests/run_pyspark_from_build.sh -m hybrid_test
     fi
 }
 

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -355,7 +355,7 @@ fi
 if [[ "$TEST_MODE" == "DEFAULT" || "$TEST_MODE" == "HYBRID_EXECUTION" ]]; then
   source "${WORKSPACE}/jenkins/hybrid_execution.sh"
   if hybrid_prepare ; then
-    hybrid_test
+    LOAD_HYBRID_BACKEND=1 ./run_pyspark_from_build.sh -m hybrid_test
   fi
 fi
 


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/11976

Seems the current directory in bash script is not the root of source,
use ${workspace} to locate the file

Signed-off-by: Chong Gao <res_life@163.com>

