### PR TITLE
Relax decimal metadata checks for mismatched precision/scale [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -1506,6 +1506,11 @@ def test_parquet_check_schema_compatibility_nested_types(spark_tmp_path):
     (DecimalGen(5, 4), DecimalGen(7, 2)),
     (DecimalGen(10, 6), DecimalGen(12, 4)),
     (DecimalGen(20, 7), DecimalGen(22, 5)),
+    # Increasing the precision and keeping the scale same (increasing the whole number part)
+    (DecimalGen(10, 2), DecimalGen(22, 2)),
+    # Decreasing the scale and keeping the precision same (decreasing the whole number part)
+    (DecimalGen(10, 5), DecimalGen(10, 2)),
+    (DecimalGen(20, 10), DecimalGen(20, 5)),
     # Increasing precision by a smaller amount than scale
     (DecimalGen(5, 2), DecimalGen(6, 4)),
     (DecimalGen(10, 4), DecimalGen(12, 7))
@@ -1534,8 +1539,8 @@ def test_parquet_decimal_precision_scale_change(spark_tmp_path, from_decimal_gen
         # is ignored by the plugin.
         spark_conf['spark.sql.parquet.enableVectorizedReader'] = 'false'
 
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: spark.read.schema(read_schema).parquet(data_path), conf=spark_conf)
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema(read_schema).parquet(data_path), conf=spark_conf)
 
 
 @pytest.mark.skipif(is_before_spark_320() or is_spark_321cdh(), reason='Encryption is not supported before Spark 3.2.0 or Parquet < 1.12')

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1500,6 +1500,8 @@ def test_parquet_check_schema_compatibility_nested_types(spark_tmp_path):
     (DecimalGen(7, 4), DecimalGen(5, 2)),
     (DecimalGen(10, 7), DecimalGen(5, 2)),
     (DecimalGen(20, 17), DecimalGen(5, 2)),
+    # Narrowing precision
+    (DecimalGen(20, 0), DecimalGen(10, 0)),
     # Increasing precision and decreasing scale
     (DecimalGen(5, 4), DecimalGen(7, 2)),
     (DecimalGen(10, 6), DecimalGen(12, 4)),
@@ -1524,13 +1526,6 @@ def test_parquet_decimal_precision_scale_change(spark_tmp_path, from_decimal_gen
         StructField("a", to_decimal_gen.data_type)
     ])
 
-    # Determine if we expect an error based on precision and scale changes
-    expect_error = (
-            to_decimal_gen.scale < from_decimal_gen.scale or
-            (to_decimal_gen.precision - to_decimal_gen.scale) <
-            (from_decimal_gen.precision - from_decimal_gen.scale)
-    )
-
     spark_conf = {}
     if is_before_spark_400():
         # In Spark versions earlier than 4.0, the vectorized Parquet reader throws an exception
@@ -1539,17 +1534,8 @@ def test_parquet_decimal_precision_scale_change(spark_tmp_path, from_decimal_gen
         # is ignored by the plugin.
         spark_conf['spark.sql.parquet.enableVectorizedReader'] = 'false'
 
-    if expect_error:
-        assert_gpu_and_cpu_error(
-            lambda spark: spark.read.schema(read_schema).parquet(data_path).collect(),
-            conf={},
-            error_message="Parquet column cannot be converted"
-        )
-    else:
         assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: spark.read.schema(read_schema).parquet(data_path),
-            conf=spark_conf
-        )
+            lambda spark: spark.read.schema(read_schema).parquet(data_path), conf=spark_conf)
 
 
 @pytest.mark.skipif(is_before_spark_320() or is_spark_321cdh(), reason='Encryption is not supported before Spark 3.2.0 or Parquet < 1.12')

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1616,7 +1616,7 @@ object GpuCast {
     }
   }
 
