### PR TITLE
Tag DeleteCommand to fallback to the CPU when deletion vectors are enabled on Databricks 14.3 [databricks]

### DIFF
--- a/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/shims/DeleteCommandMetaShim.scala
+++ b/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/shims/DeleteCommandMetaShim.scala
@@ -16,10 +16,28 @@
 
 package com.nvidia.spark.rapids.delta.shims
 
+import com.databricks.sql.transaction.tahoe.commands.DeletionVectorUtils
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
 import com.nvidia.spark.rapids.delta.{DeleteCommandEdgeMeta, DeleteCommandMeta}
 
 object DeleteCommandMetaShim {
-  def tagForGpu(meta: DeleteCommandMeta): Unit = {}
+  def tagForGpu(meta: DeleteCommandMeta): Unit = {
+    val dvFeatureEnabled = DeletionVectorUtils.deletionVectorsWritable(
+      meta.deleteCmd.deltaLog.unsafeVolatileSnapshot)
+    if (dvFeatureEnabled && meta.deleteCmd.conf.getConf(
+        DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS)) {
+      // https://github.com/NVIDIA/spark-rapids/issues/8654
+      meta.willNotWorkOnGpu("Deletion vector writes are not supported on GPU")
+    }
+  }
 
-  def tagForGpu(meta: DeleteCommandEdgeMeta): Unit = {}
+  def tagForGpu(meta: DeleteCommandEdgeMeta): Unit = {
+    val dvFeatureEnabled = DeletionVectorUtils.deletionVectorsWritable(
+      meta.deleteCmd.deltaLog.unsafeVolatileSnapshot)
+    if (dvFeatureEnabled && meta.deleteCmd.conf.getConf(
+        DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS)) {
+      // https://github.com/NVIDIA/spark-rapids/issues/8654
+      meta.willNotWorkOnGpu("Deletion vector writes are not supported on GPU")
+    }
+  }
 }


### PR DESCRIPTION
This PR checks the deletion vectors property and fallback to the CPU on Databricks 14.3

fixes https://github.com/NVIDIA/spark-rapids/issues/12405
contributes towards https://github.com/NVIDIA/spark-rapids/issues/12360

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
