### PR TITLE
print spillable summary on bookkeep

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -27,6 +27,7 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.jni.{CpuRetryOOM, CpuSplitAndRetryOOM, GpuRetryOOM, GpuSplitAndRetryOOM, RmmSpark, RmmSparkThreadState}
+import com.nvidia.spark.rapids.spill.SpillFramework
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
@@ -819,6 +820,10 @@ object RmmRapidsRetryIterator extends Logging {
   val threadCountBlockedUntilReady: AtomicInteger = new AtomicInteger(0)
 
   private def logMemoryBookkeeping(): Unit = synchronized { // use synchronized to keep neat
+
+    // print spillable status
+    logInfo(SpillFramework.getHostStoreSpillableSummary)
+    logInfo(SpillFramework.getDeviceStoreSpillableSummary)
 
     // print host memory bookkeeping
     logInfo(HostAlloc.getHostAllocBookkeepSummary())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
@@ -1741,11 +1741,21 @@ object SpillFramework extends Logging {
   }
 
   def getHostStoreSpillableSummary: String = {
-    stores.hostStore.spillableSummary()
+    try {
+      stores.hostStore.spillableSummary()
+    } catch {
+      case _: IllegalStateException =>
+        "Could not log spill summary, spill framework not initialized"
+    }
   }
 
   def getDeviceStoreSpillableSummary: String = {
-    stores.deviceStore.spillableSummary()
+    try {
+      stores.deviceStore.spillableSummary()
+    } catch {
+      case _: IllegalStateException =>
+        "Could not log spill summary, spill framework not initialized"
+    }
   }
 
   def shutdown(): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillFramework.scala
@@ -1231,6 +1231,24 @@ trait SpillableStore[T <: SpillableHandle]
       }
     }
   }
+
+  def spillableSummary(): String = {
+    var spillableHandleCount = 0L
+    var spillableHandleBytes = 0L
+    var totalHandleBytes = 0L
+    handles.forEach((handle, _) => {
+      totalHandleBytes += handle.approxSizeInBytes
+      if (handle.spillable) {
+        spillableHandleCount += 1
+        spillableHandleBytes += handle.approxSizeInBytes
+      }
+    })
+    s"SpillableStore: ${this.getClass.getSimpleName}, " +
+      s"Total Handles: $numHandles, " +
+      s"Spillable Handles: $spillableHandleCount, " +
+      s"Total Handle Bytes: $totalHandleBytes, " +
+      s"Spillable Handle Bytes: $spillableHandleBytes"
+  }
 }
 
 class SpillableHostStore(val maxSize: Option[Long] = None)
@@ -1720,6 +1738,14 @@ object SpillFramework extends Logging {
     }
     val hostSpillStorageSizeStr = hostSpillStorageSize.map(sz => s"$sz B").getOrElse("unlimited")
     logInfo(s"Initialized SpillFramework. Host spill store max size is: $hostSpillStorageSizeStr.")
+  }
+
+  def getHostStoreSpillableSummary: String = {
+    stores.hostStore.spillableSummary()
+  }
+
+  def getDeviceStoreSpillableSummary: String = {
+    stores.deviceStore.spillableSummary()
   }
 
   def shutdown(): Unit = {


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/12173

When BOOKKEEP is enabled and when it is triggered printing, it is high likely that we encounter some bugs from oom state machine like https://github.com/NVIDIA/spark-rapids/issues/12311. At this point, some of the spillable handles are spillable but oom state machine might mistakenly think there's no more memory to use.

so it's useful to print how much much memory is spillable from the perspective from SpillFramework.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
