### PR TITLE
Support legacy mode for yyyy-mm-dd format

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -634,6 +634,7 @@ guaranteed to produce the same results as the CPU:
 - `dd/MM/yyyy`
 - `yyyy/MM/dd`
 - `yyyy-MM-dd`
+- `yyyy-mm-dd`
 - `yyyyMMdd`
 - `yyyymmdd`
 - `yyyy/MM/dd HH:mm:ss`
@@ -647,6 +648,8 @@ LEGACY timeParserPolicy support has the following limitations when running on th
   that Spark uses in legacy mode
 - When format is/contains `yyyyMMdd` or `yyyymmdd`, GPU only supports 8 digit strings for these formats.
   Spark supports like 7 digit `2024101` string while GPU does not support. Only tested `UTC` and
+  `Asia/Shanghai` timezones.
+- When format is `yyyy-mm-dd`, only supports 2 digit `mm` and 2 digit `dd`. Only tested `UTC` and
   `Asia/Shanghai` timezones.
 
 ## Formatting dates and timestamps as strings

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -494,7 +494,7 @@ def test_to_timestamp(parser_policy):
 
 # mm: minute; MM: month
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
-@pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd'], ids=idfn)
+@pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd', 'yyyy-mm-dd'], ids=idfn)
 # Test years after 1900, refer to issues: https://github.com/NVIDIA/spark-rapids/issues/11543, https://github.com/NVIDIA/spark-rapids/issues/11539
 @pytest.mark.skipif(get_test_tz() != "Asia/Shanghai" and get_test_tz() != "UTC", reason="https://github.com/NVIDIA/spark-rapids/issues/11562")
 def test_formats_for_legacy_mode(format):

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -633,6 +633,8 @@ object GpuToTimestamp {
   val LEGACY_COMPATIBLE_FORMATS = Map(
     "yyyy-MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
       raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
+    "yyyy-mm-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
+      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
     "yyyy/MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
       raw"\A\d{4}/\d{1,2}/\d{1,2}(\D|\s|\Z)"),
     "dd-MM-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,


### PR DESCRIPTION
closes #12234

Support legacy mode for yyyy-mm-dd format

Signed-off-by: Chong Gao <res_life@163.com>