### PR TITLE
Add spark355 to FilePartitionShims

### DIFF
--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/rapids/shims/FilePartitionShims.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/rapids/shims/FilePartitionShims.scala
@@ -20,6 +20,7 @@
 {"spark": "352"}
 {"spark": "353"}
 {"spark": "354"}
+{"spark": "355"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.rapids.shims
 


### PR DESCRIPTION
fix #12278 

Previously in add shim PR https://github.com/NVIDIA/spark-rapids/pull/12259 missed to include `FilePartitionShims`