### PR TITLE
Add a flag to override the PLUGIN_JARS [databricks]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -12,6 +12,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Documentation generated using a generative AI tool
+# ============================================================================
+# run_pyspark_from_build.sh
+# ============================================================================
+#
+# Description:
+#   This script runs PySpark integration tests from a build environment.
+#
+# Usage:
+#   To run this script, ensure you have Apache Spark installed and configured
+#   properly, along with the necessary dependencies (e.g., findspark, xdist).
+#
+# Parameters and Environment Variables:
+#   - SPARK_HOME: Path to your Apache Spark installation.
+#   - SKIP_TESTS: If set to true, skips running the Python integration tests.
+#   - INCLUDE_SPARK_AVRO_JAR: If set to true, includes Avro tests.
+#   - TEST: Specifies a specific test to run.
+#   - TEST_TAGS: Allows filtering tests based on tags.
+#   - TEST_TYPE: Specifies the type of tests to run.
+#   - LOCAL_JAR_PATH: Path to local jars if not building from source.
+#   - PLUGIN_JAR: Path to a built spark-rapids plugin jar, the default points to the target directory
+#   - INTEGRATION_TEST_VERSION_OVERRIDE: Overrides the auto-detected shim version.
+#
+# Script Flow:
+#   1. Setup and Checks: Validates environment and detects Spark/Scala versions.
+#   2. Jars and Dependencies: Identifies necessary jars based on Spark version.
+#   3. Test Configuration: Determines parallelism and checks for necessary tools.
+#   4. Running Tests: Executes tests using runtests.py with specified options.
+#
+# Example Usage:
+#   To run all tests, including Avro tests:
+#     INCLUDE_SPARK_AVRO_JAR=true ./run_pyspark_from_build.sh
+#
+#   To run a specific test:
+#     TEST=my_test ./run_pyspark_from_build.sh
+#
+# Troubleshooting:
+#   - Ensure SPARK_HOME is correctly set.
+#   - Check for missing dependencies like findspark or xdist.
+#   - Verify that the necessary jars are correctly linked.
+#
+# Contributing:
+#   Contributions should follow the NVIDIA Spark-Rapids project guidelines.
+#   Ensure changes are tested thoroughly to maintain compatibility.
+#
+# ============================================================================
+
 set -ex
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
@@ -56,7 +104,7 @@ else
     # support alternate local jars NOT building from the source code
     if [ -d "$LOCAL_JAR_PATH" ]; then
         AVRO_JARS=$(echo "$LOCAL_JAR_PATH"/spark-avro*.jar)
-        PLUGIN_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
+        PLUGIN_JAR=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
         if [ -f $(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar) ]; then
             export INCLUDE_PARQUET_HADOOP_TEST_JAR=true
             PARQUET_HADOOP_TESTS=$(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar)
@@ -80,7 +128,7 @@ else
         # Make sure we have Parquet version >= 1.12 in the dependency
         LOWEST_PARQUET_JAR=$(echo -e "$MIN_PARQUET_JAR\n$PARQUET_HADOOP_TESTS" | sort -V | head -1)
         export INCLUDE_PARQUET_HADOOP_TEST_JAR=$([[ "$LOWEST_PARQUET_JAR" == "$MIN_PARQUET_JAR" ]] && echo true || echo false)
-        PLUGIN_JARS=$(echo "$TARGET_DIR"/../../dist/target/rapids-4-spark_*.jar)
+        PLUGIN_JAR=${PLUGIN_JAR:-$(echo "$TARGET_DIR"/../../dist/target/rapids-4-spark_*.jar)}
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
         TEST_JARS=$(echo "$TARGET_DIR"/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)
     fi
@@ -99,7 +147,7 @@ else
 
     # ALL_JARS includes dist.jar integration-test.jar avro.jar parquet.jar if they exist
     # Remove non-existing paths and canonicalize the paths including get rid of links and `..`
-    ALL_JARS=$(readlink -e $PLUGIN_JARS $TEST_JARS $AVRO_JARS $PARQUET_HADOOP_TESTS || true)
+    ALL_JARS=$(readlink -e $PLUGIN_JAR $TEST_JARS $AVRO_JARS $PARQUET_HADOOP_TESTS || true)
     # `:` separated jars
     ALL_JARS="${ALL_JARS//$'\n'/:}"
 


### PR DESCRIPTION
This PR adds a way to override the plugin jar when running integration tests.

By setting PLUGIN_JAR env variable you can override the default which would use the plugin jar from the dist module.

fixes https://github.com/NVIDIA/spark-rapids/issues/12393

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
