### PR TITLE
WAR: hardcode fsspec==2025.3.0 [skip ci]

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,5 +17,6 @@ pandas
 pyarrow
 pytest-xdist >= 2.0.0
 findspark
+fsspec == 2025.3.0
 fastparquet == 0.8.3 ; python_version == '3.8'
 fastparquet == 2024.5.0 ; python_version >= '3.9'

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,5 +52,5 @@ PYTHON_SITE_PACKAGES="$HOME/.local/lib/${PYTHON_VERSION}/site-packages"
 $PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES pytest sre_yield requests pandas pyarrow findspark pytest-xdist pytest-order
 
 # Install fastparquet (and numpy as its dependency).
-echo -e "fastparquet==0.8.3;python_version=='3.8'\nfastparquet==2024.5.0;python_version>='3.9'" > fastparquet.txt
+echo -e "fsspec==2025.3.0\nfastparquet==0.8.3;python_version=='3.8'\nfastparquet==2024.5.0;python_version>='3.9'" > fastparquet.txt
 $PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES -r fastparquet.txt


### PR DESCRIPTION
workaround https://github.com/NVIDIA/spark-rapids/issues/12412 to unblock DB 11.x and 12.x runtimes (3.8 as default python) CI

this is a bug from https://github.com/fsspec/filesystem_spec/issues/1816 which published new release (2025.3.1) with incorrect meta (which should support only py3.9+)
<img width="290" alt="image" src="https://github.com/user-attachments/assets/0f9e8abf-5602-482e-a157-52d1f149e334" />


