### PR TITLE
Conditional spark job timeout 12398

### DIFF
--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -37,6 +37,6 @@ markers =
     pyarrow_test: Mark pyarrow tests
     datagen_overrides: Mark that allows overriding datagen settings (i.e. seed) for a test
     tz_sensitive_test: Mark the test as a time zone sensitive test which will be tested against extra timezones
-    spark_job_timeout(seconds, dump_threads): Override the default timeout settrings
+    spark_job_timeout(condition, seconds, dump_threads): Override the default timeout settrings
 filterwarnings =
     ignore:.*pytest.mark.order.*:_pytest.warning_types.PytestUnknownMarkWarning

--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -98,7 +98,7 @@ public class TimeoutSparkListener extends SparkListener {
         timeoutSeconds + " seconds, cancelling. " +
         "Look into fixing the test or reducing its execution time. " +
         "If necessary, adjust the timeout using the marker " +
-        "pytest.mark.spark_job_timeout(seconds,dump_threads)";
+        "pytest.mark.spark_job_timeout(condition, seconds,dump_threads)";
       if (shouldDumpThreads) {
         LOG.error(message + " Driver thread dump follows");
         dumpThreads();

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -272,7 +272,7 @@ def set_spark_job_timeout(request):
         spark_timeout = tm.kwargs.get('seconds', default_timeout_seconds)
         dump_threads = tm.kwargs.get('dump_threads', True)
     # before the test
-    if condition:
+    if condition is True:
         logger.info(f"timeout={spark_timeout} seconds marker is active")
         hung_job_listener = (
         _spark._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener(

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -180,12 +180,12 @@ def _get_driver_opts_for_worker_logs(_sb, wid):
         ' -Dlogfile={}'.format(log_file)
 
     # Set up Logging to the WORKERID_worker_logs
-    # Note: This logger is only used for logging the test name in method `log_test_name`. 
+    # Note: This logger is only used for logging the test name in method `log_test_name`.
     global logger
     logger.setLevel(logging.INFO)
     # Create file handler to output logs into corresponding worker log file
-    # This file_handler is modifying the worker_log file that the plugin will also write to 
-    # The reason for doing this is to get all test logs in one place from where we can do other analysis 
+    # This file_handler is modifying the worker_log file that the plugin will also write to
+    # The reason for doing this is to get all test logs in one place from where we can do other analysis
     # that might be needed in future to look at the execs that were used in our integration tests
     file_handler = logging.FileHandler(log_file)
     # Set the formatter for the file handler, we match the formatter from the basicConfig for consistency in logs
@@ -262,25 +262,29 @@ def set_spark_job_timeout(request):
     # TODO dial down after identifying all long tests
     # and set exceptions there
     default_timeout_seconds = 900
+    spark_timeout = default_timeout_seconds
+    dump_threads = True
+    condition = True
     logger.debug("set_spark_job_timeout: BEFORE TEST\n")
     tm = request.node.get_closest_marker("spark_job_timeout")
     if tm:
+        condition = tm.kwargs.get('condition', True)
         spark_timeout = tm.kwargs.get('seconds', default_timeout_seconds)
         dump_threads = tm.kwargs.get('dump_threads', True)
-    else:
-        spark_timeout = default_timeout_seconds
-        dump_threads = True
     # before the test
-    hung_job_listener = (
-      _spark._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener(
-          _spark._jsc, 
-          spark_timeout, 
-          dump_threads)
-    ) 
-    hung_job_listener.register()
+    if condition:
+        logger.info(f"timeout={spark_timeout} seconds marker is active")
+        hung_job_listener = (
+        _spark._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener(
+            _spark._jsc,
+            spark_timeout,
+            dump_threads)
+        )
+        hung_job_listener.register()
     # yield for test
-    yield 
+    yield
     # after the test
     logger.debug("set_spark_job_timeout: AFTER TEST\n")
-    hung_job_listener.unregister()
+    if condition:
+        hung_job_listener.unregister()
 

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -24,7 +24,7 @@ from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_mi
 # TODO undo once we fix 400 and 350db143
 # https://github.com/NVIDIA/spark-rapids/pull/12383
 pytestmark = [
-    pytest.mark.spark_job_timeout(condition=is_databricks143_or_later(),  seconds=30)
+    pytest.mark.spark_job_timeout(condition=is_databricks143_or_later(), seconds=30)
 ]
 
 try:

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -17,14 +17,14 @@ from pyspark import BarrierTaskContext, TaskContext
 
 from conftest import is_at_least_precommit_run, is_databricks_runtime
 from spark_session import (is_before_spark_330, is_before_spark_331, is_before_spark_350, is_spark_341,
-                           is_spark_400_or_later)
+                           is_spark_400_or_later, is_databricks143_or_later)
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
 
 # TODO undo once we fix 400 and 350db143
 # https://github.com/NVIDIA/spark-rapids/pull/12383
 pytestmark = [
-    pytest.mark.spark_job_timeout(seconds=30)
+    pytest.mark.spark_job_timeout(condition=is_databricks143_or_later(),  seconds=30)
 ]
 
 try:


### PR DESCRIPTION
One of the options to fix #12398

udf_test timeout shortening was only needed for DBR 14.3 where many items timed out

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