-  private def castDecimalToDecimal(
+  def castDecimalToDecimal(
       input: ColumnView,
       from: DecimalType,
       to: DecimalType,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -690,18 +690,18 @@ private case class GpuParquetFileFilterHandler(
           case ParquetFooterReaderType.NATIVE =>
             val serialized = withResource(readAndFilterFooter(file, conf,
               readDataSchema, filePath)) { tableFooter =>
-               if (tableFooter.getNumColumns <= 0) {
-                 // Special case because java parquet reader does not like having 0 columns.
-                 val numRows = tableFooter.getNumRows
-                 val block = new BlockMetaData()
-                 block.setRowCount(numRows)
-                 val schema = new MessageType("root")
-                 return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
-                   schema, readDataSchema, DateTimeRebaseLegacy, DateTimeRebaseLegacy,
-                   hasInt96Timestamps = false)
-               }
+                if (tableFooter.getNumColumns <= 0) {
+                  // Special case because java parquet reader does not like having 0 columns.
+                  val numRows = tableFooter.getNumRows
+                  val block = new BlockMetaData()
+                  block.setRowCount(numRows)
+                  val schema = new MessageType("root")
+                  return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
+                    schema, readDataSchema, DateTimeRebaseLegacy, DateTimeRebaseLegacy,
+                    hasInt96Timestamps = false)
+                }
 
-               tableFooter.serializeThriftFile()
+                tableFooter.serializeThriftFile()
             }
             withResource(serialized) { serialized =>
               withResource(new NvtxRange("readFilteredFooter", NvtxColor.YELLOW)) { _ =>
@@ -1032,8 +1032,8 @@ private case class GpuParquetFileFilterHandler(
   @scala.annotation.nowarn("msg=method getDecimalMetadata in class PrimitiveType is deprecated")
   private def canReadAsDecimal(pt: PrimitiveType, dt: DataType): Boolean = {
     (DecimalType.is32BitDecimalType(dt)
-        || DecimalType.is64BitDecimalType(dt)
-        || DecimalType.isByteArrayDecimalType(dt)) && isValidDecimalType(pt.getDecimalMetadata)
+      || DecimalType.is64BitDecimalType(dt)
+      || DecimalType.isByteArrayDecimalType(dt)) && isValidDecimalType(pt.getDecimalMetadata)
   }
 
   // TODO: After we deprecate Spark 3.1, fetch decimal meta with DecimalLogicalTypeAnnotation

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -470,9 +470,9 @@ private case class GpuParquetFileFilterHandler(
 
   private def isParquetTimeInInt96(parquetType: Type): Boolean = {
     parquetType match {
-      case p:PrimitiveType =>
+      case p: PrimitiveType =>
         p.getPrimitiveTypeName == PrimitiveTypeName.INT96
-      case g:GroupType => //GroupType
+      case g: GroupType => //GroupType
         g.getFields.asScala.exists(t => isParquetTimeInInt96(t))
       case _ => false
     }
@@ -539,7 +539,7 @@ private case class GpuParquetFileFilterHandler(
       filePath: Path,
       conf: Configuration): HostMemoryBuffer = {
     PerfIO.readParquetFooterBuffer(filePath, conf, verifyParquetMagic)
-      .getOrElse(readFooterBufUsingHadoop(filePath, conf))
+        .getOrElse(readFooterBufUsingHadoop(filePath, conf))
   }
 
   private def readFooterBufUsingHadoop(filePath: Path, conf: Configuration): HostMemoryBuffer = {
@@ -563,7 +563,7 @@ private case class GpuParquetFileFilterHandler(
         verifyParquetMagic(filePath, magic)
         if (footerIndex < MAGIC.length || footerIndex >= footerLengthIndex) {
           throw new RuntimeException(s"corrupted file: the footer index is not within " +
-            s"the file: $footerIndex")
+              s"the file: $footerIndex")
         }
         val hmbLength = (fileLen - footerIndex).toInt
         closeOnExcept(HostMemoryBuffer.allocate(hmbLength + MAGIC.length, false)) { outBuffer =>
@@ -590,19 +590,19 @@ private case class GpuParquetFileFilterHandler(
     if (!util.Arrays.equals(MAGIC, magic)) {
       if (util.Arrays.equals(PARQUET_MAGIC_ENCRYPTED, magic)) {
         throw new RuntimeException("The GPU does not support reading encrypted Parquet " +
-          "files. To read encrypted or columnar encrypted files, disable the GPU Parquet " +
-          s"reader via ${RapidsConf.ENABLE_PARQUET_READ.key}.")
+            "files. To read encrypted or columnar encrypted files, disable the GPU Parquet " +
+            s"reader via ${RapidsConf.ENABLE_PARQUET_READ.key}.")
       } else {
         throw new RuntimeException(s"$filePath is not a Parquet file. " +
-          s"Expected magic number at tail ${util.Arrays.toString(MAGIC)} " +
-          s"but found ${util.Arrays.toString(magic)}")
+            s"Expected magic number at tail ${util.Arrays.toString(MAGIC)} " +
+            s"but found ${util.Arrays.toString(magic)}")
       }
     }
   }
 
   private def readAndFilterFooter(
       file: PartitionedFile,
-      conf : Configuration,
+      conf: Configuration,
       readDataSchema: StructType,
       filePath: Path): ParquetFooter = {
     val footerSchema = convertToFooterSchema(readDataSchema)
@@ -626,7 +626,7 @@ private case class GpuParquetFileFilterHandler(
   )
   private def readAndSimpleFilterFooter(
       file: PartitionedFile,
-      conf : Configuration,
+      conf: Configuration,
       filePath: Path): ParquetMetadata = {
     //noinspection ScalaDeprecation
     withResource(new NvtxRange("readFooter", NvtxColor.YELLOW)) { _ =>
@@ -690,18 +690,18 @@ private case class GpuParquetFileFilterHandler(
           case ParquetFooterReaderType.NATIVE =>
             val serialized = withResource(readAndFilterFooter(file, conf,
               readDataSchema, filePath)) { tableFooter =>
-                if (tableFooter.getNumColumns <= 0) {
-                  // Special case because java parquet reader does not like having 0 columns.
-                  val numRows = tableFooter.getNumRows
-                  val block = new BlockMetaData()
-                  block.setRowCount(numRows)
-                  val schema = new MessageType("root")
-                  return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
-                    schema, readDataSchema, DateTimeRebaseLegacy, DateTimeRebaseLegacy,
-                    hasInt96Timestamps = false)
-                }
+              if (tableFooter.getNumColumns <= 0) {
+                // Special case because java parquet reader does not like having 0 columns.
+                val numRows = tableFooter.getNumRows
+                val block = new BlockMetaData()
+                block.setRowCount(numRows)
+                val schema = new MessageType("root")
+                return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
+                  schema, readDataSchema, DateTimeRebaseLegacy, DateTimeRebaseLegacy,
+                  hasInt96Timestamps = false)
+              }
 
-                tableFooter.serializeThriftFile()
+              tableFooter.serializeThriftFile()
             }
             withResource(serialized) { serialized =>
               withResource(new NvtxRange("readFilteredFooter", NvtxColor.YELLOW)) { _ =>
@@ -717,8 +717,8 @@ private case class GpuParquetFileFilterHandler(
       } catch {
         case e if GpuParquetCrypto.isColumnarCryptoException(e) =>
           throw new RuntimeException("The GPU does not support reading encrypted Parquet " +
-            "files. To read encrypted or columnar encrypted files, disable the GPU Parquet " +
-            s"reader via ${RapidsConf.ENABLE_PARQUET_READ.key}.", e)
+              "files. To read encrypted or columnar encrypted files, disable the GPU Parquet " +
+              s"reader via ${RapidsConf.ENABLE_PARQUET_READ.key}.", e)
       }
 
       val fileSchema = footer.getFileMetaData.getSchema
@@ -763,9 +763,9 @@ private case class GpuParquetFileFilterHandler(
         }
       val hasDateTimeInReadSchema = DataTypeUtils.hasDateOrTimestampType(readDataSchema)
       val dateRebaseModeForThisFile = DateTimeRebaseUtils.datetimeRebaseMode(
-          footer.getFileMetaData.getKeyValueMetaData.get,
-          datetimeRebaseMode,
-          hasDateTimeInReadSchema)
+        footer.getFileMetaData.getKeyValueMetaData.get,
+        datetimeRebaseMode,
+        hasDateTimeInReadSchema)
       val hasInt96Timestamps = isParquetTimeInInt96(fileSchema)
       val timestampRebaseModeForThisFile = if (hasInt96Timestamps) {
         DateTimeRebaseUtils.int96RebaseMode(
@@ -789,36 +789,37 @@ private case class GpuParquetFileFilterHandler(
    * The function only accepts top-level schemas, which means structures of root columns. Based
    * on this assumption, it can infer root types from input schemas.
    *
-   * @param fileType input file's Parquet schema
-   * @param readType spark type read from Parquet file
+   * @param fileType      input file's Parquet schema
+   * @param readType      spark type read from Parquet file
    * @param errorCallback call back function to throw exception if type mismatch
-   * @param rootFileType file type of each root column
-   * @param rootReadType read type of each root column
+   * @param rootFileType  file type of each root column
+   * @param rootReadType  read type of each root column
    */
   private def checkSchemaCompat(fileType: Type,
-                                readType: DataType,
-                                errorCallback: (Type, DataType) => Unit,
-                                isCaseSensitive: Boolean,
-                                useFieldId: Boolean,
-                                rootFileType: Option[Type] = None,
-                                rootReadType: Option[DataType] = None): Unit = {
+      readType: DataType,
+      errorCallback: (Type, DataType) => Unit,
+      isCaseSensitive: Boolean,
+      useFieldId: Boolean,
+      rootFileType: Option[Type] = None,
+      rootReadType: Option[DataType] = None): Unit = {
     readType match {
       case struct: StructType =>
         val fileFieldMap = fileType.asGroupType().getFields.asScala
-          .map { f =>
-            (if (isCaseSensitive) f.getName else f.getName.toLowerCase(Locale.ROOT)) -> f
-          }.toMap
+            .map { f =>
+              (if (isCaseSensitive) f.getName else f.getName.toLowerCase(Locale.ROOT)) -> f
+            }.toMap
 
         val fieldIdToFieldMap = ParquetSchemaClipShims.fieldIdToFieldMap(useFieldId, fileType)
 
         def getParquetType(f: StructField): Option[Type] = {
-          if(useFieldId && ParquetSchemaClipShims.hasFieldId(f)) {
+          if (useFieldId && ParquetSchemaClipShims.hasFieldId(f)) {
             // use field ID and Spark schema specified field ID
             fieldIdToFieldMap.get(ParquetSchemaClipShims.getFieldId(f))
           } else {
             fileFieldMap.get(if (isCaseSensitive) f.name else f.name.toLowerCase(Locale.ROOT))
           }
         }
+
         struct.fields.foreach { f =>
           getParquetType(f).foreach { fieldType =>
             checkSchemaCompat(fieldType,
@@ -946,15 +947,15 @@ private case class GpuParquetFileFilterHandler(
    */
   @scala.annotation.nowarn("msg=method getDecimalMetadata in class PrimitiveType is deprecated")
   private def checkPrimitiveCompat(pt: PrimitiveType,
-                                   dt: DataType,
-                                   errorCallback: () => Unit): Unit = {
+      dt: DataType,
+      errorCallback: () => Unit): Unit = {
     pt.getPrimitiveTypeName match {
       case PrimitiveTypeName.BOOLEAN if dt == DataTypes.BooleanType =>
         return
 
       case PrimitiveTypeName.INT32 =>
         if (dt == DataTypes.IntegerType || GpuTypeShims.isSupportedYearMonthType(dt)
-          || canReadAsDecimal(pt, dt)) {
+            || canReadAsDecimal(pt, dt)) {
           // Year-month interval type is stored as int32 in parquet
           return
         }
@@ -962,14 +963,14 @@ private case class GpuParquetFileFilterHandler(
         if (dt == DataTypes.LongType && pt.getOriginalType == OriginalType.UINT_32) {
           return
         }
-         if (dt == DataTypes.ByteType || dt == DataTypes.ShortType || dt == DataTypes.DateType) {
-           return
-         }
+        if (dt == DataTypes.ByteType || dt == DataTypes.ShortType || dt == DataTypes.DateType) {
+          return
+        }
 
       case PrimitiveTypeName.INT64 =>
         if (dt == DataTypes.LongType || GpuTypeShims.isSupportedDayTimeType(dt) ||
             // Day-time interval type is stored as int64 in parquet
-          canReadAsDecimal(pt, dt)) {
+            canReadAsDecimal(pt, dt)) {
           return
         }
         // TODO: After we deprecate Spark 3.1, replace OriginalType with LogicalTypeAnnotation
@@ -977,7 +978,7 @@ private case class GpuParquetFileFilterHandler(
           return
         }
         if (pt.getOriginalType == OriginalType.TIMESTAMP_MICROS ||
-          pt.getOriginalType == OriginalType.TIMESTAMP_MILLIS) {
+            pt.getOriginalType == OriginalType.TIMESTAMP_MILLIS) {
           return
         }
 
@@ -1007,8 +1008,8 @@ private case class GpuParquetFileFilterHandler(
   }
 
   private def throwTypeIncompatibleError(parquetType: Type,
-                                         sparkType: DataType,
-                                         filePath: String): Unit = {
+      sparkType: DataType,
+      filePath: String): Unit = {
     val exception = new SchemaColumnConvertNotSupportedException(
       parquetType.getName,
       parquetType.toString,
@@ -1017,8 +1018,8 @@ private case class GpuParquetFileFilterHandler(
     // A copy of QueryExecutionErrors.unsupportedSchemaColumnConvertError introduced in 3.2+
     // TODO: replace with unsupportedSchemaColumnConvertError after we deprecate Spark 3.1
     val message = "Parquet column cannot be converted in " +
-      s"file $filePath. Column: ${parquetType.getName}, " +
-      s"Expected: ${sparkType.catalogString}, Found: $parquetType"
+        s"file $filePath. Column: ${parquetType.getName}, " +
+        s"Expected: ${sparkType.catalogString}, Found: $parquetType"
     throw new QueryExecutionException(message, exception)
   }
 
@@ -1032,22 +1033,14 @@ private case class GpuParquetFileFilterHandler(
   @scala.annotation.nowarn("msg=method getDecimalMetadata in class PrimitiveType is deprecated")
   private def canReadAsDecimal(pt: PrimitiveType, dt: DataType): Boolean = {
     (DecimalType.is32BitDecimalType(dt)
-      || DecimalType.is64BitDecimalType(dt)
-      || DecimalType.isByteArrayDecimalType(dt)) && isDecimalTypeMatched(pt.getDecimalMetadata, dt)
+        || DecimalType.is64BitDecimalType(dt)
+        || DecimalType.isByteArrayDecimalType(dt)) && isValidDecimalType(pt.getDecimalMetadata)
   }
 
   // TODO: After we deprecate Spark 3.1, fetch decimal meta with DecimalLogicalTypeAnnotation
   @scala.annotation.nowarn("msg=class DecimalMetadata in package schema is deprecated")
-  private def isDecimalTypeMatched(metadata: DecimalMetadata,
-                                   sparkType: DataType): Boolean = {
-    if (metadata == null) {
-      false
-    } else {
-      val dt = sparkType.asInstanceOf[DecimalType]
-      val scaleIncrease = dt.scale - metadata.getScale
-      val precisionIncrease = dt.precision - metadata.getPrecision
-      scaleIncrease >= 0 && precisionIncrease >= scaleIncrease
-    }
+  private def isValidDecimalType(metadata: DecimalMetadata): Boolean = {
+    metadata != null
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -576,7 +576,10 @@ object ParquetSchemaUtils {
   private def evolveSchemaCasts(cv: ColumnView, dt: DataType, originalFromDt: DataType)
   : ColumnView = {
     if (needDecimalCast(cv, dt)) {
-      cv.castTo(DecimalUtil.createCudfDecimal(dt.asInstanceOf[DecimalType]))
+      val fromDecimal = originalFromDt.asInstanceOf[DecimalType]
+      val toDecimal = dt.asInstanceOf[DecimalType]
+      val ansiMode = CastOptions.DEFAULT_CAST_OPTIONS.isAnsiMode
+      GpuCast.castDecimalToDecimal(cv, fromDecimal, toDecimal, ansiMode)
     } else if (needUnsignedToSignedCast(cv, dt) || needInt32Downcast(cv, dt) ||
         needSignedUpcast(cv, dt)) {
       cv.castTo(DType.create(GpuColumnVector.getNonNestedRapidsType(dt).getTypeId))

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -85,7 +85,7 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("unannotated array of struct with unannotated array", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11476"))
   enableSuite[RapidsParquetQuerySuite]
     .exclude("SPARK-26677: negated null-safe equality comparison should not filter matched row groups", ADJUST_UT("fetches the CPU version of Execution Plan instead of the GPU version."))
-    .exclude("SPARK-34212 Parquet should read decimals correctly", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11433"))
+    .exclude("SPARK-34212 Parquet should read decimals correctly", ADJUST_UT("Vectorized Parquet reader throws an exception when scale is narrowed in Apache Spark where as the spark-rapids plugin does not."))
   enableSuite[RapidsParquetRebaseDatetimeSuite]
     .exclude("SPARK-31159, SPARK-37705: compatibility with Spark 2.4/3.2 in reading dates/timestamps", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11599"))
     .exclude("SPARK-31159, SPARK-37705: rebasing timestamps in write", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11593"))


### PR DESCRIPTION
This PR fixes https://github.com/NVIDIA/spark-rapids/issues/11433 .

This PR makes the GPU Parquet reader more flexible when handling files whose decimal columns have a different precision/scale than Spark’s requested schema. Previously, the plugin’s code would fail early (“Parquet column cannot be converted”) if the file declared, for example, DECIMAL(20, 0) but Spark asked for DECIMAL(10, 0) or DECIMAL(5, 1). Now we defer these mismatches to be resolved with optional half-up rounding or overflow handling trying to match standard Spark behavior.

In this PR, we make castDecimalToDecimal as public function. In `evolveSchemaCasts`, we pass the from and to DecimalTypes to cast the decimals to the required form. castDecimalToDecimal will handle the case of widening the scale/precisions or narrowing of scale/precisions.

Updated the current integration tests. 
In Spark-UT we are disabling the test as the Apache Spark vectorized path throws error where as the spark-rapids implementation produces the correct results.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
