### PR TITLE
Set the parquet reader type to AUTO to make sure multi-file reader is used [databricks]

### DIFF
--- a/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
+++ b/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
+++ b/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
@@ -70,6 +70,7 @@ if os.environ.get('INCLUDE_SPARK_AVRO_JAR', 'false') == 'true':
 
 conf = {
     'spark.rapids.sql.columnSizeBytes': 1000,
+    'spark.rapids.sql.format.parquet.reader.type': 'AUTO',
     'spark.sql.orc.impl': 'hive',  # null type column is not supported on native
     'spark.rapids.sql.format.avro.enabled': 'true',
     'spark.rapids.sql.format.avro.read.enabled': 'true'


### PR DESCRIPTION
This PR makes sure we use the multi-file parquet reader. 

As part of #12238 we set the `spark.rapids.sql.format.parquet.reader.type` to `PERFILE` on Databricks 14.3 by default to support reading deletion vectors. As a consequence some tests that rely on multi-file reader were failing. 

fixes #12376 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
