### PR TITLE
Simplify mvn verify cache key [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -55,7 +55,7 @@ jobs:
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.12)
           hashfile=$(echo ${{ hashFiles('**/pom.xml') }})
-          md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
+          md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}')
           cacheKey="${{ runner.os }}-maven-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository
@@ -174,7 +174,7 @@ jobs:
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.13)
           hashfile=$(echo ${{ hashFiles('**/pom.xml') }})
-          md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
+          md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}')
           cacheKey="${{ runner.os }}-maven-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "scala213dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -56,7 +56,7 @@ jobs:
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.12)
           hashfile=$(echo ${{ hashFiles('**/pom.xml') }})
           md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
-          cacheKey="${{ runner.os }}-${{ github.event.pull_request.base.ref }}-${md5sum}"
+          cacheKey="${{ runner.os }}-maven-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository
         id: cache
@@ -175,7 +175,7 @@ jobs:
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.13)
           hashfile=$(echo ${{ hashFiles('**/pom.xml') }})
           md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
-          cacheKey="${{ runner.os }}-${{ github.event.pull_request.base.ref }}-${md5sum}"
+          cacheKey="${{ runner.os }}-maven-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "scala213dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository
         id: cache

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -172,7 +172,8 @@ jobs:
         run: |
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.13)
-          cacheKey="${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.event.pull_request.base.ref }}-${depsSHA1}"
+          hashfile=$(echo ${{ hashFiles('**/pom.xml') }} | cut -c1-8)
+          cacheKey="${{ runner.os }}-maven-${hashfile}-${{ github.event.pull_request.base.ref }}-${depsSHA1}"
           echo "scala213dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository
         id: cache

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -54,7 +54,8 @@ jobs:
         run: |
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.12)
-          cacheKey="${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.event.pull_request.base.ref }}-${depsSHA1}"
+          hashfile=$(echo ${{ hashFiles('**/pom.xml') }} | cut -c1-8)
+          cacheKey="${{ runner.os }}-maven-${hashfile}-${{ github.event.pull_request.base.ref }}-${depsSHA1}"
           echo "dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository
         id: cache

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.12)
-          hashfile=$(echo ${{ hashFiles('**/pom.xml') }} | cut -c1-8)
+          hashfile=$(echo ${{ hashFiles('**/pom.xml') }})
           md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
           cacheKey="${{ runner.os }}-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
@@ -173,7 +173,7 @@ jobs:
         run: |
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.13)
-          hashfile=$(echo ${{ hashFiles('**/pom.xml') }} | cut -c1-8)
+          hashfile=$(echo ${{ hashFiles('**/pom.xml') }})
           md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
           cacheKey="${{ runner.os }}-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "scala213dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -55,7 +55,8 @@ jobs:
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.12)
           hashfile=$(echo ${{ hashFiles('**/pom.xml') }} | cut -c1-8)
-          cacheKey="${{ runner.os }}-maven-${hashfile}-${{ github.event.pull_request.base.ref }}-${depsSHA1}"
+          md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
+          cacheKey="${{ runner.os }}-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository
         id: cache
@@ -173,7 +174,8 @@ jobs:
           set -x
           depsSHA1=$(. .github/workflows/mvn-verify-check/get-deps-sha1.sh 2.13)
           hashfile=$(echo ${{ hashFiles('**/pom.xml') }} | cut -c1-8)
-          cacheKey="${{ runner.os }}-maven-${hashfile}-${{ github.event.pull_request.base.ref }}-${depsSHA1}"
+          md5sum=$(echo -n "$depsSHA1-$hashfile" | md5sum | awk '{print $1}' | cut -c1-8)
+          cacheKey="${{ runner.os }}-${{ github.event.pull_request.base.ref }}-${md5sum}"
           echo "scala213dailyCacheKey=$cacheKey" | tee $GITHUB_ENV $GITHUB_OUTPUT
       - name: Cache local Maven repository
         id: cache

--- a/.github/workflows/mvn-verify-check/get-deps-sha1.sh
+++ b/.github/workflows/mvn-verify-check/get-deps-sha1.sh
@@ -29,7 +29,7 @@ hybrid_ver=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-hybrid.vers
 if [[ $jni_ver == *SNAPSHOT* ]]; then
   jni_sha1=$(curl -s -H "Accept: application/json" \
     "${base_URL}?r=snapshots&g=com.nvidia&a=${project_jni}&v=${jni_ver}&c=&e=jar&wt=json" \
-    | jq -r .data.sha1 | cut -c1-8) || $(date +'%Y-%m-%d')
+    | jq .data.sha1) || $(date +'%Y-%m-%d')
 else
   jni_sha1=$jni_ver
 fi
