### PR TITLE
Do not build Spark-4.0.0-SNAPSHOT [skip ci]

### DIFF
--- a/build/get_buildvers.py
+++ b/build/get_buildvers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ def _get_buildvers(buildvers, pom_file, logger=None):
 
     for release in releases:
         spark_version = pom.find(".//pom:spark{}.version".format(release), ns)
+        if spark_version is None:
+            continue
         if spark_version.text.endswith("SNAPSHOT"):
             snapshots.append(release)
         else:

--- a/pom.xml
+++ b/pom.xml
@@ -974,8 +974,8 @@
         <jdk17.buildvers>
         </jdk17.buildvers>
         <jdk17.scala213.buildvers>
-            330,
-            400
+            330
+            <!-- 400 -->
         </jdk17.scala213.buildvers>
         <shimplify.shims/>
         <cpd.sourceType>main</cpd.sourceType>

--- a/pom.xml
+++ b/pom.xml
@@ -915,7 +915,7 @@
         <spark352.version>3.5.2</spark352.version>
         <spark353.version>3.5.3</spark353.version>
         <spark354.version>3.5.4</spark354.version>
-        <!--spark400.version>4.0.0-SNAPSHOT</spark400.version -->
+        <!-- spark400.version>4.0.0-SNAPSHOT</spark400.version -->
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
         <scala.plugin.version>4.9.1</scala.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -915,7 +915,7 @@
         <spark352.version>3.5.2</spark352.version>
         <spark353.version>3.5.3</spark353.version>
         <spark354.version>3.5.4</spark354.version>
-        <spark400.version>4.0.0-SNAPSHOT</spark400.version>
+        <!--spark400.version>4.0.0-SNAPSHOT</ispark400.version -->
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
         <scala.plugin.version>4.9.1</scala.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -915,7 +915,7 @@
         <spark352.version>3.5.2</spark352.version>
         <spark353.version>3.5.3</spark353.version>
         <spark354.version>3.5.4</spark354.version>
-        <!--spark400.version>4.0.0-SNAPSHOT</ispark400.version -->
+        <!--spark400.version>4.0.0-SNAPSHOT</spark400.version -->
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
         <scala.plugin.version>4.9.1</scala.plugin.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -915,7 +915,7 @@
         <spark352.version>3.5.2</spark352.version>
         <spark353.version>3.5.3</spark353.version>
         <spark354.version>3.5.4</spark354.version>
-        <spark400.version>4.0.0-SNAPSHOT</spark400.version>
+        <!-- spark400.version>4.0.0-SNAPSHOT</spark400.version -->
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
         <scala.plugin.version>4.9.1</scala.plugin.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -974,8 +974,8 @@
         <jdk17.buildvers>
         </jdk17.buildvers>
         <jdk17.scala213.buildvers>
-            330,
-            400
+            330
+            <!-- 400 -->
         </jdk17.scala213.buildvers>
         <shimplify.shims/>
         <cpd.sourceType>main</cpd.sourceType>


### PR DESCRIPTION
This PR to stop building SPARK-4.0.0-SNAPSHOT in pre-merge and nightlies.
A massive change went in Spark-4.0- https://github.com/apache/spark/pull/49713 recently which breaks the builds and causes jenkins jobs failure.
We stop building it temporarily until we fix the issue.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
