### PR TITLE
Lazy materialization of  build-side batches in BroadcastJoins [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -143,16 +143,16 @@ trait JoinGatherer extends LazySpillable {
 
 object JoinGatherer {
   def apply(gatherMap: LazySpillableGatherMap,
-            inputData: LazySpillableColumnarBatch,
-            outOfBoundsPolicy: OutOfBoundsPolicy): JoinGatherer =
+      inputData: LazySpillableColumnarBatch,
+      outOfBoundsPolicy: OutOfBoundsPolicy): JoinGatherer =
     new JoinGathererImpl(gatherMap, inputData, outOfBoundsPolicy)
 
   def apply(leftMap: LazySpillableGatherMap,
-            leftData: LazySpillableColumnarBatch,
-            rightMap: LazySpillableGatherMap,
-            rightData: LazySpillableColumnarBatch,
-            outOfBoundsPolicyLeft: OutOfBoundsPolicy,
-            outOfBoundsPolicyRight: OutOfBoundsPolicy): JoinGatherer = {
+      leftData: LazySpillableColumnarBatch,
+      rightMap: LazySpillableGatherMap,
+      rightData: LazySpillableColumnarBatch,
+      outOfBoundsPolicyLeft: OutOfBoundsPolicy,
+      outOfBoundsPolicyRight: OutOfBoundsPolicy): JoinGatherer = {
     val left = JoinGatherer(leftMap, leftData, outOfBoundsPolicyLeft)
     val right = JoinGatherer(rightMap, rightData, outOfBoundsPolicyRight)
     MultiJoinGather(left, right)
@@ -220,7 +220,7 @@ trait LazySpillableColumnarBatch extends LazySpillable {
 
 object LazySpillableColumnarBatch {
   def apply(cb: ColumnarBatch,
-            name: String): LazySpillableColumnarBatch =
+      name: String): LazySpillableColumnarBatch =
     new LazySpillableColumnarBatchImpl(cb, name)
 
   /**

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #8346

Generally, this PR applies the second approach of #7642 : "spillable flavor of objects deep into the join code, only taking a ColumnarBatch from it when needed".  With this change, under the scenario of broadcast joins, spark-rapids will materialize the first batch of stream iterator at first instead of the broadcasted build batch.  

This change is aim to reduce the unwanted situation: holding the GpuSemaphore for non-GPU works. Currently, it may occur in broadcast joins, because currently spark-rapids materializes the build-side batch firstly, starting to hold the GPU semaphore from that. However,  the stream-side are usually started from operations(Scan/ShuffleRead) involving significant I/O and CPU work, which means spark-rapids holds GpuSemaphore for the I/O and host-side work (such as I/O buffering for Scan).

This change introduces a new variant of `LazySpillableColumnarBatch`: `LazySpillableBatchBuilder`, which accepts a build function rather than the built Gpu columnar batch. With the new variant, we can achieve the idea of #7642 : only taking (the build-side) ColumnarBatch from it when needed, so as to ensure the GpuSemaphore being taken by the steam side.
