### PR TITLE
Removed the assumption if a plan is Columnar it probably is on the GPU [databricks]

### DIFF
--- a/integration_tests/src/main/python/datasourcev2_read_test.py
+++ b/integration_tests/src/main/python/datasourcev2_read_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,15 +26,17 @@ def readTable(types, classToUse):
         .format(classToUse).load()\
         .orderBy("col1")
 
+@allow_non_gpu('BatchScanExec')
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_int():
     assert_gpu_and_cpu_are_equal_collect(readTable("int", columnarClass))
 
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
-@allow_non_gpu(*non_utc_allow)
+@allow_non_gpu('BatchScanExec', *non_utc_allow)
 def test_read_strings():
     assert_gpu_and_cpu_are_equal_collect(readTable("string", columnarClass))
 
+@allow_non_gpu('BatchScanExec')
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_all_types():
     assert_gpu_and_cpu_are_equal_collect(
@@ -42,6 +44,7 @@ def test_read_all_types():
             conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
 
 
+@allow_non_gpu('BatchScanExec')
 @disable_ansi_mode  # Cannot run in ANSI mode until COUNT aggregation is supported.
                     # See https://github.com/NVIDIA/spark-rapids/issues/5114
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
@@ -51,6 +54,7 @@ def test_read_all_types_count():
             conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
 
 
+@allow_non_gpu('BatchScanExec')
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_arrow_off():
     assert_gpu_and_cpu_are_equal_collect(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1017,6 +1017,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
       val conf = new SparkConf()
         .set(RapidsConf.ENABLE_CAST_FLOAT_TO_DECIMAL.key, "true")
         .set("spark.rapids.sql.exec.FileSourceScanExec", "false")
+        .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "FileSourceScanExec")
         .set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")
         .set("spark.sql.ansi.enabled", ansiEnabled.toString)
 

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/ProjectExprSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/ProjectExprSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,6 +226,7 @@ class ProjectExprSuite extends SparkQueryCompareTestSuite {
       val fun = (df: DataFrame) => df.withColumn("dec", df("decimals")).select("dec")
       val conf = new SparkConf()
           .set("spark.rapids.sql.exec.FileSourceScanExec", "false")
+          .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "FileSourceScanExec")
       val (fromCpu, fromGpu) = runOnCpuAndGpu(createDF, fun, conf, repart = 0)
       compareResults(false, 0.0, fromCpu, fromGpu)
     } finally {


### PR DESCRIPTION
This PR fixes the piece of code where we decide if an Expression is on the GPU or not. 

fixes #12036 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
