### PR TITLE
Quick fix for hybrid tests without git information.

### DIFF
--- a/jenkins/hybrid_execution.sh
+++ b/jenkins/hybrid_execution.sh
@@ -32,9 +32,8 @@ hybrid_prepare(){
     fi
 
     echo "Downloading hybrid execution dependency jars..."
-    project_root=$(git rev-parse --show-toplevel)
-    # This script may run outside the project root path, so we use mvn -f $project_root to target the project's pom.xml
-    RAPIDS_HYBRID_VER=${RAPIDS_HYBRID_VER:-$(mvn -f $project_root -B -q help:evaluate -Dexpression=spark-rapids-hybrid.version -DforceStdout)}
+    # This script may run outside the project root path, so we use mvn -f $WORKSPACE to target the project's pom.xml
+    RAPIDS_HYBRID_VER=${RAPIDS_HYBRID_VER:-$(mvn -f $WORKSPACE -B -q help:evaluate -Dexpression=spark-rapids-hybrid.version -DforceStdout)}
     RAPIDS_HYBRID_URL=${RAPIDS_HYBRID_URL:-$URM_URL}
     GLUTEN_BUNDLE_JAR="gluten-velox-bundle-${GLUTEN_VERSION}-spark${spark_prefix}_${SCALA_BINARY_VER}-${os_version}_${cup_arch}.jar"
     HYBRID_JAR="rapids-4-spark-hybrid_${SCALA_BINARY_VER}-${RAPIDS_HYBRID_VER}.jar"


### PR DESCRIPTION
For some tests in CI/CD, we only need to download specific test files and do not need to clone the entire Git repository.

As a result, we cannot retrieve the project root directory using Git commands.

So we use the $WORKSPACE(always pointing to the root dir of the project) instead of the Git top-level path.

To fix below error:
```
 Downloading hybrid execution dependency jars...
 ++ git rev-parse --show-toplevel
 fatal: not a git repository (or any parent up to mount point /home/jenkins)
 Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
 + project_root=
 ++ mvn -f -B -q help:evaluate -Dexpression=spark-rapids-hybrid.version -DforceStdout
 POM file -B specified with the -f/--file command line argument does not exist
```