### PR TITLE
Workaround: tmply disable the HostAllocSuite to unblock CI [skip ci]

### DIFF
--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -23,10 +23,9 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.jni.{RmmSpark, RmmSparkThreadState}
 import com.nvidia.spark.rapids.spill._
 import org.mockito.Mockito.when
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Ignore}
 import org.scalatest.concurrent.{Signaler, TimeLimits}
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.Ignore
 import org.scalatest.time._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
@@ -35,7 +34,8 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
-@Ignore("https://github.com/NVIDIA/spark-rapids/issues/12194")
+// Waiting for the fix of https://github.com/NVIDIA/spark-rapids/issues/12194
+@Ignore
 class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
     BeforeAndAfterAll with TimeLimits {
   private val sqlConf = new SQLConf()

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
+@Ignore("https://github.com/NVIDIA/spark-rapids/issues/12194")
 class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
     BeforeAndAfterAll with TimeLimits {
   private val sqlConf = new SQLConf()

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -26,6 +26,7 @@ import org.mockito.Mockito.when
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.{Signaler, TimeLimits}
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.Ignore
 import org.scalatest.time._
 import org.scalatestplus.mockito.MockitoSugar.mock
 


### PR DESCRIPTION
this is a workaound for https://github.com/NVIDIA/spark-rapids/issues/12194 to unblock others
before we figure out the root cause of the OOM issue

```
[2025-02-24T02:56:08.571Z] [32mHostAllocSuite:[0m
[2025-02-24T02:56:08.571Z] [33m- simple pinned tryAlloc !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- simple non-pinned tryAlloc !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- simple mixed tryAlloc !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- simple pinned blocking alloc !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- simple non-pinned blocking alloc !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- simple mixed blocking alloc !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- pinned blocking alloc with spill !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- non-pinned blocking alloc with spill !!! IGNORED !!!
[2025-02-24T02:56:08.571Z] [33m- mixed blocking alloc with spill !!! IGNORED !!!
```