### PR TITLE
Allow BigSizedJoinIterator#buildPartitioner to produce more subparittions

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -110,6 +110,7 @@ class GpuShuffledHashJoinMeta(
           right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
+          conf.sizedJoinPartitionAmplification,
           readOpt,
           isSkewJoin = false)(
           join.leftKeys,
@@ -125,6 +126,7 @@ class GpuShuffledHashJoinMeta(
           right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
+          conf.sizedJoinPartitionAmplification,
           readOpt,
           isSkewJoin = false)(
           join.leftKeys,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -518,6 +518,7 @@ abstract class GpuShuffledSizedHashJoinExec[HOST_BATCH_TYPE <: AutoCloseable] ex
    * @param info join information from the probing phase
    * @param gpuBatchSizeBytes target GPU batch size
    * @param metricsMap metrics to update
+   * @param partitionNumAmplification boost number of partitions for build size by this times
    * @return iterator to produce the results of the join
    */
   private def doBigBuildJoin(
@@ -1583,6 +1584,7 @@ class StreamSidePartitioner(
  *
  * @param info join information from input probing phase
  * @param gpuBatchSizeBytes target GPU batch size
+ * @param partitionNumAmplification boost number of partitions for build size by this times
  * @param metrics metrics to update
  */
 class BigSizedJoinIterator(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
@@ -97,6 +97,7 @@ class GpuSortMergeJoinMeta(
           right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
+          conf.sizedJoinPartitionAmplification,
           readOpt,
           join.isSkewJoin)(
           join.leftKeys,
@@ -112,6 +113,7 @@ class GpuSortMergeJoinMeta(
           right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
+          conf.sizedJoinPartitionAmplification,
           readOpt,
           join.isSkewJoin)(
           join.leftKeys,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2322,6 +2322,18 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .integerConf
     .createWithDefault(16)
 
+  val SIZED_JOIN_PARTITION_AMPLIFICATION =
+    conf("spark.rapids.sql.join.sizedJoin.buildPartitionNumberAmplification")
+      .doc("In sized join, by default we'll use bytes_of_build_size/batch_size + 1 as the number " +
+        "of partitions for the build side. This config is used to amplify the number of " +
+        "partitions for the build side. The default value is 1, which means we'll use the " +
+        "default number of partitions. If the value is greater than 1, we'll amplify the " +
+        "number of partitions by this value.")
+      .internal()
+      .doubleConf
+      .checkValue(v => v >= 1, "The amplification factor must be greater than or equal to 1")
+      .createWithDefault(1)
+
   val ENABLE_AQE_EXCHANGE_REUSE_FIXUP = conf("spark.rapids.sql.aqeExchangeReuseFixup.enable")
       .doc("Option to turn on the fixup of exchange reuse when running with " +
           "adaptive query execution.")
@@ -2746,6 +2758,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
     get(USE_SHUFFLED_ASYMMETRIC_HASH_JOIN)
 
   lazy val joinOuterMagnificationThreshold: Int = get(JOIN_OUTER_MAGNIFICATION_THRESHOLD)
+
+  lazy val sizedJoinPartitionAmplification: Double = get(SIZED_JOIN_PARTITION_AMPLIFICATION)
 
   lazy val stableSort: Boolean = get(STABLE_SORT)
 


### PR DESCRIPTION
This PR closes https://github.com/NVIDIA/spark-rapids/issues/12367 by introducing a new config called spark.rapids.sql.join.sizedJoin.buildPartitionNumberAmplification