### PR TITLE
make inputs of AsymmetricJoinSizer spillable for non kudo cases

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -1168,8 +1168,7 @@ object SpillableHostConcatResult {
         new KudoSpillableHostConcatResult(oldKudoTable.header, buffer)
       }
       case col: SerializedTableColumn =>
-        val buffer = col.hostBuffer
-        buffer.incRefCount()
+        val buffer = col.getHostBuffer
         new CudfSpillableHostConcatResult(col.header, buffer)
       case c =>
         throw new IllegalStateException(s"Expected SerializedTableColumn, got ${c.getClass}")


### PR DESCRIPTION
this PR closes https://github.com/NVIDIA/spark-rapids/issues/12417 by modifying SerializedTableColumn's HostMemoryBuffer field to a SpillableHostBuffer field