### PR TITLE
[Doc] Update doc: Hybrid execution limitations [skip ci]

### DIFF
--- a/docs/dev/hybrid-execution.md
+++ b/docs/dev/hybrid-execution.md
@@ -53,7 +53,7 @@ the Rapids hybrid jar) in the classpath by specifying:
 ## Limitations
 - Only supports CPU architecture: x86_64
 - Only supports OS: Ubuntu 20.04, Ubuntu 22.04
-- Only supports Java versions: 8, 11, 17
+- Only tested Java versions: 8, 11, 17
 - Only supports V1 Parquet data source.
 - Only supports Scala 2.12, do not support Scala 2.13.
 - Support Spark 3.2.2, 3.3.1, 3.4.2, and 3.5.1, matching [Gluten](https://github.com/apache/incubator-gluten/releases/tag/v1.2.0).

--- a/docs/dev/hybrid-execution.md
+++ b/docs/dev/hybrid-execution.md
@@ -51,6 +51,9 @@ the Rapids hybrid jar) in the classpath by specifying:
 `--jars=<gluten-bundle-jar>,<gluten-thirdparty-jar>,<rapids-hybrid-jar>`
 
 ## Limitations
+- Only supports CPU architecture: x86_64
+- Only supports OS: Ubuntu 20.04, Ubuntu 22.04
+- Only supports Java versions: 8, 11, 17
 - Only supports V1 Parquet data source.
 - Only supports Scala 2.12, do not support Scala 2.13.
 - Support Spark 3.2.2, 3.3.1, 3.4.2, and 3.5.1, matching [Gluten](https://github.com/apache/incubator-gluten/releases/tag/v1.2.0).


### PR DESCRIPTION
Add Hybrid execution limitations:

- Only supports CPU architecture: x86_64
- Only supports OS: Ubuntu 20.04, Ubuntu 22.04
- Only tested Java versions: 8, 11, 17

Signed-off-by: Chong Gao <res_life@163.com>