### PR TITLE
 Fix bloop project generation on [databricks]

### DIFF
--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -51,6 +51,8 @@ declare -A artifacts
 # Initializes the scripts and the variables based on teh arguments passed to the script.
 initialize()
 {
+    set -ex
+
     # install rsync to be used for copying onto the databricks nodes
     sudo apt install -y rsync
 
@@ -134,6 +136,8 @@ initialize()
 # Install dependency jars to MVN repository.
 install_dependencies()
 {
+    set -ex
+
     local depsPomXml="$(mktemp /tmp/install-databricks-deps-XXXXXX-pom.xml)"
 
     python jenkins/databricks/install_deps.py "${BASE_SPARK_VERSION}" "${SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS}" "${SCALA_VERSION}" "${M2DIR}" "${JARDIR}" "${depsPomXml}"
@@ -163,7 +167,8 @@ fi
 if [[ "$WITH_BLOOP" == "1" ]]; then
     MVN_OPT="-DbloopInstall $MVN_OPT"
     MVN_PHASES="clean install"
-    export JAVA_HOME="/usr/lib/jvm/zulu11"
+    export JAVA_HOME="/usr/lib/jvm/zulu17"
+    WITH_DEFAULT_UPSTREAM_SHIM=0
 else
     MVN_PHASES="clean package"
 fi

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -51,8 +51,6 @@ declare -A artifacts
 # Initializes the scripts and the variables based on teh arguments passed to the script.
 initialize()
 {
-    set -ex
-
     # install rsync to be used for copying onto the databricks nodes
     sudo apt install -y rsync
 
@@ -136,8 +134,6 @@ initialize()
 # Install dependency jars to MVN repository.
 install_dependencies()
 {
-    set -ex
-
     local depsPomXml="$(mktemp /tmp/install-databricks-deps-XXXXXX-pom.xml)"
 
     python jenkins/databricks/install_deps.py "${BASE_SPARK_VERSION}" "${SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS}" "${SCALA_VERSION}" "${M2DIR}" "${JARDIR}" "${depsPomXml}"

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -163,7 +163,19 @@ fi
 if [[ "$WITH_BLOOP" == "1" ]]; then
     MVN_OPT="-DbloopInstall $MVN_OPT"
     MVN_PHASES="clean install"
-    export JAVA_HOME="/usr/lib/jvm/zulu17"
+    for jdk_ver in 17 11 8; do
+      if [[ $jdk_ver == 8 ]]; then
+        echo >2 "WARNING: could not find an 11+ JDK. Bloop Project might not be fully functional"
+        exit 1
+      fi
+
+      jdk_home="/usr/lib/jvm/zulu${jdk_ver}"
+      if ls $jdk_home > /dev/null; then
+        export JAVA_HOME=$jdk_home
+        break
+      fi
+    done
+
     WITH_DEFAULT_UPSTREAM_SHIM=0
 else
     MVN_PHASES="clean package"

--- a/pom.xml
+++ b/pom.xml
@@ -917,6 +917,7 @@
         <spark354.version>3.5.4</spark354.version>
         <spark400.version>4.0.0-SNAPSHOT</spark400.version>
         <mockito.version>3.12.4</mockito.version>
+        <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
         <scala.plugin.version>4.9.2</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -814,6 +814,8 @@
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                                     <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
+
+                                    <downloadSources>true</downloadSources>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -606,8 +606,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- Downgrade scala plugin version due to: https://github.com/sbt/sbt/issues/4305 -->
-                <scala.plugin.version>3.4.4</scala.plugin.version>
                 <spark.version.classifier>spark350db143</spark.version.classifier>
                 <spark.version>${spark350db143.version}</spark.version>
                 <spark.test.version>${spark350db143.version}</spark.test.version>
@@ -919,8 +917,7 @@
         <spark354.version>3.5.4</spark354.version>
         <spark400.version>4.0.0-SNAPSHOT</spark400.version>
         <mockito.version>3.12.4</mockito.version>
-        <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
-        <scala.plugin.version>4.9.1</scala.plugin.version>
+        <scala.plugin.version>4.9.2</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
@@ -1566,7 +1563,7 @@ This will force full Scala code rebuild in downstream modules.
             <plugin>
                 <groupId>ch.epfl.scala</groupId>
                 <artifactId>bloop-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/pom.xml
+++ b/pom.xml
@@ -812,7 +812,6 @@
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                                     <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
-
                                     <downloadSources>true</downloadSources>
                                 </configuration>
                             </execution>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -814,6 +814,8 @@
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                                     <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
+
+                                    <downloadSources>true</downloadSources>
                                 </configuration>
                             </execution>
                         </executions>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -812,7 +812,6 @@
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                                     <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
-
                                     <downloadSources>true</downloadSources>
                                 </configuration>
                             </execution>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -606,8 +606,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- Downgrade scala plugin version due to: https://github.com/sbt/sbt/issues/4305 -->
-                <scala.plugin.version>3.4.4</scala.plugin.version>
                 <spark.version.classifier>spark350db143</spark.version.classifier>
                 <spark.version>${spark350db143.version}</spark.version>
                 <spark.test.version>${spark350db143.version}</spark.test.version>
@@ -920,7 +918,7 @@
         <spark400.version>4.0.0-SNAPSHOT</spark400.version>
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
-        <scala.plugin.version>4.9.1</scala.plugin.version>
+        <scala.plugin.version>4.9.2</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
@@ -1566,7 +1564,7 @@ This will force full Scala code rebuild in downstream modules.
             <plugin>
                 <groupId>ch.epfl.scala</groupId>
                 <artifactId>bloop-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>


### PR DESCRIPTION
Closes #12245 

- Drop special scala-maven-plugin on Databricks preventing picking up the right flags for scalac for JDK9+
- Upgrade scala-maven-plugin to the latest 4.9.2
- Upgrade bloop-maven-plugin to the latest 2.0.1
- For Bloop on Databricks use zulu17 if available to workaround another Incremental compile error
- Set downloadSources to true by default
- Disable two-shim build when used WITH_BLOOP because with different JDKs used for 320 and db shims each it will fail on binary-dedupe given differences in the constant pool in otherwise equivalent classfiles.
    
 Signed-off-by: Gera Shegalov <gshegalov@nvidia.com>