### PR TITLE
Set parquet reader type to `PERFILE` when performing delta scan on Databricks 14.3

### DIFF
--- a/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
+++ b/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
@@ -246,11 +246,7 @@ case class GpuDeltaParquetFileFormat(
 }
 
 object GpuDeltaParquetFileFormat {
-  def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
-    if (!meta.conf.isParquetPerFileReadEnabled) {
-      meta.willNotWorkOnGpu("Deletion vectors only supported for PERFILE reader")
-    }
-  }
+  def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {}
 
   /** Utility method to create a new writable vector */
   private def newVector(size: Int, dataType: StructField): WritableColumnVector = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1111,11 +1111,7 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .stringConf
     .transform(_.toUpperCase(java.util.Locale.ROOT))
     .checkValues(RapidsReaderType.values.map(_.toString))
-    .createWithDefault(
-      ShimLoader.getShimVersion match {
-        case DatabricksShimVersion(3, 5, 0, "14.3") => RapidsReaderType.PERFILE.toString
-        case _ => RapidsReaderType.AUTO.toString
-      })
+    .createWithDefault(RapidsReaderType.AUTO.toString)
 
   val PARQUET_DECOMPRESS_CPU =
     conf("spark.rapids.sql.format.parquet.decompressCpu")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1111,7 +1111,11 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .stringConf
     .transform(_.toUpperCase(java.util.Locale.ROOT))
     .checkValues(RapidsReaderType.values.map(_.toString))
-    .createWithDefault(RapidsReaderType.AUTO.toString)
+    .createWithDefault(
+      ShimLoader.getShimVersion match {
+        case DatabricksShimVersion(3, 5, 0, "14.3") => RapidsReaderType.PERFILE.toString
+        case _ => RapidsReaderType.AUTO.toString
+      })
 
   val PARQUET_DECOMPRESS_CPU =
     conf("spark.rapids.sql.format.parquet.decompressCpu")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/VersionUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/VersionUtils.scala
@@ -18,6 +18,11 @@ package com.nvidia.spark.rapids
 
 object VersionUtils {
 
+  lazy val isDatabricks143 = ShimLoader.getShimVersion match {
+    case DatabricksShimVersion(3, 5, 0, "14.3") => true
+    case _ => false
+  }
+
   lazy val isSpark320OrLater: Boolean = cmpSparkVersion(3, 2, 0) >= 0
 
   lazy val isSpark: Boolean = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -99,7 +99,7 @@ case class GpuFileSourceScanExec(
   /**
    Remove after GpuDeltaParquetFileFormat support other readers besides PERFILE
    */
-  private lazy val deltaProvider = DeltaProvider()
+  @transient private lazy val deltaProvider = DeltaProvider()
 
   private val isPerFileReadEnabled = {
     val isDatabricks143 = VersionUtils.isDatabricks143


### PR DESCRIPTION
This PR sets the parquet reader type to `PERFILE` on Databricks 14.3 when performing a delta scan. 

fixes #12427

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
