### PR TITLE
Fix HybridParquetScan over select(1)

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
@@ -55,7 +55,9 @@ object HybridExecutionUtils extends PredicateHelper {
       false
     }
     // Currently, only support reading Parquet
-    lazy val isParquet = fsse.relation.fileFormat.getClass == classOf[ParquetFileFormat]
+    val isParquet = fsse.relation.fileFormat.getClass == classOf[ParquetFileFormat]
+    // Fallback to GpuScan over the `select count(1)` cases
+    val nonEmptySchema = fsse.output.nonEmpty && fsse.requiredSchema.nonEmpty
     // Check if data types of all fields are supported by HybridParquetReader
     lazy val allSupportedTypes = !fsse.requiredSchema.exists { field =>
       TrampolineUtil.dataTypeExistsRecursively(field.dataType, {
@@ -78,7 +80,7 @@ object HybridExecutionUtils extends PredicateHelper {
     // TODO: supports BucketedScan
     lazy val noBucketedScan = !fsse.bucketedScan
 
-    isEnabled && isParquet && allSupportedTypes && noBucketedScan
+    isEnabled && isParquet && nonEmptySchema && allSupportedTypes && noBucketedScan
   }
 
   /**


### PR DESCRIPTION
Fix #12113

This fixes the issue by not using the HybridParquetScan when the schema is empty