### PR TITLE
HybridParquetScan: Fix velox runtime error in hybrid scan when filter timestamp

### DIFF
--- a/integration_tests/src/main/python/hybrid_parquet_test.py
+++ b/integration_tests/src/main/python/hybrid_parquet_test.py
@@ -228,6 +228,9 @@ def test_hybrid_parquet_filter_pushdown_unsupported(spark_tmp_path):
         lambda spark: spark.read.parquet(data_path).filter("ascii(a) >= 50 and udf_fallback(a) = 'udf_100'"),
         conf=filter_split_conf)
 
+@pytest.mark.skipif(is_databricks_runtime(), reason="Hybrid feature does not support Databricks currently")
+@pytest.mark.skipif(not is_hybrid_backend_loaded(), reason="HybridScan specialized tests")
+@hybrid_test
 @allow_non_gpu(*non_utc_allow)
 def test_hybrid_parquet_filter_pushdown_timestamp(spark_tmp_path):
     data_path = spark_tmp_path + '/PARQUET_DATA'

--- a/integration_tests/src/main/python/hybrid_parquet_test.py
+++ b/integration_tests/src/main/python/hybrid_parquet_test.py
@@ -159,8 +159,8 @@ filter_split_conf = {
 def check_filter_pushdown(plan, pushed_exprs, not_pushed_exprs):
     plan = str(plan)
     filter_part, scan_part = plan.split("Scan parquet")
-    # for expr in pushed_exprs:
-    #     assert expr in scan_part
+    for expr in pushed_exprs:
+        assert expr in scan_part
     for expr in not_pushed_exprs:
         assert expr in filter_part
 

--- a/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
@@ -318,8 +318,13 @@ object HybridExecutionUtils extends PredicateHelper {
     }
   }
 
+  def isTimestampCondition(expr: Expression): Boolean = {
+    expr.references.exists(attr => attr.dataType == TimestampType)
+  }
+
   def isExprSupportedByHybridScan(condition: Expression, whitelistExprsName: String): Boolean = {
     condition match {
+      case filter if isTimestampCondition(filter) => false // Timestamp is not fully supported in Hybrid Filter
       case filter if HybridExecutionUtils.supportedByHybridFilters(whitelistExprsName)
           .exists(_.isInstance(filter)) =>
         val childrenSupported = filter.children.forall(


### PR DESCRIPTION
Fix #12111 

Timestamp is not fully supported in Hybrid Filter, so conditions with Timestamp should not pushed to Hybrid Scan in filter splitter.

This pr fixes it.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
