### PR TITLE
Grab the GPU Semaphore when reading cached batch data with the GPU

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -487,6 +487,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
     val cbRdd: RDD[ColumnarBatch] = input.map {
       case parquetCB: ParquetCachedBatch if parquetCB.sizeInBytes == 0 =>
+        GpuSemaphore.acquireIfNecessary(TaskContext.get())
         // If the buffer is empty, we have cached a batch with no columns, we don't need to decode
         // it, instead just return a ColumnarBatch with only rows
         withResource(new GpuColumnarBatchBuilder(originalSelectedAttributes.toStructType,
@@ -494,6 +495,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
           builder => builder.build(parquetCB.numRows)
         }
       case parquetCB: ParquetCachedBatch =>
+        GpuSemaphore.acquireIfNecessary(TaskContext.get())
         val parquetOptions = ParquetOptions.builder()
             .includeColumn(selectedAttributes.map(_.name).asJavaCollection).build()
         val table = try {


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/11989
except for the retry which I will file a follow on issue for.

I want to spend a little more time to verify that it is doing the right thing in all cases, but I think this is right, and I will get the tests running while I dig into it more.