### PR TITLE
Fallback GpuDeltaParquetFileFormat to CPU in presence of deletion vectors [databricks] 

### DIFF
--- a/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
+++ b/delta-lake/delta-spark350db143/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
@@ -21,7 +21,6 @@ import java.net.URI
 import com.databricks.sql.io.RowIndexFilterType
 import com.databricks.sql.transaction.tahoe.{DeltaColumnMappingMode, DeltaParquetFileFormat, IdMapping}
 import com.databricks.sql.transaction.tahoe.DeltaParquetFileFormat._
-import com.databricks.sql.transaction.tahoe.commands.DeletionVectorUtils
 import com.databricks.sql.transaction.tahoe.deletionvectors.{DropMarkedRowsFilter, KeepAllRowsFilter, KeepMarkedRowsFilter}
 import com.databricks.sql.transaction.tahoe.files.TahoeFileIndex
 import com.databricks.sql.transaction.tahoe.util.DeltaFileOperations.absolutePath
@@ -249,11 +248,13 @@ case class GpuDeltaParquetFileFormat(
 object GpuDeltaParquetFileFormat {
   def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     val format = meta.wrapped.relation.fileFormat.asInstanceOf[DeltaParquetFileFormat]
-    val dvEnabled = DeletionVectorUtils.deletionVectorsWritable(format.protocol, format.metadata)
-
-    if (dvEnabled || format.hasDeletionVectorMap) {
+    val requiredSchema = meta.wrapped.requiredSchema
+    if (requiredSchema.exists(_.name.startsWith("_databricks_internal"))) {
       meta.willNotWorkOnGpu(
-        s"Reading deletion vectors is not supported on the GPU")
+        s"reading metadata columns starting with prefix _databricks_internal is not supported")
+    }
+    if (format.hasDeletionVectorMap) {
+      meta.willNotWorkOnGpu("deletion vectors are not supported")
     }
   }
 

--- a/integration_tests/src/main/python/delta_lake_delete_test.py
+++ b/integration_tests/src/main/python/delta_lake_delete_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_equal, assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write, assert_gpu_and_cpu_are_equal_collect
+from asserts import assert_equal, assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write, assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
 from data_gen import *
 from delta_lake_utils import *
 from marks import *
@@ -137,6 +137,34 @@ def test_delta_deletion_vector(spark_tmp_path):
     with_cpu_session(write_func(data_path))
 
     assert_gpu_and_cpu_are_equal_collect(read_parquet_sql(data_path))
+
+@allow_non_gpu("SortExec, ColumnarToRowExec", *delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(), \
+                    reason="Deletion vectors new in Delta Lake 2.4 / Apache Spark 3.4")
+def test_delta_deletion_vector_perfile_read_fallback(spark_tmp_path):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    def setup_tables(spark):
+        setup_delta_dest_table(spark, data_path,
+                               dest_table_func=lambda spark: unary_op_df(spark, int_gen),
+                               use_cdf=False, enable_deletion_vectors=True)
+    def write_func(path):
+        delete_sql="DELETE FROM delta.`{}` where a = 0".format(path)
+        def delete_func(spark):
+            spark.sql(delete_sql)
+        return delete_func
+
+    def read_parquet_sql(data_path):
+        return lambda spark : spark.sql('select * from delta.`{}`'.format(data_path))
+
+    enable_conf = copy_and_update(delta_delete_enabled_conf,
+                                   {"spark.databricks.delta.delete.deletionVectors.persistent": "true"})
+
+    with_cpu_session(setup_tables, conf=enable_conf)
+    with_cpu_session(write_func(data_path), conf=enable_conf)
+
+    assert_gpu_fallback_collect(read_parquet_sql(data_path), "FileSourceScanExec", conf={"spark.rapids.sql.format.parquet.reader.type": "PERFILE"})
 
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake


### PR DESCRIPTION
This PR tags the plan to fallback to the CPU when deletion vectors are being read. 

fixes #12460 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
