### PR TITLE
add test case for issue 12158

### DIFF
--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -267,7 +267,7 @@ class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
       waitForFree()
     }
 
-    private def doAlloc(): Void = {
+    def doAlloc(): Void = {
       RmmRapidsRetryIterator.withRetryNoSplit {
         val tmp = HostAlloc.alloc(size, preferPinned)
         synchronized {
@@ -670,6 +670,75 @@ class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
         thread1.done.get(1, TimeUnit.SECONDS)
         thread2.done.get(1, TimeUnit.SECONDS)
         thread3.done.get(1, TimeUnit.SECONDS)
+      }
+    }
+  }
+
+  test("split should not happen immediately after fallback on memory contention") {
+
+    // It allocates a small piece of memory (1024) as a warmup, sleep 1s,
+    // then allocates a large piece of memory
+    class AllocOnAnotherThreadWithWarmup(override val thread: TaskThread,
+        override val size: Long) extends AllocOnAnotherThread(thread, size) {
+
+      override def doAlloc(): Void = {
+        RmmRapidsRetryIterator.withRetryNoSplit {
+
+          // read shuffle data from remote and put it into Spillalble Framework
+          val w = SpillableHostBuffer.apply(HostAlloc.alloc(1024, preferPinned),
+            1024, SpillPriorities.ACTIVE_BATCHING_PRIORITY)
+
+          Thread.sleep(1000)
+
+          // let's say we will do sth with the shuffle data read, e.g. concat them
+          // for simplicity, we just have one SpillableHostBuffer as input, in real case there
+          // should be multiple SpillableHostBuffer as input
+          withResource(w.getHostBuffer()) { _ =>
+            // create another buffer as destination for concat
+            val tmp = HostAlloc.alloc(size, preferPinned)
+            synchronized {
+              closeOnExcept(tmp) { _ =>
+                assert(b.isEmpty)
+                b = Option(tmp)
+              }
+            }
+          }
+
+          // at some point close w
+          w.close()
+        }
+        null
+      }
+    }
+
+    PinnedMemoryPool.initialize(0)
+    HostAlloc.initialize(10 * 1024) // memory only big enough for the one concurrent thread to pass
+
+    failAfter(Span(10, Seconds)) {
+      val thread1 = new TaskThread("thread1", 1)
+      thread1.initialize()
+      val thread2 = new TaskThread("thread2", 2)
+      thread2.initialize()
+
+      try {
+        // Actually it will require 10 * 1024 memory
+        withResource(new AllocOnAnotherThreadWithWarmup(thread2, 9 * 1024)) { a =>
+
+          // Actually it will require 10 * 1024 memory
+          withResource(new AllocOnAnotherThreadWithWarmup(thread1, 9 * 1024)) { b =>
+
+            // At this point, both threads are blocked because of memory contention,
+            // we expect both thread1 and thread2 to fall back to BUFN state, and then thread1
+            // should attempt another try before doing splitting
+
+            b.waitForAlloc()
+            b.assertAllocSize(9 * 1024)
+            b.freeAndWait()
+          }
+        }
+      } finally {
+        thread1.done.get(1, TimeUnit.SECONDS)
+        thread2.done.get(1, TimeUnit.SECONDS)
       }
     }
   }


### PR DESCRIPTION
This PR closes https://github.com/NVIDIA/spark-rapids/issues/12158 by adding a test case to verify that https://github.com/NVIDIA/spark-rapids-jni/pull/2976 is actually working.



The PR can be reviewed now, but won't be merged until https://github.com/NVIDIA/spark-rapids/issues/12194 is fixed, as  @pxLi ignored the whole HostAllocSuite as a workaround. Nontheless, local test have passed:

![image](https://github.com/user-attachments/assets/99542609-7a93-4384-bd9a-93e93a9b1eaf)