### PR TITLE
Update jvm heap size to 6g for scala-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1450,7 +1450,7 @@ This will force full Scala code rebuild in downstream modules.
                         <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                         <junitxml>.</junitxml>
                         <filereports>scala-test-output.txt</filereports>
-                        <argLine>${argLine} -ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
+                        <argLine>${argLine} -ea -Xmx6g -Xss4m ${extraJavaTestArgs}</argLine>
                         <stderr/>
                         <systemProperties>
                             <rapids.shuffle.manager.override>${rapids.shuffle.manager.override}</rapids.shuffle.manager.override>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1450,7 +1450,7 @@ This will force full Scala code rebuild in downstream modules.
                         <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                         <junitxml>.</junitxml>
                         <filereports>scala-test-output.txt</filereports>
-                        <argLine>${argLine} -ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
+                        <argLine>${argLine} -ea -Xmx6g -Xss4m ${extraJavaTestArgs}</argLine>
                         <stderr/>
                         <systemProperties>
                             <rapids.shuffle.manager.override>${rapids.shuffle.manager.override}</rapids.shuffle.manager.override>


### PR DESCRIPTION
Based on the pod memory usage, we saw the peak memory of mvn test is intermittently larger than previous 4g, so before we have some adjustment of corresponding cases, 

lets try update the Xmx to 6g to mitigate the potential OOM issue e.g. https://github.com/NVIDIA/spark-rapids/issues/11227