### PR TITLE
Make KudoHostMergeResultWrapper spillable

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -167,7 +167,7 @@ object GpuShuffleCoalesceUtils {
 /**
  * A trait representing the shuffle coalesced result by the Shuffle coalesce iterator.
  */
-sealed trait CoalescedHostResult extends AutoCloseable {
+trait CoalescedHostResult extends AutoCloseable {
   /** Convert itself to a GPU batch */
   def toGpuBatch(dataTypes: Array[DataType]): ColumnarBatch
 
@@ -216,23 +216,6 @@ class JCudfTableOperator extends SerializedTableOperator[SerializedTableColumn] 
     }
     new JCudfCoalescedHostResult(ret)
   }
-}
-
-case class KudoHostMergeResultWrapper(inner: KudoHostMergeResult) extends CoalescedHostResult {
-
-  /** Convert itself to a GPU batch */
-  override def toGpuBatch(dataTypes: Array[DataType]): ColumnarBatch = {
-    RmmRapidsRetryIterator.withRetryNoSplit {
-      withResource(inner.toTable) { cudfTable =>
-        GpuColumnVector.from(cudfTable, dataTypes)
-      }
-    }
-  }
-
-  /** Get the data size */
-  override def getDataSize: Long = inner.getDataLength
-
-  override def close(): Unit = inner.close()
 }
 
 case class RowCountOnlyMergeResult(rowCount: Int) extends CoalescedHostResult {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -27,7 +27,7 @@ import com.nvidia.spark.rapids.FileUtils.createTempFile
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
-import com.nvidia.spark.rapids.jni.kudo.{DumpOption, KudoHostMergeResult, KudoSerializer, MergeOptions}
+import com.nvidia.spark.rapids.jni.kudo.{DumpOption, KudoHostMergeResultWrapper, KudoSerializer, MergeOptions}
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 import org.apache.hadoop.conf.Configuration
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
@@ -51,9 +51,9 @@ case class KudoHostMergeResultWrapper(
 
 object KudoHostMergeResultWrapper {
   def apply(inner: KudoHostMergeResult): KudoHostMergeResultWrapper = {
-    KudoHostMergeResultWrapper(inner.schema, inner.columnInfoList,
-      SpillableHostBuffer(inner.hostBuf,
-        inner.hostBuf.getLength, SpillPriorities.ACTIVE_BATCHING_PRIORITY
+    KudoHostMergeResultWrapper(inner.getSchema, inner.getColumnInfoList,
+      SpillableHostBuffer(inner.getHostBuf,
+        inner.getHostBuf.getLength, SpillPriorities.ACTIVE_BATCHING_PRIORITY
       )
     )
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * Use KudoHostMergeResultWrapper.apply(KudoHostMergeResult) to construct
  * a KudoHostMergeResultWrapper.
  */
-case class KudoHostMergeResultWrapper(
+case class KudoHostMergeResultWrapper private(
     schema: Schema, columnInfoList: Array[ColumnViewInfo], spillableHostBuffer: SpillableHostBuffer)
   extends CoalescedHostResult {
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni.kudo
+
+import ai.rapids.cudf.Schema
+import com.nvidia.spark.rapids.{CoalescedHostResult, GpuColumnVector, RmmRapidsRetryIterator, SpillableHostBuffer, SpillPriorities}
+import com.nvidia.spark.rapids.Arm.withResource
+
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+case class KudoHostMergeResultWrapper(
+    schema: Schema, columnInfoList: Array[ColumnViewInfo], spillableHostBuffer: SpillableHostBuffer)
+  extends CoalescedHostResult {
+
+  /** Convert itself to a GPU batch */
+  override def toGpuBatch(dataTypes: Array[DataType]): ColumnarBatch = {
+    RmmRapidsRetryIterator.withRetryNoSplit {
+      withResource(
+        KudoHostMergeResult.toTableStatic(
+          spillableHostBuffer.getHostBuffer(), schema, columnInfoList)
+      ) { cudfTable =>
+        GpuColumnVector.from(cudfTable, dataTypes)
+      }
+    }
+  }
+
+  /** Get the data size */
+  override def getDataSize: Long = spillableHostBuffer.length
+
+  override def close(): Unit = spillableHostBuffer.close()
+}
+
+object KudoHostMergeResultWrapper {
+  def apply(inner: KudoHostMergeResult): KudoHostMergeResultWrapper = {
+    KudoHostMergeResultWrapper(inner.schema, inner.columnInfoList,
+      SpillableHostBuffer(inner.hostBuf,
+        inner.hostBuf.getLength, SpillPriorities.ACTIVE_BATCHING_PRIORITY
+      )
+    )
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/jni/kudo/KudoHostMergeResultWrapper.scala
@@ -23,6 +23,14 @@ import com.nvidia.spark.rapids.Arm.withResource
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+/**
+ * KudoHostMergeResultWrapper is a replacement for KudoHostMergeResult, because it:
+ * 1. Implements the CoalescedHostResult interface
+ * 2. Make the host buffer in KudoHostMergeResult spillable
+ *
+ * Use KudoHostMergeResultWrapper.apply(KudoHostMergeResult) to construct
+ * a KudoHostMergeResultWrapper.
+ */
 case class KudoHostMergeResultWrapper(
     schema: Schema, columnInfoList: Array[ColumnViewInfo], spillableHostBuffer: SpillableHostBuffer)
   extends CoalescedHostResult {


### PR DESCRIPTION
Contributes to #12345 by taking care of the kudo part.
This PR relies on https://github.com/NVIDIA/spark-rapids-jni/pull/3049 to be merged first.