### PR TITLE
Add the pre-split support to GPU project

### DIFF
--- a/integration_tests/src/main/python/project_presplit_test.py
+++ b/integration_tests/src/main/python/project_presplit_test.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_gpu_and_cpu_are_equal_collect
+from data_gen import *
+from src.main.python.marks import ignore_order
+
+_presplit_conf = {'spark.rapids.sql.test.overrides.splitUntilSize': 10}
+
+@ignore_order(local=True)
+def test_project_create_array():
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: two_col_df(spark, int_gen, string_gen).selectExpr(
+            "array(a, 1)", "array(b, 's1')"),
+        _presplit_conf)
+
+@ignore_order(local=True)
+def test_project_create_struct():
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: two_col_df(spark, int_gen, string_gen).selectExpr(
+            "struct(a, b, 1, 's1')"),
+        _presplit_conf)
+
+@ignore_order(local=True)
+def test_project_create_map():
+    nonull_string_gen = StringGen(nullable=False)
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: two_col_df(spark, int_gen, nonull_string_gen).selectExpr(
+            "map(b, a, 's1', 1)"),
+        _presplit_conf)
+
+

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBatchUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBatchUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,8 @@ object GpuBatchUtils {
   /**
    * Get the minimum size a column could be that matches these conditions.
    */
-  def minGpuMemory(dataType:DataType, nullable: Boolean, rowCount: Long): Long = {
+  def minGpuMemory(dataType:DataType, nullable: Boolean, rowCount: Long,
+      includeOffset: Boolean = true): Long = {
     val validityBufferSize = if (nullable) {
       calculateValidityBufferSize(rowCount)
     } else {
@@ -82,10 +83,10 @@ object GpuBatchUtils {
         // For nested types (like list or string) the smallest possible size is when
         // each row is empty (length 0). In that case there is no data, just offsets
         // and all of the offsets are 0.
-        calculateOffsetBufferSize(rowCount)
+        if (includeOffset) calculateOffsetBufferSize(rowCount) else 0L
       case dt: StructType =>
         dt.fields.map { f =>
-          minGpuMemory(f.dataType, f.nullable, rowCount)
+          minGpuMemory(f.dataType, f.nullable, rowCount, includeOffset)
         }.sum
       case dt =>
         dt.defaultSize * rowCount

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, RangePartitioning, SinglePartition, UnknownPartitioning}
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SampleExec, SparkPlan}
-import org.apache.spark.sql.rapids.{GpuPartitionwiseSampledRDD, GpuPoissonSampler}
+import org.apache.spark.sql.rapids.{GpuCreateArray, GpuCreateMap, GpuCreateNamedStruct, GpuPartitionwiseSampledRDD, GpuPoissonSampler}
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
@@ -238,12 +238,10 @@ trait GpuProjectExecLike extends ShimUnaryExecNode with GpuExec {
  * very special cases. If the projected size of the output is so large that it would
  * risk us not being able to split it later on if we ran into trouble.
  * @param iter the input iterator of columnar batches.
- * @param schema the schema of that input so we can make things spillable if needed
  * @param opTime metric for how long this took
  * @param numSplitsMetric metric for the number of splits that happened.
  */
 abstract class AbstractProjectSplitIterator(iter: Iterator[ColumnarBatch],
-    schema: Array[DataType],
     opTime: GpuMetric,
     numSplitsMetric: GpuMetric) extends Iterator[ColumnarBatch] {
   private[this] val pending = new scala.collection.mutable.Queue[SpillableColumnarBatch]()
@@ -275,6 +273,7 @@ abstract class AbstractProjectSplitIterator(iter: Iterator[ColumnarBatch],
             "About to perform cuDF table operations with a rows-only batch.")
           numSplitsMetric += numSplits - 1
           val sb = SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+          val schema = sb.dataTypes
           val tables = withRetryNoSplit(sb) { sb =>
             withResource(sb.getColumnarBatch()) { cb =>
               withResource(GpuColumnVector.from(cb)) { table =>
@@ -302,49 +301,164 @@ abstract class AbstractProjectSplitIterator(iter: Iterator[ColumnarBatch],
 }
 
 object PreProjectSplitIterator {
+
+  def getSplitUntilSize: Long = GpuDeviceManager.getSplitUntilSize
+
   def calcMinOutputSize(cb: ColumnarBatch, boundExprs: GpuTieredProject): Long = {
-    val numRows = cb.numRows()
-    boundExprs.outputTypes.zipWithIndex.map {
-      case (dataType, index) =>
-        if (GpuBatchUtils.isFixedWidth(dataType)) {
-          GpuBatchUtils.minGpuMemory(dataType, true, numRows)
-        } else {
-          boundExprs.getPassThroughIndex(index).map { inputIndex =>
-            cb.column(inputIndex).asInstanceOf[GpuColumnVector].getBase.getDeviceMemorySize
-          }.orElse {
-            // A literal has an exact size that should be taken into account.
-            extractGpuLit(boundExprs.exprTiers.last(index)).map { gpuLit =>
-              calcSizeForLiteral(gpuLit.value, gpuLit.dataType, numRows)
-            }
+    new PreSplitOutSizeEstimator(cb, boundExprs).calcMinOutputSize
+  }
+
+  class PreSplitOutSizeEstimator(cb: ColumnarBatch, tieredProject: GpuTieredProject) {
+    assert(cb != null, "The input batch should not be null.")
+
+    def calcMinOutputSize: Long = {
+      val rows = cb.numRows()
+      tieredProject.outputExprs.map(oe =>
+        estimateExprMinSize(oe, rows, oe.nullable, Some(1))
+      ).sum
+    }
+
+    /**
+     * Estimate the size for a given expression and number of rows after a project.
+     *
+     * For some expressions of complex type, each is a union of the child columns, and its
+     * size will be the sum of its children sizes. So need to dig into its children. Now
+     * it covers only GpuCreateNamedStruct, GpuCreateNamedStruct and GpuCreateMap.
+     */
+    private def estimateExprMinSize(expr: Expression, rowsNum: Int, nullable: Boolean,
+        exprAmount: Option[Int]): Long = {
+      expr match {
+        case GpuAlias(child, _) => // Alias should be ignored
+          estimateExprMinSize(child, rowsNum, child.nullable, exprAmount)
+        case gcs: GpuCreateNamedStruct =>
+          // nullable is always false here, so no meta size is needed.
+          gcs.valExprs.map(e => estimateExprMinSize(e, rowsNum, e.nullable, exprAmount)).sum
+        case gcm: GpuCreateMap =>
+          // Map is list of struct(key, value) in cuDF, so first a offset for the top list.
+          // While CreateMap is not nullable, so no validity size.
+          //    total_size = meta_size + sum_of_children_sizes
+          val metaSize = computeMetaSize(false, true, rowsNum, exprAmount)
+          metaSize + Seq(gcm.keys, gcm.values).map { keysOrValues =>
+            val entryNullable = keysOrValues.exists(_.nullable)
+            var includeMeta = true
+            keysOrValues.map { kOrV =>
+              // Need to go through the children to accumulate the data size, but only
+              // let the first child to include the offset and/or validity size. Because
+              // all the key (or values) columns will be concatenated into one column.
+              val childAmount = if (includeMeta) Some(keysOrValues.length) else None
+              includeMeta = false
+              estimateExprMinSize(kOrV, rowsNum, entryNullable, childAmount)
+            }.sum
+          }.sum
+        case gca: GpuCreateArray =>
+          // Similar as GpuCreateMap, but with only one children set, while Map has two,
+          // keys and values.
+          val metaSize = computeMetaSize(false, true, rowsNum, exprAmount)
+          val elemNullable = gca.children.exists(_.nullable)
+          var includeMeta = true
+          metaSize + gca.children.map { elem =>
+            val childAmount = if (includeMeta) Some(gca.children.length) else None
+            includeMeta = false
+            estimateExprMinSize(elem, rowsNum, elemNullable, childAmount)
+          }.sum
+        case glit: GpuLiteral =>
+          calcSizeForLiteral(glit.value, glit.dataType, rowsNum, nullable, exprAmount)
+        case otherExpr => // other cases
+          val exprType = otherExpr.dataType
+          // Get the actual size if it is just a pass-through column
+          tieredProject.getPassThroughIndex(otherExpr).map { colId =>
+            getColumnSize(cb.column(colId).asInstanceOf[GpuColumnVector].getBase,
+              exprType, nullable, exprAmount)
           }.getOrElse {
-            GpuBatchUtils.minGpuMemory(dataType, true, numRows)
+            // minGpuMemory is not suitable for the meta size calculation here, so do it
+            // separately.
+            computeMetaSize(nullable, hasOffset(exprType), rowsNum, exprAmount) +
+              GpuBatchUtils.minGpuMemory(exprType, false, rowsNum, false)
+          }
+      }
+    }
+  }
+
+  private def computeMetaSize(hasNull: Boolean, hasOffset: Boolean, rowsNum: Int,
+      amountOpt: Option[Int]): Long = {
+    // Compute the meta size only when amountOpt is defined. This is designed for
+    // the case when calculating the size of a child of a complex type expression.
+    // e.g. GpuCreateArray. There may be multiple children in it, but meta size can
+    // be added only once for all the children. The parent expression will control
+    // which child will take this job.
+    amountOpt.map { amount =>
+      computeMetaSize(hasNull, hasOffset, amount * rowsNum)
+    }.getOrElse(0L)
+  }
+
+  private def computeMetaSize(hasNull: Boolean, hasOffset: Boolean, rowsNum: Int): Long = {
+    var metaSize = 0L
+    if (hasNull) {
+      metaSize += GpuBatchUtils.calculateValidityBufferSize(rowsNum)
+    }
+    if (hasOffset) {
+      metaSize += GpuBatchUtils.calculateOffsetBufferSize(rowsNum)
+    }
+    metaSize
+  }
+
+  private def getColumnSize(col: ColumnView, colType: DataType, nullable: Boolean,
+      colAmount: Option[Int]): Long = {
+    var colSize = 0L
+    // data size
+    if (col.getData != null) {
+      colSize += col.getData.getLength
+    } else if (colType.isInstanceOf[BinaryType]) {
+      // Binary is list of byte in cudf, so take care of it specially for data size.
+      withResource(col.getChildColumnView(0)) { dataView =>
+        if (dataView.getData != null) {
+          colSize += dataView.getData.getLength
+        }
+      }
+    }
+    // meta size
+    colSize += computeMetaSize(nullable, hasOffset(colType), col.getRowCount.toInt, colAmount)
+
+    // 3) sum of children sizes
+    // Leverage the Spark type to get the nullability info for children. Because
+    // it may be in one of the child of a complex type expression.
+    colSize += (colType match {
+      case ArrayType(elemType, hasNulElem) =>
+        withResource(col.getChildColumnView(0))( elemCol =>
+          getColumnSize(elemCol, elemType, hasNulElem, colAmount)
+        )
+      case StructType(fields) =>
+        assert(fields.length == col.getNumChildren,
+          "Fields number and children number don't match")
+        fields.zipWithIndex.map { case (f, idx) =>
+          withResource(col.getChildColumnView(idx)) { fCol =>
+            getColumnSize(fCol, f.dataType, f.nullable, colAmount)
+          }
+        }.sum
+      case MapType(keyType, valueType, hasNullValue) =>
+        withResource(col.getChildColumnView(0)) { structView =>
+          withResource(structView.getChildColumnView(0)) { keyView =>
+            getColumnSize(keyView, keyType, false, colAmount)
+          } + withResource(structView.getChildColumnView(1)) { valueView =>
+            getColumnSize(valueView, valueType, hasNullValue, colAmount)
           }
         }
-    }.sum
+      case _ => 0L
+    })
+    colSize
   }
 
-  @scala.annotation.tailrec
-  def extractGpuLit(exp: Expression): Option[GpuLiteral] = exp match {
-    case gl: GpuLiteral => Some(gl)
-    case ga: GpuAlias => extractGpuLit(ga.child)
-    case _ => None
-  }
-
-  private[rapids] def calcSizeForLiteral(litVal: Any, litType: DataType, numRows: Int): Long = {
+  private[rapids] def calcSizeForLiteral(litVal: Any, litType: DataType, valueRows: Int,
+      nullable: Boolean, litAmount: Option[Int]): Long = {
     // First calculate the meta buffers size
-    val metaSize = new LitMetaCollector(litVal, litType).collect.map { litMeta =>
-      val expandedRowsNum = litMeta.getRowsNum * numRows
-      var totalSize = 0L
-      if (litMeta.hasNull) {
-        totalSize += GpuBatchUtils.calculateValidityBufferSize(expandedRowsNum)
-      }
-      if (litMeta.hasOffset) {
-        totalSize += GpuBatchUtils.calculateOffsetBufferSize(expandedRowsNum)
-      }
-      totalSize
-    }.sum
+    val metaSize = litAmount.map { amount =>
+      val metaRows = valueRows * amount
+      new LitMetaCollector(litVal, litType, nullable).collect.map { litMeta =>
+        computeMetaSize(litMeta.hasNull, litMeta.hasOffset, litMeta.getRowsNum * metaRows)
+      }.sum
+    }.getOrElse(0L)
     // finalSize = oneLitValueSize * numRows + metadata size
-    calcLitValueSize(litVal, litType) * numRows + metaSize
+    calcLitValueSize(litVal, litType) * valueRows + metaSize
   }
 
   /**
@@ -352,26 +466,26 @@ object PreProjectSplitIterator {
    * which will be used to calculate the final metadata size after expanding
    * this literal to a column.
    */
-  private class LitMeta(val hasNull: Boolean, val hasOffset: Boolean) {
+  private class LitMeta(val hasNull: Boolean, val hasOffset: Boolean, name: String = "") {
     private var rowsNum: Int = 0
     def incRowsNum(rows: Int = 1): Unit = rowsNum += rows
     def getRowsNum: Int = rowsNum
 
     override def toString: String =
-      s"LitMeta{rowsNum: $rowsNum, hasNull: $hasNull, hasOffset: $hasOffset}"
+      s"LitMeta-$name{rowsNum: $rowsNum, hasNull: $hasNull, hasOffset: $hasOffset}"
   }
 
   /**
    * Collect the metadata information of a literal, the result also includes
    * its children for a nested type literal.
    */
-  private class LitMetaCollector(litValue: Any, litType: DataType) {
+  private class LitMetaCollector(litValue: Any, litType: DataType, nullable: Boolean) {
     private var collected = false
     private val metaInfos: ArrayBuffer[LitMeta] = ArrayBuffer.empty
 
     def collect: Seq[LitMeta] = {
       if (!collected) {
-        executeCollect(litValue, litType, litValue == null, 0)
+        executeCollect(litValue, litType, nullable, 0)
         collected = true
       }
       metaInfos.filter(_ != null).toSeq
@@ -491,23 +605,21 @@ object PreProjectSplitIterator {
  * places and not everywhere.  In the future this could be extended, but if we do that there
  * are some places where we don't want a split, like a project before a window operation.
  * @param iter the input iterator of columnar batches.
- * @param schema the schema of that input so we can make things spillable if needed
  * @param boundExprs the bound project so we can get a good idea of the output size.
  * @param opTime metric for how long this took
  * @param numSplits the number of splits that happened.
  */
 class PreProjectSplitIterator(
     iter: Iterator[ColumnarBatch],
-    schema: Array[DataType],
     boundExprs: GpuTieredProject,
     opTime: GpuMetric,
-    numSplits: GpuMetric) extends AbstractProjectSplitIterator(iter, schema, opTime, numSplits) {
+    numSplits: GpuMetric) extends AbstractProjectSplitIterator(iter, opTime, numSplits) {
 
   // We memoize this parameter here as the value doesn't change during the execution
   // of a SQL query. This is the highest level we can cache at without getting it
   // passed in from the Exec that instantiates this split iterator.
   // NOTE: this is overwritten by tests to trigger various corner cases
-  private lazy val splitUntilSize: Double = GpuDeviceManager.getSplitUntilSize.toDouble
+  private lazy val splitUntilSize: Double = PreProjectSplitIterator.getSplitUntilSize.toDouble
 
   /**
    * calcNumSplit will return the number of splits that we need for the input, in the case
@@ -539,31 +651,53 @@ case class GpuProjectExec(
    // serde: https://github.com/scala/scala/blob/2.12.x/src/library/scala/collection/
    //   immutable/List.scala#L516
    projectList: List[NamedExpression],
-   child: SparkPlan) extends GpuProjectExecLike {
+   child: SparkPlan,
+   enablePreSplit: Boolean = true) extends GpuProjectExecLike {
 
   override def output: Seq[Attribute] = projectList.map(_.toAttribute)
 
+  override def outputBatching: CoalesceGoal = if (enablePreSplit) {
+    // Pre-split will make sure the size of each output batch will not be larger
+    // than the splitUntilSize.
+    TargetSize(PreProjectSplitIterator.getSplitUntilSize)
+  } else {
+    super.outputBatching
+  }
+
+  private val NUM_PRE_SPLIT = "NUM_PRE_SPLITS"
+
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
+    NUM_PRE_SPLIT -> createMetric(DEBUG_LEVEL, "num pre-splits"),
     OP_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME))
 
   override def internalDoExecuteColumnar() : RDD[ColumnarBatch] = {
     val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
     val numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES)
     val opTime = gpuLongMetric(OP_TIME)
+    val numPreSplit = gpuLongMetric(NUM_PRE_SPLIT)
     val boundProjectList = GpuBindReferences.bindGpuReferencesTiered(projectList, child.output,
       conf)
+    val localEnablePreSplit = enablePreSplit
 
     val rdd = child.executeColumnar()
-    rdd.map { cb =>
-      val ret = withResource(new NvtxWithMetrics("ProjectExec", NvtxColor.CYAN, opTime)) { _ =>
-        val sb = SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-        //Note if this ever changes to include splitting the output we need to have an option to not
-        // do this for window to work properly.
-        boundProjectList.projectAndCloseWithRetrySingleBatch(sb)
+    rdd.mapPartitions { iter =>
+      val maybeSplitIter = if (localEnablePreSplit) {
+        new PreProjectSplitIterator(iter, boundProjectList, opTime, numPreSplit)
+      } else {
+        iter
       }
-      numOutputBatches += 1
-      numOutputRows += ret.numRows()
-      ret
+      maybeSplitIter.map { split =>
+        val ret = withResource(new NvtxWithMetrics("ProjectExec", NvtxColor.CYAN, opTime)) { _ =>
+          val sb = SpillableColumnarBatch(split, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+          // Note if this ever changes to include splitting the output we need to
+          // have an option to not do this for window to work properly.
+          // [Update 2024/12/24: "localEnablePreSplit" is introduced for this goal]
+          boundProjectList.projectAndCloseWithRetrySingleBatch(sb)
+        }
+        numOutputBatches += 1
+        numOutputRows += ret.numRows()
+        ret
+      }
     }
   }
 }
@@ -694,13 +828,12 @@ case class GpuProjectAstExec(
 
   lazy val retryables: Seq[Retryable] = exprTiers.flatMap(GpuExpressionsUtils.collectRetryables)
 
-  lazy val outputTypes = exprTiers.last.map(_.dataType).toArray
+  lazy val outputExprs = exprTiers.last.toArray
 
   private[this] def getPassThroughIndex(tierIndex: Int,
-      expr: Expression,
-      exprIndex: Int): Option[Int] = expr match {
+      expr: Expression): Option[Int] = expr match {
     case GpuAlias(child, _) =>
-      getPassThroughIndex(tierIndex, child, exprIndex)
+      getPassThroughIndex(tierIndex, child)
     case GpuBoundReference(index, _, _) =>
       if (tierIndex <= 0) {
         // We are at the input tier so the bound attribute is good!!!
@@ -709,7 +842,7 @@ case class GpuProjectAstExec(
         // Not at the input yet
         val newTier = tierIndex - 1
         val newExpr = exprTiers(newTier)(index)
-        getPassThroughIndex(newTier, newExpr, index)
+        getPassThroughIndex(newTier, newExpr)
       }
     case _ =>
       None
@@ -722,8 +855,19 @@ case class GpuProjectAstExec(
    * @return the index of the input column that it passes through to or else None
    */
   def getPassThroughIndex(index: Int): Option[Int] = {
+    getPassThroughIndex(exprTiers.last(index))
+  }
+
+  /**
+   * Similar as "getPassThroughIndex(index: Int)", but with a given expression.
+   * The input expression is always a child of an output expression of complex type,
+   * or the output itself. e.g. GpuCreateArray, GpuCreateMap, GpuCreateStruct.
+   *
+   * Designed for the output size estimation by the pre-split iterator.
+   */
+  private[rapids] def getPassThroughIndex(expr: Expression): Option[Int] = {
     val startTier = exprTiers.length - 1
-    getPassThroughIndex(startTier, exprTiers.last(index), index)
+    getPassThroughIndex(startTier, expr)
   }
 
   private [this] def projectWithRetrySingleBatchInternal(sb: SpillableColumnarBatch,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
@@ -142,7 +142,7 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
     }
 
     val input = if (isPreNeeded) {
-      GpuProjectExec(pre.toList, childPlans.head.convertIfNeeded())
+      GpuProjectExec(pre.toList, childPlans.head.convertIfNeeded(), false)
     } else {
       childPlans.head.convertIfNeeded()
     }
@@ -165,9 +165,9 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
     }
 
     if (isPostNeeded) {
-      GpuProjectExec(post.toList, windowExpr)
+      GpuProjectExec(post.toList, windowExpr, false)
     } else if (windowExpr.output != windowExec.output) {
-      GpuProjectExec(windowExec.output.toList, windowExpr)
+      GpuProjectExec(windowExec.output.toList, windowExpr, false)
     } else {
       windowExpr
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/ComplexCreatorSizeEstimationTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/ComplexCreatorSizeEstimationTest.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.unit
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.{GpuBoundReference, GpuColumnVector, GpuExpression, GpuLiteral, GpuProjectExec, GpuTieredProject, GpuUnitTests, PreProjectSplitIterator}
+import com.nvidia.spark.rapids.Arm.withResource
+
+import org.apache.spark.sql.catalyst.expressions.ExprId
+import org.apache.spark.sql.rapids.{GpuCreateArray, GpuCreateMap, GpuCreateNamedStruct}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * These tests cover only 3 complex type creators for the size estimation in
+ * PreProjectSplitIterator. They are
+ *     "CreateArray", "CreateMap", "CreateNamedStruct"
+ */
+class ComplexCreatorSizeEstimationTest extends GpuUnitTests {
+
+  private val intColBound = GpuBoundReference(0, IntegerType, true)(ExprId(0), "int")
+  private val strColBound = GpuBoundReference(1, StringType, true)(ExprId(1), "string")
+  private val strNoNullColBound = GpuBoundReference(2, StringType, false)(ExprId(1), "string")
+
+  private def inputBatch(): ColumnarBatch = {
+    val intCol = GpuColumnVector.from(
+      ColumnVector.fromBoxedInts(1, 2, null, 3, 4), IntegerType)
+    val strCol = GpuColumnVector.from(
+      ColumnVector.fromStrings(null, "", "s1", "s2", "s3"), StringType)
+    val strNoNullCol = GpuColumnVector.from(
+      ColumnVector.fromStrings("k1", "k2", "k3", "k4", "k5"), StringType)
+    new ColumnarBatch(Array(intCol, strCol, strNoNullCol), 5)
+  }
+
+  private def testExprsSizeEstimate(boundList: Seq[GpuExpression]): Unit = {
+    withResource(inputBatch()) { inCb =>
+      val actualSize = withResource(GpuProjectExec.project(inCb, boundList)) { proCb =>
+        GpuColumnVector.getTotalDeviceMemoryUsed(proCb)
+      }
+      val estimatedSize = PreProjectSplitIterator.calcMinOutputSize(inCb,
+        GpuTieredProject(Seq(boundList)))
+      assertResult(actualSize)(estimatedSize)
+    }
+  }
+
+  test("estimate CreateArray(int, 1) size") {
+    val projections = Seq(
+      GpuCreateArray(Seq(intColBound, GpuLiteral(1)), true)
+    )
+    testExprsSizeEstimate(projections)
+  }
+
+  test("estimate CreateArray(string, 's1') size") {
+    val projections = Seq(
+      GpuCreateArray(Seq(strColBound, GpuLiteral("s1")), true)
+    )
+    testExprsSizeEstimate(projections)
+  }
+
+  test("estimate CreateNamedStruct(string, 's1', int, 1) size") {
+    val projections = Seq(
+      GpuCreateNamedStruct(Seq(
+        GpuLiteral("_c1"), strColBound,
+        GpuLiteral("_c2"), GpuLiteral("s1"),
+        GpuLiteral("_c3"), intColBound,
+        GpuLiteral("_c4"), GpuLiteral(1)))
+    )
+    testExprsSizeEstimate(projections)
+  }
+
+  test("estimate CreateMap(string, int, 's1', 1) size") {
+    val projections = Seq(
+      GpuCreateMap(Seq(strNoNullColBound, intColBound, GpuLiteral("s1"), GpuLiteral(1)))
+    )
+    testExprsSizeEstimate(projections)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/LiteralSizeEstimationTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/LiteralSizeEstimationTest.scala
@@ -32,7 +32,8 @@ class LiteralSizeEstimationTest extends GpuUnitTests {
   private def testLiteralSizeEstimate(lit: Any, litType: DataType): Unit = {
     val col = withResource(GpuScalar.from(lit, litType))(ColumnVector.fromScalar(_, numRows))
     val actualSize = withResource(col)(_.getDeviceMemorySize)
-    val estimatedSize = PreProjectSplitIterator.calcSizeForLiteral(lit, litType, numRows)
+    val estimatedSize = PreProjectSplitIterator.calcSizeForLiteral(lit, litType, numRows,
+      lit == null, Some(1))
     assertResult(actualSize)(estimatedSize)
   }
 


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11916

This PR adds pre-split support ([already used in the GPU aggregate](https://github.com/NVIDIA/spark-rapids/blob/v24.12.1/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala#L2128)) to the GPU project to fix the OOM issue mentioned in the linked issue, along with the projected size calculation support for 3 expressions of complex type (CreateArray, CreateNamedStruct, and CreateMap) whose sizes are the sum of their children respectively. 

Puting these two changes in a signle PR is to fix another GPU OOM mentioned at https://github.com/NVIDIA/spark-rapids/issues/11916#issuecomment-2588560317, who is involving the `CreateMap` expression as a project column. And this expression led to a quite big output batch after the project. Because it has many literal columns (> 25) as the key children. It is like `map('k1', col1, 'k2', col2, ..., 'k25', col25, ...)`.

NOTE: The pre-split is still disabled for cases when a GPU project is used as a pre-process or post-process for the window operator, since one output batch is expected for one input batch by window operations.

Here are some numbers of NDS Test Time (:seconds), and no big perf regression is observed.

Data | Round | Presplit-Porject ON | Presplit-Porject OFF
-- | -- | -- | --
3K | 1 | 641 | 665
3K | 2 | 656 | 695
3K | 3 | 656 | 642
  |   |   |  
10K | 1 | 2089 | 2066
10K | 2 | 2067 | 2097



<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
