### PR TITLE
Add Support For Timezone Rules [WIP]

### DIFF
--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -106,16 +106,7 @@ def is_supported_time_zone():
     """
     Is current TZ supported, forward to Java TimeZoneDB to check
     """
-    tz = get_test_tz()
-    if tz in _support_info_cache_for_time_zone:
-        # already cached
-        return _support_info_cache_for_time_zone[tz]
-    else:
-        jvm = spark_jvm()
-        support = jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.isSupportedTimeZone(tz)
-        # cache support info
-        _support_info_cache_for_time_zone[tz] = support
-        return support
+    return True
 
 _is_nightly_run = False
 _is_precommit_run = False

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1752,7 +1752,8 @@ object GpuOverrides extends Logging {
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (hour, conf, p, r) => new UnaryExprMeta[Hour](hour, conf, p, r) {
         override def isTimeZoneSupported = true
-        override def convertToGpu(expr: Expression): GpuExpression = GpuHour(expr, hour.timeZoneId)
+        override def convertToGpu(expr: Expression): GpuExpression =
+          GpuHour(expr, hour.timeZoneId, conf.maxTimestamp)
       }),
     expr[Minute](
       "Returns the minute component of the string/timestamp",
@@ -1761,7 +1762,7 @@ object GpuOverrides extends Logging {
       (minute, conf, p, r) => new UnaryExprMeta[Minute](minute, conf, p, r) {
         override def isTimeZoneSupported = true
         override def convertToGpu(expr: Expression): GpuExpression =
-          GpuMinute(expr, minute.timeZoneId)
+          GpuMinute(expr, minute.timeZoneId, conf.maxTimestamp)
       }),
     expr[Second](
       "Returns the second component of the string/timestamp",
@@ -1770,7 +1771,7 @@ object GpuOverrides extends Logging {
       (second, conf, p, r) => new UnaryExprMeta[Second](second, conf, p, r) {
         override def isTimeZoneSupported = true
         override def convertToGpu(expr: Expression): GpuExpression =
-          GpuSecond(expr, second.timeZoneId)
+          GpuSecond(expr, second.timeZoneId, conf.maxTimestamp)
       }),
     expr[WeekDay](
       "Returns the day of the week (0 = Monday...6=Sunday)",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -619,6 +619,13 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .internal()
     .stringConf
     .createOptional
+  
+  val MAX_TIMEZONE_YEAR = conf("spark.rapids.sql.maxTimezoneYear")
+    .doc("Set the max year for timestamp processing. Adding more years will use " +
+      "more memory, where 100 years is roughly 1MB.")
+    .commonlyUsed()
+    .integerConf
+    .createWithDefault(2200)
 
   // Internal Features
 
@@ -3324,6 +3331,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val gpuWriteMemorySpeed: Double = get(OPTIMIZER_GPU_WRITE_SPEED)
 
   lazy val driverTimeZone: Option[String] = get(DRIVER_TIMEZONE)
+
+  lazy val maxTimeZoneYear: Int = get(MAX_TIMEZONE_YEAR)
 
   lazy val isRangeWindowByteEnabled: Boolean = get(ENABLE_RANGE_WINDOW_BYTES)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -16,6 +16,7 @@
 package com.nvidia.spark.rapids
 
 import java.io.{File, FileOutputStream}
+import java.time.{LocalDateTime, ZoneId}
 import java.util
 
 import scala.collection.JavaConverters._
@@ -3332,7 +3333,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val driverTimeZone: Option[String] = get(DRIVER_TIMEZONE)
 
-  lazy val maxTimeZoneYear: Int = get(MAX_TIMEZONE_YEAR)
+  lazy val maxTimestamp: Long = LocalDateTime.of(get(MAX_TIMEZONE_YEAR)+1, 1, 1, 0, 0, 0)
+    .atZone(ZoneId.of("UTC")).toEpochSecond
 
   lazy val isRangeWindowByteEnabled: Boolean = get(ENABLE_RANGE_WINDOW_BYTES)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -17,7 +17,6 @@
 package com.nvidia.spark.rapids
 
 import com.nvidia.spark.rapids.RapidsMeta.noNeedToReplaceReason
-import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
 import com.nvidia.spark.rapids.shims.{DistributionUtil, SparkShimImpl}
 import java.time.ZoneId
 import scala.collection.mutable
@@ -384,18 +383,6 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
     }
   }
 
-  def checkTimeZoneId(sessionZoneId: ZoneId): Unit = {
-    // Both of the Spark session time zone and JVM's default time zone should be UTC.
-    if (!TimeZoneDB.isSupportedTimezone(sessionZoneId)) {
-      willNotWorkOnGpu("Not supported zone id. " +
-        s"Actual session local zone id: $sessionZoneId")
-    }
-
-    val defaultZoneId = ZoneId.systemDefault()
-    if (!TimeZoneDB.isSupportedTimezone(defaultZoneId)) {
-      willNotWorkOnGpu(s"Not supported zone id. Actual default zone id: $defaultZoneId")
-    }
-  }
 
   /**
    * Create a string representation of this in append.
@@ -1125,12 +1112,6 @@ abstract class BaseExprMeta[INPUT <: Expression](
 
     // Level 2 check
     if (!isTimeZoneSupported) return checkUTCTimezone(this, getZoneId())
-
-    // Level 3 check
-    val zoneId = getZoneId()
-    if (!GpuTimeZoneDB.isSupportedTimeZone(zoneId)) {
-      willNotWorkOnGpu(TimeZoneDB.timezoneNotSupportedStr(zoneId.toString))
-    }
   }
 
   protected def getZoneId(): ZoneId = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
@@ -40,7 +40,7 @@ object TimeStamp {
       (a, conf, p, r) => new UnixTimeExprMeta[GetTimestamp](a, conf, p, r) {
         override def isTimeZoneSupported = true
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
-          GpuGetTimestamp(lhs, rhs, sparkFormat, strfFormat, a.timeZoneId)
+          GpuGetTimestamp(lhs, rhs, sparkFormat, strfFormat, a.timeZoneId, conf.maxTimestamp)
         }
       })
   ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/TimeZoneDB.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/TimeZoneDB.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/TimeZoneDB.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/TimeZoneDB.scala
@@ -36,17 +36,6 @@ object TimeZoneDB {
     DateTimeUtils.getZoneId(formattedZoneId)
   }
 
-  // Support fixed offset or no transition rule case
-  def isSupportedTimeZone(timezoneId: String): Boolean = {
-    val rules = getZoneId(timezoneId).getRules
-    rules.isFixedOffset || rules.getTransitionRules.isEmpty
-  }
-
-  def isSupportedTimezone(timezoneId: ZoneId): Boolean = {
-    val rules = timezoneId.getRules
-    rules.isFixedOffset || rules.getTransitionRules.isEmpty
-  }
-
   def nonUTCTimezoneNotSupportedStr(exprName: String): String = {
     s"$exprName is not supported with timezone settings: (JVM:" +
       s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -77,42 +77,6 @@ trait TimestampConversionExpression {
     }
   }
 
-  // /**
-  //  * Get the result of evaluating this expression on the CPU side.
-  //  * This can be called from any point when CPU fallback is needed.
-  //  * @return A ColumnVector containing the CPU-computed results
-  //  */
-  // def getCpuResult(cpuExpr: Expression, lhs: GpuColumnVector, rhs: GpuScalar,
-  //   lhsType: DataType, rhsType: DataType): ColumnVector = {
-  //   // Create CPU expression with bound references
-  //   // val cpuExpr = ToUTCTimestamp(
-  //   //   BoundReference(0, TimestampType, nullable = true),
-  //   //   BoundReference(1, StringType, nullable = true)
-  //   // )
-    
-  //   val numRows = lhs.getRowCount.toInt
-  //   val resultVector = new OnHeapColumnVector(numRows, TimestampType)
-    
-  //   // Process each row manually
-  //   for (i <- 0 until numRows) {
-  //     val timestampValue = lhs.getBase.getLong(i)
-  //     val timezoneValue = rhs.getValue.asInstanceOf[UTF8String]
-      
-  //     // Create a row with these values
-  //     val row = InternalRow.fromSeq(Seq(timestampValue, timezoneValue))
-      
-  //     // Evaluate the expression
-  //     val result = cpuExpr.eval(row)
-      
-  //     if (result == null) {
-  //       resultVector.putNull(i)
-  //     } else {
-  //       resultVector.putLong(i, result.asInstanceOf[Long])
-  //     }
-  //   }
-    
-  //   GpuColumnVector.from(resultVector)
-  // }
   /**
   * Evaluates a CPU expression using GPU column vector data
   *


### PR DESCRIPTION
Closes #6840 
Needs to be pushed together with https://github.com/NVIDIA/spark-rapids-jni/pull/3072
We are adding timezone rules up to a certain year specified in config (defaults to 2170, will change to 2200 later)
Most of the new code on the spark-rapids side is on enabling variable offset timezones again, tests, and adding the runtime CPU fallback logic.

For Reviewers: it's a lot of changes, might be worth looking at the testing files (python) and scala changes separately

Code still in progress, might break into two separate PRs (one for Python test change, one for Scala change)

- [ ] Add Variable Timezone Tests
- [ ] Add Fallback Tests