### PR TITLE
Support HiveHash in GPU partitioning

### DIFF
--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -263,7 +263,9 @@ def test_hash_repartition_exact_fallback(gen, num_parts, kudo_enabled):
             .repartition(num_parts, *part_on) \
             .withColumn('id', f.spark_partition_id()) \
             .selectExpr('*'), "ShuffleExchangeExec",
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        # Force to use murmur3
+        conf = {'spark.rapids.sql.partitioning.hashFunction.enabled': False,
+                kudo_enabled_conf_key: kudo_enabled})
 
 @allow_non_gpu("ProjectExec")
 @pytest.mark.parametrize('data_gen', [ArrayGen(StructGen([('b1', long_gen)]))], ids=idfn)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
@@ -120,10 +120,10 @@ object GpuHashPartitioningBase extends Logging {
           case h if h == classOf[HiveHash] => HiveMode
           case o => UnsupportedMode(o.asInstanceOf[Class[_]].getSimpleName)
         }
-        logInfo(s"Found hash function '$hashMode' from cpu hash partitioning.")
+        logInfo(s"Found hash function '$hashMode' from CPU hash partitioning.")
       } catch {
         case _: NoSuchMethodException => // not the customized spark distributions, noop
-          logInfo("No hash function field is found in cpu hash partitioning.")
+          logInfo("Use murmur3 for GPU hash partitioning.")
       }
     }
     hashMode

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
@@ -120,10 +120,10 @@ object GpuHashPartitioningBase extends Logging {
           case h if h == classOf[HiveHash] => HiveMode
           case o => UnsupportedMode(o.asInstanceOf[Class[_]].getSimpleName)
         }
