### PR TITLE
Tag UpdateCommand to fallback to the CPU when deletion vectors are enabled [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/UpdateCommandMeta.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/UpdateCommandMeta.scala
@@ -19,11 +19,12 @@ package com.nvidia.spark.rapids.delta
 import com.databricks.sql.transaction.tahoe.commands.{UpdateCommand, UpdateCommandEdge}
 import com.databricks.sql.transaction.tahoe.rapids.{GpuDeltaLog, GpuUpdateCommand}
 import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.shims.UpdateCommandMetaShim
 
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 class UpdateCommandMeta(
-    updateCmd: UpdateCommand,
+    val updateCmd: UpdateCommand,
     conf: RapidsConf,
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule)
@@ -34,6 +35,7 @@ class UpdateCommandMeta(
       willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
+    UpdateCommandMetaShim.tagForGpu(this)
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
       Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }
@@ -50,7 +52,7 @@ class UpdateCommandMeta(
 }
 
 class UpdateCommandEdgeMeta(
-    updateCmd: UpdateCommandEdge,
+    val updateCmd: UpdateCommandEdge,
     conf: RapidsConf,
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule)
@@ -61,6 +63,7 @@ class UpdateCommandEdgeMeta(
       willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
+    UpdateCommandMetaShim.tagForGpu(this)
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
       Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }

--- a/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/shims/UpdateCommandMetaShim.scala
+++ b/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/shims/UpdateCommandMetaShim.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.shims
+
+import com.databricks.sql.transaction.tahoe.commands.DeletionVectorUtils
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
+import com.nvidia.spark.rapids.delta.{UpdateCommandEdgeMeta, UpdateCommandMeta}
+
+object UpdateCommandMetaShim {
+  def tagForGpu(meta: UpdateCommandMeta): Unit = {
+    val deltaLog = Option(meta.updateCmd.tahoeFileIndex).map(_.deltaLog).orNull
+    val dvFeatureEnabled = deltaLog == null ||
+      DeletionVectorUtils.deletionVectorsWritable(deltaLog.unsafeVolatileSnapshot)
+
+    if (dvFeatureEnabled && meta.updateCmd.conf.getConf(
+      DeltaSQLConf.UPDATE_USE_PERSISTENT_DELETION_VECTORS)) {
+      // https://github.com/NVIDIA/spark-rapids/issues/8654
+      meta.willNotWorkOnGpu("Deletion vector writes are not supported on GPU")
+    }
+  }
+
+  def tagForGpu(meta: UpdateCommandEdgeMeta): Unit = {
+    val deltaLog = Option(meta.updateCmd.tahoeFileIndex).map(_.deltaLog).orNull
+    val dvFeatureEnabled = deltaLog == null ||
+      DeletionVectorUtils.deletionVectorsWritable(deltaLog.unsafeVolatileSnapshot)
+
+    if (dvFeatureEnabled && meta.updateCmd.conf.getConf(
+      DeltaSQLConf.UPDATE_USE_PERSISTENT_DELETION_VECTORS)) {
+      // https://github.com/NVIDIA/spark-rapids/issues/8654
+      meta.willNotWorkOnGpu("Deletion vector writes are not supported on GPU")
+    }
+  }
+}


### PR DESCRIPTION
This PR tags the UpdateCommand and UpdateCommandEdge to fallback to the CPU on Databricks 14.3

fixes #12123 
fixes #12360 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
