### PR TITLE
Fix leaks when we re-partition in GpuSubPartitionHashJoin

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -444,7 +444,7 @@ class GpuSubPartitionPairIterator(
     val realNumPartitions = computeNumPartitions(bigBuildBatches)
     // build partitioner
     val buildIt = GpuSubPartitionHashJoin.safeIteratorFromSeq(bigBuildBatches.toSeq)
-      .map(_.getColumnarBatch())
+      .map(scb => withResource(scb){_.getColumnarBatch()})
     bigBuildBatches.clear()
     buildSubPartitioner.safeClose(new Exception())
     buildSubPartitioner = new GpuBatchSubPartitioner(buildIt, boundBuildKeys,
@@ -453,7 +453,7 @@ class GpuSubPartitionPairIterator(
 
     // stream partitioner
     val streamIt = GpuSubPartitionHashJoin.safeIteratorFromSeq(bigStreamBatches.toSeq)
-      .map(_.getColumnarBatch())
+      .map(scb => withResource(scb){_.getColumnarBatch()})
     bigStreamBatches.clear()
     streamSubPartitioner.safeClose(new Exception())
     streamSubPartitioner = new GpuBatchSubPartitioner(streamIt, boundStreamKeys,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/12319

The PR here ensures we close spillable batches when we rebuild the `GpuBatchSubPartitioner` with a new number of partitions. Failing to do so means we leak the memory, causing the spill framework to have to spill and never free these orphaned handles.