### PR TITLE
Add validation for `start` and `length` parameters for `slice`

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -32,10 +32,9 @@ array_no_zero_index_gen = IntegerGen(min_val=1, max_val=25,
     special_cases=[(-25, 100), (-20, 100), (-10, 100), (-4, 100), (-3, 100), (-2, 100), (-1, 100), (None, 100)])
 
 array_all_null_gen = ArrayGen(int_gen, all_null=True)
-array_item_test_gens_sans_allnull = array_gens_sample + [
+array_item_test_gens = array_gens_sample + [array_all_null_gen,
     ArrayGen(MapGen(StringGen(pattern='key_[0-9]', nullable=False), StringGen(), max_length=10), max_length=10),
     ArrayGen(BinaryGen(max_length=10), max_length=10)]
-array_item_test_gens = array_item_test_gens_sans_allnull + [array_all_null_gen]
 
 
 # Need these for set-based operations
@@ -295,7 +294,7 @@ def test_array_slice(data_gen):
 
 @pytest.mark.parametrize('zero_start', [0, 'b'], ids=idfn)
 @pytest.mark.parametrize('valid_length', [5, 'c'], ids=idfn)
-@pytest.mark.parametrize('data_gen', array_item_test_gens_sans_allnull, ids=idfn)
+@pytest.mark.parametrize('data_gen', [ArrayGen(int_gen)], ids=idfn)
 def test_array_slice_with_zero_start(data_gen, zero_start, valid_length):
     zero_start_gen = IntegerGen(nullable=False, min_val=0, max_val=0, special_cases=[])
     valid_length_gen = IntegerGen(min_val=0, max_val=100, special_cases=[None])
@@ -313,7 +312,7 @@ def test_array_slice_with_zero_start(data_gen, zero_start, valid_length):
 
 @pytest.mark.parametrize('valid_start', [5, 'b'], ids=idfn)
 @pytest.mark.parametrize('negative_length', [-5, 'c'], ids=idfn)
-@pytest.mark.parametrize('data_gen', array_item_test_gens_sans_allnull, ids=idfn)
+@pytest.mark.parametrize('data_gen', [ArrayGen(int_gen)], ids=idfn)
 def test_array_slice_with_negative_length(data_gen, valid_start, negative_length):
     negative_length_gen = IntegerGen(nullable=False, min_val=-25, max_val=-1, special_cases=[])
     # When the list column is all null, the result is also all null regardless of the start and length


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
Closes https://github.com/NVIDIA/spark-rapids/issues/12203

Depends on
- https://github.com/NVIDIA/spark-rapids-jni/pull/2993

This PR adds validation for the legality of `start` and `length` in the `slice` expression. 

When they are invalid, it will throw an exception consistent with Spark's `slice` behavior.