### PR TITLE
Support more types for a Seq to dump the total size when an OOM happens

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -294,6 +294,11 @@ object RmmRapidsRetryIterator extends Logging {
     item
   }
 
+  /** Co-work with AutoCloseableSeqInternal to print the total size information when OOM */
+  trait SizeProvider {
+    def sizeInBytes: Long
+  }
+
   /**
    * AutoCloseable wrapper on Seq[T], returning a Seq[T] that can be closed.
    *
@@ -314,10 +319,11 @@ object RmmRapidsRetryIterator extends Logging {
 
     override def toString(): String = {
       val totalSize = ts.map {
-        case scb: SpillableColumnarBatch => scb.sizeInBytes
+        case sp: SizeProvider => sp.sizeInBytes
         case _ => 0L
       }.sum
-      s"AutoCloseableSeqInternal totalSize:$totalSize, inner:[${ts.mkString(";")}]"
+      s"AutoCloseableSeqInternal totalSize:$totalSize with ${length} elements, inner:\n" +
+        s"[${ts.mkString("; ")}]"
     }
   }
 


### PR DESCRIPTION
No issue here.

Since this PR is a small refactor to have more buffer types support the `AutoCloseableSeqInternal` in calculating the total size and output it into OOM logs for debugging.

This is to resolve the following issue: (The totalSize is 0 but there are indeed buffers taking some memory.)
```
com.nvidia.spark.rapids.jni.CpuSplitAndRetryOOM: CPU OutOfMemory: could not split inputs and retry.
  The current attempt: {AutoCloseableSeqInternal totalSize:0, 
  inner:[
    KudoSerializedTableColumn(SpillableKudoTable{header=SerializedTableHeader{offset=927930, numRows=309308, validityBufferLen=1159920, offsetBufferLen=2474472, totalDataLen=81270700, numColumns=33, hasValidityBuffer=[-43, -1, -1, -1, 1]}, shb=SpillableHostBuffer length:81270700, handle:com.nvidia.spark.rapids.spill.SpillableHostBufferHandle@603be768});
    KudoSerializedTableColumn(SpillableKudoTable{header=SerializedTableHeader{offset=0, numRows=306219, validityBufferLen=1148400, offsetBufferLen=2449760, totalDataLen=80459132, numColumns=33, hasValidityBuffer=[-43, -1, -1, -1, 1]}, shb=SpillableHostBuffer length:80459132, handle:com.nvidia.spark.rapids.spill.SpillableHostBufferHandle@7cce2c4});
    KudoSerializedTableColumn(SpillableKudoTable{header=SerializedTableHeader{offset=306219, numRows=306219, validityBufferLen=1148400, offsetBufferLen=2449760, totalDataLen=80459132, numColumns=33, hasValidityBuffer=[-43, -1, -1, -1, 1]}, shb=SpillableHostBuffer length:80459132, handle:com.nvidia.spark.rapids.spill.SpillableHostBufferHandle@28a40d75});
```
