### PR TITLE
Fixed `FileSourceScanExec` and `BatchScanExec` inadvertently falling to the CPU in non-utc orc tests 

### DIFF
--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ def test_casting_among_integer_types(spark_tmp_path, reader_confs, v1_enabled_li
         lambda spark: spark.read.schema(schema_str).orc(data_path),
         conf=all_confs)
 
-non_utc_allow_orc_scan=['ColumnarToRowExec', 'FileScan'] if is_not_utc() else []
+non_utc_allow_orc_scan=['ColumnarToRowExec', 'FileScan', 'FileSourceScanExec'] if is_not_utc() else []
 
 @pytest.mark.parametrize('to_type', ['float', 'double', 'string', 'timestamp'])
 @allow_non_gpu(*non_utc_allow_orc_scan)

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ reader_opt_confs = __reader_opt_confs_no_chunked + __reader_opt_confs_chunked
 # The Count result can not be sorted, so local sort can not be used.
 reader_opt_confs_for_count = __reader_opt_confs_common + [__multithreaded_orc_file_reader_combine_unordered_conf_no_chunked]
 
-non_utc_allow_orc_file_source_scan=['ColumnarToRowExec', 'FileSourceScanExec'] if is_not_utc() else []
+non_utc_allow_orc_file_source_scan=['ColumnarToRowExec', 'FileSourceScanExec', 'BatchScanExec'] if is_not_utc() else []
 
 @pytest.mark.parametrize('name', ['timestamp-date-test.orc'])
 @pytest.mark.parametrize('read_func', [read_orc_df, read_orc_sql])


### PR DESCRIPTION
After https://github.com/NVIDIA/spark-rapids/pull/12037 was merged, it did the right thing by ensuring that source scans are not allowed to fall back to the CPU unless we expect them to. Some non-UTC tests were falling back to the CPU without the test complaining, but now they are. 

This PR adds `FileSourceScanExec` and `BatchScanExec` to the allowNonGpu in `orc_test.py` and `orc_cast_test.py`

fixes #12046 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
