### PR TITLE
Avoid using the deprecated method 

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -253,9 +253,10 @@ class KudoTableOperator(kudo: Option[KudoSerializer])
         kudoTables.add(column.kudoTable)
       }
 
-      val result = kudo.get.mergeOnHost(kudoTables)
+      val result =
+        kudo.get.mergeOnHost(kudoTables.toArray(Array.ofDim[KudoTable](kudoTables.size())))
 
-      KudoHostMergeResultWrapper(result.getLeft)
+      KudoHostMergeResultWrapper(result)
     }
   }
 }


### PR DESCRIPTION
This PR replaces `mergeOnHost` that takes in a list of kudoTables with an array as required after https://github.com/NVIDIA/spark-rapids-jni/pull/2944 was merged

fixes #12164 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
