### PR TITLE
Use 1hr as the default Spark action timeout

### DIFF
--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -261,7 +261,7 @@ def log_test_name(request):
 def set_spark_job_timeout(request):
     # TODO dial down after identifying all long tests
     # and set exceptions there
-    default_timeout_seconds = 900
+    default_timeout_seconds = 60 * 60
     logger.debug("set_spark_job_timeout: BEFORE TEST\n")
     tm = request.node.get_closest_marker("spark_job_timeout")
     if tm:


### PR DESCRIPTION
This PR updates the default Spark action timeout in integration tests from 900 seconds (15 minutes) to 3600 seconds (1 hour).

Resolves #12411