### PR TITLE
Revert "Enable event log for qualification & profiling tools testing …

### DIFF
--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -74,10 +74,6 @@ IS_SPARK_321_OR_LATER=0
 # --packages in distributed setups, should be fixed by
 # https://github.com/NVIDIA/spark-rapids/pull/5646
 
-# Enable event log for qualification & profiling tools testing
-export PYSP_TEST_spark_eventLog_enabled=true
-mkdir -p /tmp/spark-events
-
 export PYSP_TEST_spark_rapids_shims_spark350db143_enabled=${PYSP_TEST_spark_rapids_shims_spark350db143_enabled:-true}
 
 rapids_shuffle_smoke_test() {


### PR DESCRIPTION
This reverts #4217 commit b18492ecee96144c5fcbbea2cac8f5f4bebbb996.

#4217 was turning on event logging which was already on by default. #4217 overrode xdist-aware setting of event log locations, and causes the hang

Fixes #12096 

Downstream steps in pipelines need to collect event logs under all eventlog_gw[0-9] paths 

```
$ find ./integration_tests/target/run_dir-20250211100159-C4VO -name \*zstd
./integration_tests/target/run_dir-20250211100159-C4VO/eventlog_gw3/eventlog_v2_local-1739268134946/events_1_local-1739268134946.zstd
./integration_tests/target/run_dir-20250211100159-C4VO/eventlog_gw0/eventlog_v2_local-1739268134579/events_1_local-1739268134579.zstd
./integration_tests/target/run_dir-20250211100159-C4VO/eventlog_gw2/eventlog_v2_local-1739268134806/events_1_local-1739268134806.zstd
./integration_tests/target/run_dir-20250211100159-C4VO/eventlog_gw1/eventlog_v2_local-1739268134420/events_1_local-1739268134420.zstd
```