### PR TITLE
Use a single listener for all timeout fixture invocations

### DIFF
--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -51,6 +51,9 @@ import org.slf4j.LoggerFactory;
  */
 public class TimeoutSparkListener extends SparkListener {
   private static final Logger LOG = LoggerFactory.getLogger(TimeoutSparkListener.class);
+  private static JavaSparkContext sparkContext;
+  private static int timeoutSeconds;
+  private static boolean shouldDumpThreads;
   private static final ScheduledExecutorService runner = Executors.newScheduledThreadPool(1,
     runnable -> {
       final Thread t = new Thread(runnable);
@@ -59,13 +62,8 @@ public class TimeoutSparkListener extends SparkListener {
       return t;
     }
   );
-
   private static final Map<Integer,ScheduledFuture<?>> cancelJobMap = new ConcurrentHashMap<>();
-  private static int timeoutSeconds;
-  private static boolean shouldDumpThreads;
-  private static JavaSparkContext sparkContext;
   private static final TimeoutSparkListener SINGLETON = new TimeoutSparkListener();
-
 
   public TimeoutSparkListener() {
     super();
@@ -118,6 +116,8 @@ public class TimeoutSparkListener extends SparkListener {
     final ScheduledFuture<?> cancelFuture = cancelJobMap.remove(jobId);
     if (cancelFuture != null) {
       cancelFuture.cancel(false);
+    } else {
+      LOG.debug("Timeout task for Job {} not found", jobId);
     }
   }
 

--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -121,9 +121,9 @@ public class TimeoutSparkListener extends SparkListener {
     }
   }
 
-  public static void setSparkJobTimeout(int ts, boolean dummpThreads) {
+  public static void setSparkJobTimeout(int ts, boolean dumpThreads) {
     timeoutSeconds = ts;
-    shouldDumpThreads = dummpThreads;
+    shouldDumpThreads = dumpThreads;
   }
 
   public void onApplicationEnd(SparkListenerApplicationEnd applicationEnd) {

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -149,6 +149,13 @@ def pytest_sessionstart(session):
     # make it a better error message
     _s.sparkContext.setLogLevel("WARN")
     java_import(_s._jvm, 'org.apache.spark.rapids.tests.TimeoutSparkListener')
+    # TODO dial down after identifying all long tests
+    # and set exceptions there
+    global default_timeout_seconds
+    global default_dump_threads
+    default_timeout_seconds = 60 * 60
+    default_dump_threads = True
+    _s._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.init(_s._jsc)
     global _spark
     _spark = _s
 
@@ -180,12 +187,12 @@ def _get_driver_opts_for_worker_logs(_sb, wid):
         ' -Dlogfile={}'.format(log_file)
 
     # Set up Logging to the WORKERID_worker_logs
-    # Note: This logger is only used for logging the test name in method `log_test_name`. 
+    # Note: This logger is only used for logging the test name in method `log_test_name`.
     global logger
     logger.setLevel(logging.INFO)
     # Create file handler to output logs into corresponding worker log file
-    # This file_handler is modifying the worker_log file that the plugin will also write to 
-    # The reason for doing this is to get all test logs in one place from where we can do other analysis 
+    # This file_handler is modifying the worker_log file that the plugin will also write to
+    # The reason for doing this is to get all test logs in one place from where we can do other analysis
     # that might be needed in future to look at the execs that were used in our integration tests
     file_handler = logging.FileHandler(log_file)
     # Set the formatter for the file handler, we match the formatter from the basicConfig for consistency in logs
@@ -259,28 +266,21 @@ def log_test_name(request):
 
 @pytest.fixture(scope="function", autouse=True)
 def set_spark_job_timeout(request):
-    # TODO dial down after identifying all long tests
-    # and set exceptions there
-    default_timeout_seconds = 60 * 60
     logger.debug("set_spark_job_timeout: BEFORE TEST\n")
     tm = request.node.get_closest_marker("spark_job_timeout")
     if tm:
         spark_timeout = tm.kwargs.get('seconds', default_timeout_seconds)
-        dump_threads = tm.kwargs.get('dump_threads', True)
+        dump_threads = tm.kwargs.get('dump_threads', default_dump_threads)
     else:
         spark_timeout = default_timeout_seconds
-        dump_threads = True
+        dump_threads = default_dump_threads
     # before the test
-    hung_job_listener = (
-      _spark._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener(
-          _spark._jsc, 
-          spark_timeout, 
-          dump_threads)
-    ) 
-    hung_job_listener.register()
+    _spark._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.setSparkJobTimeout(
+        spark_timeout,
+        dump_threads
+    )
     # yield for test
-    yield 
+    yield
     # after the test
-    logger.debug("set_spark_job_timeout: AFTER TEST\n")
-    hung_job_listener.unregister()
+
 


### PR DESCRIPTION
Resolves #12413
Resolves #12408

- Make most of the state and the thread pool `static`
- Ignore any exceptions when trying to register the timeout
- Log an error once 

Verified that the number of threads grows linearly without this PR and stays flat with this PR using
```
watch 'pidof java | xargs -n 1 ps -eL --pid | grep -c spark-job'
```