### PR TITLE
Disable HLLPP precision 4 due to cuCollection bug

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -867,7 +867,7 @@ But this is not something that can be done generically and requires inner knowle
 what can trigger a side effect.
 
 ## HyperLogLogPlusPlus(approx_count_distinct)
-Spark supports a precision range [4, Infinity). GPU supports a precision range: [4, 14].
+Spark supports a precision range [4, Infinity). GPU supports a precision range: [5, 14].
 The precision formula from rsd parameter is:
 ```scala
 Math.ceil(2.0d * Math.log(1.106d / rsd) / Math.log(2.0d)).toInt

--- a/integration_tests/src/main/python/hyper_log_log_plus_plus_test.py
+++ b/integration_tests/src/main/python/hyper_log_log_plus_plus_test.py
@@ -40,12 +40,12 @@ def test_hllpp_reduction(data_gen):
 
 # precision = Math.ceil(2.0d * Math.log(1.106d / relativeSD) / Math.log(2.0d)).toInt
 _relativeSD = [
-    0.3,   #  precision 4
+    pytest.param(0.3, marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12452")), #  precision 4
     0.25,  #  precision 5
     0.15,  #  precision 6
     0.1,   #  precision 7
     0.08,  #  precision 8
-    0.05,  #  precision 9
+    0.05,  #  precision 9 # The default precision
     0.04,  #  precision 10
     0.03,  #  precision 11
     0.02,  #  precision 12

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4056,17 +4056,16 @@ object GpuOverrides extends Logging {
                 "5: Map counts: 2 + max(depthOf(key), depthOf(value)); "
             )
           }
-          // Spark already checked: precision >= 4, no need to check again.
           val precision = GpuHyperLogLogPlusPlus.computePrecision(a.relativeSD)
           // Spark supports precision range: [4, Infinity)
-          // Spark-Rapids only supports precision range: [4, 14]
-          if (precision > 14) {
+          // Spark-Rapids only supports precision range: [5, 14]
+          if (precision <= 4 || precision > 14) {
             //
             // Info: cuCollection supports precision range [4, 18]
             // Due to https://github.com/NVIDIA/spark-rapids/issues/12347, the Spark-Rapids supports
-            // fewer precisions than cuCollection: range: [4, 14]
+            // fewer precisions than cuCollection: range: [5, 14]
             willNotWorkOnGpu(s"The precision $precision from relativeSD ${a.relativeSD} is bigger" +
-              s" than 14, GPU only supports precision is less or equal to 14.")
+              s" than 14, GPU only supports precision range [5, 14].")
           }
         }
 


### PR DESCRIPTION
contributes https://github.com/NVIDIA/spark-rapids/issues/12452

Disable HLLPP precision 4 due to cuCollection bug

Signed-off-by: Chong Gao <res_life@163.com>