-        logInfo(s"Found hash function '$hashMode' from CPU hash partitioning.")
+        logDebug(s"Found hash function '$hashMode' from CPU hash partitioning.")
       } catch {
         case _: NoSuchMethodException => // not the customized spark distributions, noop
-          logInfo("Use murmur3 for GPU hash partitioning.")
+          logDebug("Use murmur3 for GPU hash partitioning.")
       }
     }
     hashMode

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4077,7 +4077,7 @@ object GpuOverrides extends Logging {
         override val childExprs: Seq[BaseExprMeta[_]] =
           hp.expressions.map(GpuOverrides.wrapExpr(_, this.conf, Some(this)))
 
-        private lazy val hashMode = GpuHashPartitioningBase.hashModeFromCpu(hp, conf)
+        private lazy val hashMode = GpuHashPartitioningBase.hashModeFromCpu(hp, this.conf)
 
         override def tagPartForGpu(): Unit = {
           val cpuHashFunc: Option[Expression] = this.hashMode match {
@@ -4089,7 +4089,7 @@ object GpuOverrides extends Logging {
               None
           }
           cpuHashFunc.foreach { chf =>
-            val hfMeta = GpuOverrides.wrapExpr(chf, conf, None)
+            val hfMeta = GpuOverrides.wrapExpr(chf, this.conf, None)
             hfMeta.tagForGpu()
             if (!hfMeta.canThisBeReplaced) {
               willNotWorkOnGpu(s"the hash function: ${chf.getClass.getSimpleName}" +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2396,6 +2396,18 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .booleanConf
     .createWithDefault(false)
 
+  val ENABLE_HASH_FUNCTION_IN_PARTITIONING =
+    conf("spark.rapids.sql.partitioning.hashFunction.enabled")
+      .doc("When false, Only Murmur3Hash is used for GPU hash partitioning to " +
+        "align with the regular Spark. When enabled, GPU will try to infer the hash " +
+        "function from the CPU hash partitioning and use the same one. This is for " +
+        "a customized Spark supporting multiple hash functions in hash partitioning. " +
+        "So far only 'HiveHash' and 'Murmur3Hash' are supported on GPU. This requires " +
+        s"'${INCOMPATIBLE_OPS.key}' to also be set to true.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
   val TAG_LORE_ID_ENABLED = conf("spark.rapids.sql.lore.tag.enabled")
     .doc("Enable add a LORE id to each gpu plan node")
     .internal()
@@ -3300,6 +3312,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val testGetJsonObjectSaveRows: Int = get(TEST_GET_JSON_OBJECT_SAVE_ROWS)
 
   lazy val isDeltaLowShuffleMergeEnabled: Boolean = get(ENABLE_DELTA_LOW_SHUFFLE_MERGE)
+
+  lazy val isHashFuncPartitioningEnabled: Boolean = get(ENABLE_HASH_FUNCTION_IN_PARTITIONING)
 
   lazy val isTagLoreIdEnabled: Boolean = get(TAG_LORE_ID_ENABLED)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,14 @@ package org.apache.spark.sql.rapids.execution
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import com.nvidia.spark.rapids.{GpuBatchUtils, GpuColumnVector, GpuExpression, GpuHashPartitioningBase, GpuMetric, RmmRapidsRetryIterator, SpillableColumnarBatch, SpillPriorities, TaskAutoCloseableResource}
+import com.nvidia.spark.rapids.{GpuBatchUtils, GpuColumnVector, GpuExpression, GpuHashPartitioner, GpuMetric, RmmRapidsRetryIterator, SpillableColumnarBatch, SpillPriorities, TaskAutoCloseableResource}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.plans.InnerLike
+import org.apache.spark.sql.rapids.{GpuHashExpression, GpuMurmur3Hash}
 import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -87,7 +88,8 @@ class GpuBatchSubPartitioner(
     inputBoundKeys: Seq[GpuExpression],
     numPartitions: Int,
     hashSeed: Int,
-    name: String = "GpuBatchSubPartitioner") extends AutoCloseable with Logging {
+    name: String = "GpuBatchSubPartitioner") extends GpuHashPartitioner
+  with AutoCloseable with Logging {
 
   private var isNotInited = true
   private var numCurBatches = 0
@@ -95,6 +97,8 @@ class GpuBatchSubPartitioner(
   private val realNumPartitions = Math.max(2, numPartitions)
   private val pendingParts =
     Array.fill(realNumPartitions)(ArrayBuffer.empty[SpillableColumnarBatch])
+
+  override protected val hashFunc: GpuHashExpression = GpuMurmur3Hash(inputBoundKeys, hashSeed)
 
   /** The actual count of partitions */
   def partitionsCount: Int = realNumPartitions
@@ -177,8 +181,7 @@ class GpuBatchSubPartitioner(
       if (gpuBatch.numRows() > 0 && gpuBatch.numCols() > 0) {
         val types = GpuColumnVector.extractTypes(gpuBatch)
         // 1) Hash partition on the batch
-        val partedTable = GpuHashPartitioningBase.hashPartitionAndClose(
-          gpuBatch, inputBoundKeys, realNumPartitions, "Sub-Hash Calculate", hashSeed)
+        val partedTable = hashPartitionAndClose(gpuBatch, realNumPartitions, "Sub-join part")
         val (spillBatch, partitions) = withResource(partedTable) { _ =>
           // Convert to SpillableColumnarBatch for the following retry.
           (SpillableColumnarBatch(GpuColumnVector.from(partedTable.getTable, types),

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuHashPartitioning.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuHashPartitioning.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,13 +24,14 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.GpuHashPartitioningBase
+import com.nvidia.spark.rapids.{GpuHashPartitioningBase, HashMode, Murmur3Mode}
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, HashClusteredDistribution}
 
-case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int)
-  extends GpuHashPartitioningBase(expressions, numPartitions) {
+case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int,
+    hashMode: HashMode = Murmur3Mode)
+  extends GpuHashPartitioningBase(expressions, numPartitions, hashMode) {
 
   override def satisfies0(required: Distribution): Boolean = {
     super.satisfies0(required) || {

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuHashPartitioning.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuHashPartitioning.scala
@@ -40,13 +40,14 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.GpuHashPartitioningBase
+import com.nvidia.spark.rapids.{GpuHashPartitioningBase, HashMode, Murmur3Mode}
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, StatefulOpClusteredDistribution}
 
-case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int)
-  extends GpuHashPartitioningBase(expressions, numPartitions) {
+case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int,
+    hashMode: HashMode = Murmur3Mode)
+  extends GpuHashPartitioningBase(expressions, numPartitions, hashMode) {
 
   override def satisfies0(required: Distribution): Boolean = {
     super.satisfies0(required) || {


### PR DESCRIPTION
(No issue for this)

This PR adds the support to allow GPU hash partitioning using the same hash function as the CPU one by trying to infer the type of hash function from the CPU hash partitioning.

This is desgined for some Spark distributions supporting to specify a hash function (e.g. one of `HiveHash`, `Murmur3Hash` ...) for hash partitioning by introducing a new field named "hashingFunctionClass". It is not like the regular Spark who always use `Murmur3Hash`. However, to align with the regular Spark's behavior, `Murmur3Hash`  is still the default option when inferring fails, and of course the inferrring will always fail in regular Spark.

Now only `HiveHash` and `Murmur3Hash` are supported on GPU.

This is hard to test by unit tests or integration tests. Since the customized Spark distribution is not public and it does not have any side effects to the regular Spark. But the CI at least can ensure no regressions and we already verify it by customer queries with the customized Spark.
