### PR TITLE
Ignore always, log once set_spark_job_timeout failures [databricks]

### DIFF
--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -286,7 +286,7 @@ def set_spark_job_timeout(request):
         hung_job_listener = None
         if set_spark_job_timeout_failure_logged is False:
             set_spark_job_timeout_failure_logged = True
-            logger.warning(f"set_spark_job_timeout: Ignoring exception : {e}")
+            logger.warning(f"set_spark_job_timeout: Ignoring pre-test exception : {e}")
             logger.error(traceback.format_exc())
         pass
     # yield for test
@@ -294,5 +294,12 @@ def set_spark_job_timeout(request):
     # after the test
     logger.debug("set_spark_job_timeout: AFTER TEST\n")
     if hung_job_listener is not None:
-        hung_job_listener.unregister()
+        try:
+            hung_job_listener.unregister()
+        except Exception as e:
+            if set_spark_job_timeout_failure_logged is False:
+                set_spark_job_timeout_failure_logged = True
+                logger.warning(f"set_spark_job_timeout: Ignoring post-test exception : {e}")
+                logger.error(traceback.format_exc())
+            pass
 


### PR DESCRIPTION
Fixes #12408 

- Ignore any exceptions when trying to register the timeout
- Log an error once 


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
