### PR TITLE
Remove Multiget Testing Config

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -211,6 +211,7 @@ case class GpuMultiGetJsonObject(json: Expression,
     val validPaths = validPathsWithIndexes.map(_._1)
     withResource(new Array[ColumnVector](validPaths.length)) { validPathColumns =>
       withResource(json.columnarEval(batch)) { input =>
+        // Last argument -1 indicates to use automatically calculated parallelism
         withResource(JSONUtils.getJsonObjectMultiplePaths(input.getBase,
           java.util.Arrays.asList(validPaths: _*), 4 * targetBatchSize,
           -1)) { chunkedResult =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
@@ -82,6 +82,7 @@ case class GpuJsonTuple(children: Seq[Expression]) extends GpuGenerator
 
         var validPathsIndex = 0
         withResource(new Array[ColumnVector](fieldInstructions.length)) { validPathColumns =>
+          // Last argument -1 indicates to use automatically calculated parallelism
           withResource(JSONUtils.getJsonObjectMultiplePaths(
               json, validPaths, 4 * targetBatchSize, -1)) { chunkedResult =>
               chunkedResult.foreach { cr =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
@@ -59,8 +59,6 @@ case class GpuJsonTuple(children: Seq[Expression]) extends GpuGenerator
 
     val conf = SQLConf.get
     val targetBatchSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
-    val tmp = conf.getConfString("spark.sql.test.multiget.parallel", null)
-    val parallel = Option(tmp).map(_.toInt)
 
     withRetry(inputBatches, splitSpillableInHalfByRows) { attempt =>
       withResource(attempt.getColumnarBatch()) { inputBatch =>
@@ -85,7 +83,7 @@ case class GpuJsonTuple(children: Seq[Expression]) extends GpuGenerator
         var validPathsIndex = 0
         withResource(new Array[ColumnVector](fieldInstructions.length)) { validPathColumns =>
           withResource(JSONUtils.getJsonObjectMultiplePaths(
-              json, validPaths, 4 * targetBatchSize, parallel.getOrElse(-1))) { chunkedResult =>
+              json, validPaths, 4 * targetBatchSize, -1)) { chunkedResult =>
               chunkedResult.foreach { cr =>
                 validPathColumns(validPathsIndex) = cr.incRefCount()
                 validPathsIndex += 1


### PR DESCRIPTION
Previously in the code there are areas (GpuJsonTuple & GpuGetJsonObject) using spark.sql.test.multiget.parallel, a config used to set the maximum number of objects we want to process in parallel during a JSON multiget. The config was used to pass into [JSONUtils.getJsonObjectMultiplePaths's parallelOverride argument](https://github.com/NVIDIA/spark-rapids-jni/blob/f007800ba49deff7160b01b8f2f7a5e361883053/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java#L100). Setting it to -1 will use the automatically calculated value for parallelism. Removed as this [config is no longer used](https://github.com/NVIDIA/spark-rapids/pull/12214#discussion_r1976071301).