@@ -37,7 +37,7 @@ fi
 if [[ $private_ver == *SNAPSHOT* ]]; then
   private_sha1=$(curl -s -H "Accept: application/json" \
     "${base_URL}?r=snapshots&g=com.nvidia&a=${project_private}&v=${private_ver}&c=&e=jar&wt=json" \
-    | jq -r .data.sha1 | cut -c1-8) || $(date +'%Y-%m-%d')
+    | jq .data.sha1) || $(date +'%Y-%m-%d')
 else
   private_sha1=$private_ver
 fi
@@ -45,11 +45,11 @@ fi
 if [[ $hybrid_ver == *SNAPSHOT* ]]; then
   hybrid_sha1=$(curl -s -H "Accept: application/json" \
     "${base_URL}?r=snapshots&g=com.nvidia&a=${project_hybrid}&v=${hybrid_ver}&c=&e=jar&wt=json" \
-    | jq -r .data.sha1 | cut -c1-8) || $(date +'%Y-%m-%d')
+    | jq .data.sha1) || $(date +'%Y-%m-%d')
 else
   hybrid_sha1=$hybrid_ver
 fi
 
-sha1md5=$(echo -n "${jni_sha1}_${private_sha1}_${hybrid_sha1}" | md5sum | awk '{print $1}')
+sha1md5=$(echo -n "${jni_sha1}_${private_sha1}_${hybrid_sha1}" | md5sum | awk '{print $1}' | cut -c1-8)
 
 echo $sha1md5

--- a/.github/workflows/mvn-verify-check/get-deps-sha1.sh
+++ b/.github/workflows/mvn-verify-check/get-deps-sha1.sh
@@ -50,6 +50,4 @@ else
   hybrid_sha1=$hybrid_ver
 fi
 
-sha1md5=$(echo -n "${jni_sha1}_${private_sha1}_${hybrid_sha1}" | md5sum | awk '{print $1}' | cut -c1-8)
-
 echo -n "${jni_sha1}_${private_sha1}_${hybrid_sha1}"

--- a/.github/workflows/mvn-verify-check/get-deps-sha1.sh
+++ b/.github/workflows/mvn-verify-check/get-deps-sha1.sh
@@ -52,4 +52,4 @@ fi
 
 sha1md5=$(echo -n "${jni_sha1}_${private_sha1}_${hybrid_sha1}" | md5sum | awk '{print $1}' | cut -c1-8)
 
-echo $sha1md5
+echo -n "${jni_sha1}_${private_sha1}_${hybrid_sha1}"

--- a/.github/workflows/mvn-verify-check/get-deps-sha1.sh
+++ b/.github/workflows/mvn-verify-check/get-deps-sha1.sh
@@ -29,7 +29,7 @@ hybrid_ver=$(mvn help:evaluate -q -pl dist -Dexpression=spark-rapids-hybrid.vers
 if [[ $jni_ver == *SNAPSHOT* ]]; then
   jni_sha1=$(curl -s -H "Accept: application/json" \
     "${base_URL}?r=snapshots&g=com.nvidia&a=${project_jni}&v=${jni_ver}&c=&e=jar&wt=json" \
-    | jq .data.sha1) || $(date +'%Y-%m-%d')
+    | jq -r .data.sha1 | cut -c1-8) || $(date +'%Y-%m-%d')
 else
   jni_sha1=$jni_ver
 fi
@@ -37,7 +37,7 @@ fi
 if [[ $private_ver == *SNAPSHOT* ]]; then
   private_sha1=$(curl -s -H "Accept: application/json" \
     "${base_URL}?r=snapshots&g=com.nvidia&a=${project_private}&v=${private_ver}&c=&e=jar&wt=json" \
-    | jq .data.sha1) || $(date +'%Y-%m-%d')
+    | jq -r .data.sha1 | cut -c1-8) || $(date +'%Y-%m-%d')
 else
   private_sha1=$private_ver
 fi
@@ -45,7 +45,7 @@ fi
 if [[ $hybrid_ver == *SNAPSHOT* ]]; then
   hybrid_sha1=$(curl -s -H "Accept: application/json" \
     "${base_URL}?r=snapshots&g=com.nvidia&a=${project_hybrid}&v=${hybrid_ver}&c=&e=jar&wt=json" \
-    | jq .data.sha1) || $(date +'%Y-%m-%d')
+    | jq -r .data.sha1 | cut -c1-8) || $(date +'%Y-%m-%d')
 else
   hybrid_sha1=$hybrid_ver
 fi


### PR DESCRIPTION
Currently the cache key ID contains hash value of all pom files and dependencies sha1 md5 value with the less predictable length.

This PR proposes a fixed-length key format that is easy to reason to be below the [GH limit](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#input-parameters-for-the-cache-action)

`Linux-maven-<target branch>-<md5sum of the rest of hash inputs: dependency signatures. poms,etc>` 

