### PR TITLE
Protect the batch read by a retry block in agg

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.GpuAggregateIterator.{computeAggregateAndClose, computeAggregateWithoutPreprocessAndClose, concatenateBatches}
+import com.nvidia.spark.rapids.GpuAggregateIterator.{computeAggregateAndClose, computeAggregateWithoutPreprocessAndClose, concatenateBatchesWithRetry}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.GpuOverrides.pluginSupportedOrderableSig
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -134,7 +134,7 @@ object AggregateUtils extends Logging {
    * @param batches batches to concatenate and merge aggregate
    * @return lazy spillable batch which has NOT been marked spillable
    */
-  def concatenateAndMerge(
+  def concatenateAndMergeWithRetry(
       batches: mutable.ArrayBuffer[SpillableColumnarBatch],
       metrics: GpuHashAggregateMetrics,
       concatAndMergeHelper: AggHelper): SpillableColumnarBatch = {
@@ -142,10 +142,8 @@ object AggregateUtils extends Logging {
     //   of batches for the partial aggregate case. This would be done in case
     //   a retry failed a certain number of times.
     val concatBatch = withResource(batches) { _ =>
-      val concatSpillable = concatenateBatches(metrics, batches.toSeq)
-      withResource(concatSpillable) {
-        _.getColumnarBatch()
-      }
+      val concatSpillable = concatenateBatchesWithRetry(metrics, batches.toSeq)
+      withRetryNoSplit(concatSpillable)(_.getColumnarBatch())
     }
     computeAggregateAndClose(metrics, concatBatch, concatAndMergeHelper)
   }
@@ -178,7 +176,7 @@ object AggregateUtils extends Logging {
                 aggregatedBatches.next
                 return nextBatch
               }
-              val merged = concatenateAndMerge(stagingBatches, metrics, helper)
+              val merged = concatenateAndMergeWithRetry(stagingBatches, metrics, helper)
               stagingBatches.clear
               currentSize = 0L
               if (merged.sizeInBytes < configuredTargetBatchSize * 0.5) {
@@ -197,7 +195,7 @@ object AggregateUtils extends Logging {
           if (stagingBatches.size == 1) {
             return stagingBatches.head
           }
-          concatenateAndMerge(stagingBatches, metrics, helper)
+          concatenateAndMergeWithRetry(stagingBatches, metrics, helper)
         }
         }
       }
@@ -237,11 +235,7 @@ object AggregateUtils extends Logging {
         NvtxColor.CYAN, metrics.repartitionTime)) { _ =>
 
         withResource(new GpuBatchSubPartitioner(
-          Seq(batch).map(batch => {
-            withResource(batch) { _ =>
-              batch.getColumnarBatch()
-            }
-          }).iterator,
+          Iterator(withRetryNoSplit(batch)(_.getColumnarBatch())),
           hashKeys, hashBucketNum, hashSeed, "aggRepartition")) {
           partitioner => {
             (0 until partitioner.partitionsCount).foreach { id =>
@@ -525,7 +519,7 @@ class AggHelper(
     // We need to merge the aggregated batches into 1 before calling post process,
     // if the aggregate code had to split on a retry
     if (aggregatedSeq.size > 1) {
-      val concatted = concatenateBatches(metrics, aggregatedSeq)
+      val concatted = concatenateBatchesWithRetry(metrics, aggregatedSeq)
       withRetryNoSplit(concatted) { attempt =>
         withResource(attempt.getColumnarBatch()) { cb =>
           SpillableColumnarBatch(
@@ -707,7 +701,7 @@ object GpuAggregateIterator extends Logging {
    * @param toConcat spillable batches to concatenate
    * @return concatenated batch result
    */
-  def concatenateBatches(
+  def concatenateBatchesWithRetry(
       metrics: GpuHashAggregateMetrics,
       toConcat: Seq[SpillableColumnarBatch]): SpillableColumnarBatch = {
     if (toConcat.size == 1) {
@@ -973,10 +967,9 @@ class GpuMergeAggregateIterator(
           return generateEmptyReductionBatch()
         } else {
           hasReductionOnlyBatch = false
-          val concat = AggregateUtils.concatenateAndMerge(batches, metrics, concatAndMergeHelper)
-          return withResource(concat) { cb =>
-            cb.getColumnarBatch()
-          }
+          val concat =
+            AggregateUtils.concatenateAndMergeWithRetry(batches, metrics, concatAndMergeHelper)
+          return withRetryNoSplit(concat)(_.getColumnarBatch())
         }
       }
 
@@ -1069,10 +1062,8 @@ class GpuMergeAggregateIterator(
           spillCbs += tmp
         }
 
-        val concat = GpuAggregateIterator.concatenateBatches(metrics, spillCbs.toSeq)
-        withResource(concat) { _ =>
-          concat.getColumnarBatch()
-        }
+        val concat = concatenateBatchesWithRetry(metrics, spillCbs.toSeq)
+        withRetryNoSplit(concat)(_.getColumnarBatch())
       }
     }
   }
@@ -1104,7 +1095,7 @@ class GpuMergeAggregateIterator(
                 }
               }
 
-              AggregateUtils.concatenateAndMerge(
+              AggregateUtils.concatenateAndMergeWithRetry(
                 toAggregateBuckets.flatMap(_.data), metrics, concatAndMergeHelper)
           }
         }


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/11979

This PR puts all the calls to `getColumnarBatch` in GPU aggregate into a retry block, along with renaming some methods to indicating they already support retry inside, don't call them inside a retry block.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
