### PR TITLE
Crash pytest worker if the Pyspark child JVM is unusable

### DIFF
--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -54,7 +54,6 @@ public class TimeoutSparkListener extends SparkListener {
   private static JavaSparkContext sparkContext;
   private static int timeoutSeconds;
   private static boolean shouldDumpThreads;
-  private static boolean onXdistWorker;
   private static final ScheduledExecutorService runner = Executors.newScheduledThreadPool(1,
     runnable -> {
       final Thread t = new Thread(runnable);
@@ -70,10 +69,9 @@ public class TimeoutSparkListener extends SparkListener {
     super();
   }
 
-  public static synchronized void init(JavaSparkContext sc, boolean onXdist) {
+  public static synchronized void init(JavaSparkContext sc) {
     if (sparkContext == null) {
       sparkContext = sc;
-      onXdistWorker = onXdist;
       sparkContext.sc().addSparkListener(SINGLETON);
     }
   }
@@ -89,12 +87,10 @@ public class TimeoutSparkListener extends SparkListener {
     if (sparkContext != null) {
       sparkContext.sc().cancelJob(jobId, message);
     }
-    if (onXdistWorker) {
-      LOG.error(message + ". Shutting down the Driver JVM; xdist worker will stop as well per " +
+    LOG.error(message + ". Shutting down the Driver JVM; xdist worker will stop as well per " +
 "https://github.com/NVIDIA/spark-rapids/pull/12455. Pending tests will be re-executed " +
 "in the replacement worker");
-      System.exit(timeoutSeconds);
-    }
+    System.exit(timeoutSeconds);
   }
 
   public void onJobStart(SparkListenerJobStart jobStart) {

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -154,10 +154,8 @@ def pytest_sessionstart(session):
     # and set exceptions there
     global default_timeout_seconds
     global default_dump_threads
-    global set_spark_job_timeout_failure_logged
     default_timeout_seconds = 60 * 60
     default_dump_threads = True
-    set_spark_job_timeout_failure_logged = False
     _s._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.init(_s._jsc)
     global _spark
     _spark = _s
@@ -267,6 +265,20 @@ def spark_version():
 def log_test_name(request):
     logger.info("Running test '{}'".format(request.node.nodeid))
 
+
+def _set_job_timeout_and_crash_when_failed(spark_timeout, dump_threads):
+    try:
+        _spark._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.setSparkJobTimeout(
+            spark_timeout,
+            dump_threads
+        )
+    except Exception as e:
+        logger.error(f"""set_spark_job_timeout: Unusable Spark Driver JVM detected!
+                     Crashing pytest worker to mitigate: {traceback.format_exc()}""")
+        os._exit(os.EX_UNAVAILABLE)
+        pass
+
+
 @pytest.fixture(scope="function", autouse=True)
 def set_spark_job_timeout(request):
     logger.debug("set_spark_job_timeout: BEFORE TEST\n")
@@ -278,18 +290,9 @@ def set_spark_job_timeout(request):
         spark_timeout = default_timeout_seconds
         dump_threads = default_dump_threads
     # before the test
-    try:
-        _spark._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.setSparkJobTimeout(
-            spark_timeout,
-            dump_threads
-        )
-    except Exception as e:
-        if not set_spark_job_timeout_failure_logged:
-            set_spark_job_timeout_failure_logged = True
-            logger.warning(f"set_spark_job_timeout: Ignoring pre-test exception : {traceback.format_exc()}")
-        pass
+    _set_job_timeout_and_crash_when_failed(spark_timeout, dump_threads)
     # yield for test
     yield
     # after the test
-
+    _set_job_timeout_and_crash_when_failed(spark_timeout, dump_threads)
 

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -156,7 +156,10 @@ def pytest_sessionstart(session):
     global default_dump_threads
     default_timeout_seconds = 60 * 60
     default_dump_threads = True
-    _s._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.init(_s._jsc)
+    _s._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.init(
+        _s._jsc,
+        running_with_xdist(session, is_worker = True)
+    )
     global _spark
     _spark = _s
 
@@ -276,7 +279,6 @@ def _set_job_timeout_and_crash_when_failed(spark_timeout, dump_threads):
         logger.error(f"""set_spark_job_timeout: Unusable Spark Driver JVM detected!
                      Crashing pytest worker to mitigate: {traceback.format_exc()}""")
         os._exit(os.EX_UNAVAILABLE)
-        pass
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -156,10 +156,7 @@ def pytest_sessionstart(session):
     global default_dump_threads
     default_timeout_seconds = 60 * 60
     default_dump_threads = True
-    _s._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.init(
-        _s._jsc,
-        running_with_xdist(session, is_worker = True)
-    )
+    _s._jvm.org.apache.spark.rapids.tests.TimeoutSparkListener.init(_s._jsc)
     global _spark
     _spark = _s
 


### PR DESCRIPTION
Resolves #12454 

This PR uses the spark-job-timeout fixture as a keep alive ping.
On any exception to `setSparkJobTimeout` (which is a trivial setter
```Java
  public static void setSparkJobTimeout(int ts, boolean dumpThreads) {
    timeoutSeconds = ts;
    shouldDumpThreads = dumpThreads;
  }
``` 
and it is fair to assume that the child JVM is unusable) we issue a hard exit on the PySpark Python driver. 

This triggers xdist to restart the worker and the previously misreported pytest items are resubmitted to the restarted worker and they succeed if simply misreported.

With this PR we get an accurate report containing only the Parquet LZ4 test failures due to #12453 

```
DATAGEN_SEED=1743895597  TEST_TAGS='not premerge_ci_1' TEST_TYPE=pre-commit TESTS='parquet_testing_test.py' SPARK_HOME=~/dist/spark-3.2.0-bin-hadoop3.2 ./integration_tests/run_pyspark_from_build.sh --test_oom_injection_mode=never 
================================================================================================================================================================================== short test summary info ===================================================================================================================================================================================
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_valid_files[confs0-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/hadoop_lz4_compressed.parquet][DATAGEN_SEED=1743895597, TZ=UTC]
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_valid_files[confs0-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/hadoop_lz4_compressed_larger.parquet][DATAGEN_SEED=1743895597, TZ=UTC]
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_valid_files[confs1-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/hadoop_lz4_compressed.parquet][DATAGEN_SEED=1743895597, TZ=UTC]
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_valid_files[confs1-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/hadoop_lz4_compressed_larger.parquet][DATAGEN_SEED=1743895597, TZ=UTC]
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_error_files[confs0-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/non_hadoop_lz4_compressed.parquet-Exception][DATAGEN_SEED=1743895597, TZ=UTC] - AssertionError: Expected error 'Exception' did not appear in 'ConnectionRefusedError: [Errno 111] Connection refused'
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_error_files[confs0-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/non_hadoop_lz4_compressed.parquet-Exception][DATAGEN_SEED=1743895597, TZ=UTC]
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_error_files[confs1-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/non_hadoop_lz4_compressed.parquet-Exception][DATAGEN_SEED=1743895597, TZ=UTC] - AssertionError: Expected error 'Exception' did not appear in 'ConnectionRefusedError: [Errno 111] Connection refused'
FAILED ../../src/main/python/parquet_testing_test.py::test_parquet_testing_error_files[confs1-/home/gshegalov/gits/NVIDIA/spark-rapids/thirdparty/parquet-testing/data/non_hadoop_lz4_compressed.parquet-Exception][DATAGEN_SEED=1743895597, TZ=UTC]
============================================================================================================================================================= 8 failed, 70 passed, 20 xfailed, 4 xpassed, 108 warnings in 33.49s =============================================================================================================================================================
```


