### PR TITLE
Add support for `ORC` stripe cudf size configs

### DIFF
--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -106,6 +106,8 @@ def test_write_round_trip(spark_tmp_path, orc_gens, orc_impl):
 def test_write_with_stripe_size_rows(spark_tmp_path, orc_gen, orc_impl):
     gen_list = [('_c0', orc_gen)]
     data_path = spark_tmp_path + '/ORC_DATA'
+    # cuDF ORC writer rounds the number of elements in each stripe (except the last) to a multiple
+    # of 8 to be able to efficiently encode the validity masks. So use an integer divisible by 8.
     stripe_size_rows = 10000
     with_gpu_session(
         lambda spark: gen_df(spark, gen_list, stripe_size_rows + 1, num_slices=1).write.orc(data_path),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1276,14 +1276,15 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .booleanConf
     .createWithDefault(false)
 
-  val ORC_STRIPE_SIZE_ROWS = conf("spark.rapids.sql.format.orc.write.stripeSizeRows")
-    .doc("When set to a valid value(no less than 512, as specified in cudf), " +
-      "the ORC writer will use this value as the maximum number of rows per stripe. " +
+  val TEST_ORC_STRIPE_SIZE_ROWS = conf("spark.rapids.sql.test.orc.write.stripeSizeRows")
+    .doc("Only to be used in tests. When set to a valid value(no less than 512, as specified " +
+      "in cudf), the ORC writer will use this value as the maximum number of rows per stripe. " +
       "Additionally, the ORC writer rounds the number of elements in each stripe " +
       "(except the last) to a multiple of 8 to efficiently encode the validity masks. " +
       "If not set, the ORC writer will use the default value 1,000,000.")
     .internal()
     .integerConf
+    .checkValue(v => v >= 512, "The stripe size rows must be no less than 512.")
     .createOptional
 
   val ENABLE_EXPAND_PREPROJECT = conf("spark.rapids.sql.expandPreproject.enabled")
@@ -3051,6 +3052,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
     RapidsReaderType.withName(get(ORC_READER_TYPE)) == RapidsReaderType.MULTITHREADED
 
   lazy val maxNumOrcFilesParallel: Int = get(ORC_MULTITHREAD_READ_MAX_NUM_FILES_PARALLEL)
+
+  lazy val testOrcStripeSizeRows: Option[Integer] = get(TEST_ORC_STRIPE_SIZE_ROWS)
 
   lazy val isOrcBoolTypeEnabled: Boolean = get(ENABLE_ORC_BOOL)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -65,7 +65,7 @@ object ConfHelper {
       s.trim.toDouble
     } catch {
       case _: IllegalArgumentException =>
-        throw new IllegalArgumentException(s"$key should be integer, but was $s")
+        throw new IllegalArgumentException(s"$key should be double, but was $s")
     }
   }
 
@@ -1275,6 +1275,16 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .internal()
     .booleanConf
     .createWithDefault(false)
+
+  val ORC_STRIPE_SIZE_ROWS = conf("spark.rapids.sql.format.orc.write.stripeSizeRows")
+    .doc("When set to a valid value(no less than 512, as specified in cudf), " +
+      "the ORC writer will use this value as the maximum number of rows per stripe. " +
+      "Additionally, the ORC writer rounds the number of elements in each stripe " +
+      "(except the last) to a multiple of 8 to efficiently encode the validity masks. " +
+      "If not set, the ORC writer will use the default value 1,000,000.")
+    .internal()
+    .integerConf
+    .createOptional
 
   val ENABLE_EXPAND_PREPROJECT = conf("spark.rapids.sql.expandPreproject.enabled")
     .doc("When set to false disables the pre-projection for GPU Expand. " +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -185,7 +185,7 @@ class GpuOrcFileFormat extends ColumnarFileFormat with Logging {
     // holdGpuBetweenBatches is on by default if asyncOutputWriteEnabled is on
     val holdGpuBetweenBatches = RapidsConf.ASYNC_QUERY_OUTPUT_WRITE_HOLD_GPU_IN_TASK.get(sqlConf)
       .getOrElse(asyncOutputWriteEnabled)
-    val orcStripeSizeRows = RapidsConf.ORC_STRIPE_SIZE_ROWS.get(sqlConf)
+    val orcStripeSizeRows = RapidsConf.TEST_ORC_STRIPE_SIZE_ROWS.get(sqlConf)
 
     new ColumnarOutputWriterFactory {
       override def newInstance(path: String,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -229,7 +229,7 @@ class GpuOrcWriter(
     val builder = SchemaUtils
       .writerOptionsFromSchema(ORCWriterOptions.builder(), dataSchema, nullable = false)
       .withCompressionType(CompressionType.valueOf(OrcConf.COMPRESS.getString(conf)))
-    orcStripeSizeRows.foreach { orcStripeSizeRows =>
+    orcStripeSizeRows.foreach { ss =>
       builder.withStripeSizeRows(orcStripeSizeRows)
     }
     Table.writeORCChunked(builder.build(), this)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -230,7 +230,7 @@ class GpuOrcWriter(
       .writerOptionsFromSchema(ORCWriterOptions.builder(), dataSchema, nullable = false)
       .withCompressionType(CompressionType.valueOf(OrcConf.COMPRESS.getString(conf)))
     orcStripeSizeRows.foreach { ss =>
-      builder.withStripeSizeRows(orcStripeSizeRows)
+      builder.withStripeSizeRows(ss)
     }
     Table.writeORCChunked(builder.build(), this)
   }


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/11799

Depends on
- https://github.com/rapidsai/cudf/pull/17927

Adding this parameter is solely for the convenience of testing, such as testing writing multiple stripes.