### PR TITLE
Update spark400 version to 4.0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -974,7 +974,7 @@
         <spark353.version>3.5.3</spark353.version>
         <spark354.version>3.5.4</spark354.version>
         <spark355.version>3.5.5</spark355.version>
-        <spark400.version>4.0.0-SNAPSHOT</spark400.version>
+        <spark400.version>4.0.1-SNAPSHOT</spark400.version>
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
         <scala.plugin.version>4.9.1</scala.plugin.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -974,7 +974,7 @@
         <spark353.version>3.5.3</spark353.version>
         <spark354.version>3.5.4</spark354.version>
         <spark355.version>3.5.5</spark355.version>
-        <spark400.version>4.0.0-SNAPSHOT</spark400.version>
+        <spark400.version>4.0.1-SNAPSHOT</spark400.version>
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
         <scala.plugin.version>4.9.1</scala.plugin.version>


### PR DESCRIPTION
This PR is to update spark400 version to 4.0.1-SNAPSHOT.
The release candidates for Apache Spark-4.0 will be cut from 4.0.1-SNAPSHOT since the pom file in Apache Spark's branch-4.0 is updated to 4.0.1-SNAPSHOT.
