### PR TITLE
Mirror the Cloudera Maven repository

### DIFF
--- a/jenkins/settings.xml
+++ b/jenkins/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+  Copyright (c) 2020-2025, NVIDIA CORPORATION. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -100,6 +100,26 @@
       </repositories>
     </profile>
     <profile>
+      <id>mirror-cloudera-to-urm</id>
+      <repositories>
+        <repository>
+          <id>cloudera-repo</id>
+          <name>sw-spark-maven</name>
+          <url>${env.URM_URL}</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <id>mirror-cloudera-fallback-to-urm</id>
+      <repositories>
+        <repository>
+          <id>cloudera-repo-fallback</id>
+          <name>sw-spark-maven</name>
+          <url>${env.URM_URL}</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
       <id>deploy-to-urm</id>
       <properties>
           <altDeploymentRepository>snapshots::default::${env.URM_URL}-local</altDeploymentRepository>
@@ -111,6 +131,8 @@
     <activeProfile>mirror-apache-to-urm</activeProfile>
     <activeProfile>mirror-apache-https-to-urm</activeProfile>
     <activeProfile>mirror-apache2-to-urm</activeProfile>
+    <activeProfile>mirror-cloudera-to-urm</activeProfile>
+    <activeProfile>mirror-cloudera-fallback-to-urm</activeProfile>
     <activeProfile>deploy-to-urm</activeProfile>
   </activeProfiles>
 </settings>


### PR DESCRIPTION
Mirror the Cloudera Maven repository to the internal Maven repository to speed up builds for CI/CD

This change only affects the CI/CD build script by adding 'mvn -s jenkins/settings.xml.'


