### PR TITLE
HybridScan: Enable bucketed read

### DIFF
--- a/integration_tests/src/main/python/hybrid_parquet_test.py
+++ b/integration_tests/src/main/python/hybrid_parquet_test.py
@@ -182,7 +182,7 @@ def test_hybrid_parquet_preloading(spark_tmp_path, coalesced_batch_size, preload
 filter_split_conf = {
     'spark.sql.sources.useV1SourceList': 'parquet',
     'spark.rapids.sql.hybrid.parquet.enabled': 'true',
-    'spark.rapids.sql.hybrid.parquet.filterPushDown': 'CPU',
+    'spark.rapids.sql.parquet.pushDownFiltersToHybrid': 'CPU',
     'spark.rapids.sql.expression.Ascii': False,
     'spark.rapids.sql.expression.StartsWith': False,
     'spark.rapids.sql.hybrid.whitelistExprs': 'StartsWith'
@@ -209,7 +209,7 @@ def test_hybrid_parquet_filter_pushdown_gpu(spark_tmp_path):
         conf=rebase_write_corrected_conf)
     conf = filter_split_conf.copy()
     conf.update({
-        'spark.rapids.sql.hybrid.parquet.filterPushDown': 'GPU'
+        'spark.rapids.sql.parquet.pushDownFiltersToHybrid': 'GPU'
     })
     # filter conditions should remain on the GPU
     plan = with_gpu_session(
@@ -262,24 +262,19 @@ def test_hybrid_parquet_filter_pushdown_unsupported(spark_tmp_path):
 
 @pytest.mark.skipif(is_databricks_runtime(), reason="Hybrid feature does not support Databricks currently")
 @pytest.mark.skipif(not is_hybrid_backend_loaded(), reason="HybridScan specialized tests")
-@pytest.mark.parametrize('parquet_gens', parquet_gens_list, ids=idfn)
 @hybrid_test
-def test_hybrid_parquet_bucket_read(parquet_gens, spark_tmp_path, spark_tmp_table_factory):
-    data_path = spark_tmp_path + '/PARQUET_BUCKET_DATA'
-    
-    gen_list = [('id', long_gen)] + [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
-    num_buckets = 8
-    table_name = spark_tmp_table_factory.get()
-    
-    with_cpu_session(lambda spark: 
-        gen_df(spark, gen_list, length=10000)
-            .write
-            .bucketBy(num_buckets, "id")
-            .sortBy("id")
-            .option("path", data_path)
-            .saveAsTable(table_name),
+@allow_non_gpu(*non_utc_allow)
+def test_hybrid_parquet_filter_pushdown_timestamp(spark_tmp_path):
+    data_path = spark_tmp_path + '/PARQUET_DATA'
+    with_cpu_session(
+        lambda spark: gen_df(spark, [('a', TimestampGen(start=datetime(1900, 1, 1, tzinfo=timezone.utc)))]).write.parquet(data_path),
         conf=rebase_write_corrected_conf)
-    
+
+    # Timestamp is not fully supported in Hybrid Filter, so it should remain on the GPU
+    plan = with_gpu_session(
+        lambda spark: spark.read.parquet(data_path).filter(f.col("a") > f.lit(datetime(2024, 1, 1, tzinfo=timezone.utc)))._jdf.queryExecution().executedPlan(),
+        conf=filter_split_conf)
+    check_filter_pushdown(plan, pushed_exprs=[], not_pushed_exprs=['isnotnull', '>'])
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.parquet(data_path).filter(f.col("a") > f.lit(datetime(2024, 1, 1, tzinfo=timezone.utc))),
         conf=filter_split_conf)

--- a/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
@@ -77,10 +77,8 @@ object HybridExecutionUtils extends PredicateHelper {
         case _ => false
       })
     }
-    // TODO: supports BucketedScan
-    lazy val noBucketedScan = !fsse.bucketedScan
 
-    isEnabled && isParquet && nonEmptySchema && allSupportedTypes && noBucketedScan
+    isEnabled && isParquet && nonEmptySchema && allSupportedTypes
   }
 
   /**


### PR DESCRIPTION
Close https://github.com/NVIDIA/spark-rapids/issues/12297

This pr turn bucketed scan on in Hybrid Scan, because it works fine under tests. Also added an integration test.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
