### PR TITLE
LoRE: support dump data from shuffle related nodes

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DumpUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DumpUtils.scala
@@ -112,7 +112,8 @@ object DumpUtils extends Logging {
    * @param columnarBatch The columnar batch to be dumped, should be GPU columnar batch. It
    *                      should be closed by caller.
    * @param outputStream  Will be closed after writing.
-   * @param kudoSerializer Optional. Only required when the batch contains a KudoSerializedTableColumn.
+   * @param kudoSerializer Optional. Only required when the batch contains a
+   *                       KudoSerializedTableColumn.
    */
   def dumpToParquet(columnarBatch: ColumnarBatch, outputStream: OutputStream,
       kudoSerializer: Option[KudoSerializer] = None)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DumpUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DumpUtils.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf._
 import ai.rapids.cudf.ColumnWriterOptions._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.jni.kudo.KudoSerializer
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 
@@ -33,10 +34,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 object DumpUtils extends Logging {
   /**
    * Debug utility to dump a host memory buffer to a file.
-   * @param conf Hadoop configuration
-   * @param data buffer containing data to dump to a file
+   *
+   * @param conf   Hadoop configuration
+   * @param data   buffer containing data to dump to a file
    * @param offset starting offset in the buffer of the data
-   * @param len size of the data in bytes
+   * @param len    size of the data in bytes
    * @param prefix prefix for a path to write the data
    * @param suffix suffix for a path to write the data
    * @return Hadoop path for where the data was written or null on error
@@ -109,15 +111,26 @@ object DumpUtils extends Logging {
    *
    * @param columnarBatch The columnar batch to be dumped, should be GPU columnar batch. It
    *                      should be closed by caller.
-   * @param outputStream Will be closed after writing.
+   * @param outputStream  Will be closed after writing.
+   * @param kudoSerializer Optional. Only required when the batch contains a KudoSerializedTableColumn.
    */
-  def dumpToParquet(columnarBatch: ColumnarBatch, outputStream: OutputStream): Unit = {
+  def dumpToParquet(columnarBatch: ColumnarBatch, outputStream: OutputStream,
+      kudoSerializer: Option[KudoSerializer] = None)
+  : Unit = {
     closeOnExcept(outputStream) { _ =>
-      // For batches from a shuffle node, convert the SerializedTableColumn to a table first
-      val table = if (columnarBatch.numCols() == 1 &&
-        columnarBatch.column(0).isInstanceOf[SerializedTableColumn]) {
-        val serializedCol = columnarBatch.column(0).asInstanceOf[SerializedTableColumn]
-        deserializeSerializedTableColumn(serializedCol)
+      // For batches from a shuffle node, convert the SerializedTableColumn or
+      // KudoSerializedTableColumn to a table first
+      val table = if (columnarBatch.numCols() == 1) {
+        columnarBatch.column(0) match {
+          case serializedCol: SerializedTableColumn =>
+            deserializeSerializedTableColumn(serializedCol)
+          case kudoCol: KudoSerializedTableColumn =>
+            require(kudoSerializer.isDefined,
+              "KudoSerializer must be provided when handling KudoSerializedTableColumn")
+            deserializeKudoSerializedTableColumn(kudoSerializer.get, kudoCol)
+          case _ =>
+            GpuColumnVector.from(columnarBatch)
+        }
       } else {
         GpuColumnVector.from(columnarBatch)
       }
@@ -175,24 +188,37 @@ object DumpUtils extends Logging {
     path
   }
 
-/**
- * Deserialize a SerializedTableColumn back to a Table
- */
-private def deserializeSerializedTableColumn(column: SerializedTableColumn): Table = {
-  import ai.rapids.cudf.JCudfSerialization
-  val header = column.header
-  val buffer = column.hostBuffer
-  if (buffer == null || header == null) {
-    throw new IllegalArgumentException("Cannot deserialize from null header or buffer")
-  }
+  /**
+   * Deserialize a SerializedTableColumn back to a Table
+   */
+  private def deserializeSerializedTableColumn(column: SerializedTableColumn): Table = {
+    import ai.rapids.cudf.JCudfSerialization
+    val header = column.header
+    val buffer = column.hostBuffer
+    if (buffer == null || header == null) {
+      throw new IllegalArgumentException("Cannot deserialize from null header or buffer")
+    }
 
-  withResource(JCudfSerialization.unpackHostColumnVectors(header, buffer)) { hostColumns =>
-    withResource(hostColumns.map(_.copyToDevice())) { deviceColumns =>
+    withResource(JCudfSerialization.unpackHostColumnVectors(header, buffer)) { hostColumns =>
+      withResource(hostColumns.map(_.copyToDevice())) { deviceColumns =>
         new Table(deviceColumns: _*)
       }
     }
   }
+
+  /**
+   * Deserialize a KudoSerializedTableColumn back to a Table
+   */
+  private def deserializeKudoSerializedTableColumn(kudoSerializer: KudoSerializer,
+      column: KudoSerializedTableColumn): Table
+  = {
+    withResource(column.spillableKudoTable.makeKudoTable) { kudoTable =>
+      kudoSerializer.mergeToTable(Array(kudoTable))
+    }
+  }
+
 }
+
 
 // parquet dumper
 class ParquetDumper(private val outputStream: OutputStream, table: Table) extends HostBufferConsumer

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
@@ -41,7 +41,7 @@ import org.apache.spark.util.SerializableConfiguration
 
 case class LoreRDDMeta(numPartitions: Int, outputPartitions: Seq[Int], attrs: Seq[Attribute])
 
-case class LoreRDDPartitionMeta(numBatches: Int, dataType: Seq[DataType], isFromShuffle: Boolean)
+case class LoreRDDPartitionMeta(numBatches: Int, dataType: Seq[DataType])
 
 trait GpuLoreRDD {
   def rootPath: Path

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
@@ -41,7 +41,7 @@ import org.apache.spark.util.SerializableConfiguration
 
 case class LoreRDDMeta(numPartitions: Int, outputPartitions: Seq[Int], attrs: Seq[Attribute])
 
-case class LoreRDDPartitionMeta(numBatches: Int, dataType: Seq[DataType])
+case class LoreRDDPartitionMeta(numBatches: Int, dataType: Seq[DataType], isFromShuffle: Boolean)
 
 trait GpuLoreRDD {
   def rootPath: Path
@@ -278,7 +278,6 @@ object GpuLore {
 
       sparkPlan
     }
-
     newPlan
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
@@ -278,6 +278,7 @@ object GpuLore {
 
       sparkPlan
     }
+
     newPlan
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/dump.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/dump.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/dump.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/dump.scala
@@ -67,9 +67,9 @@ class GpuLoreDumpRDD(info: LoreDumpRDDInfo, input: RDD[ColumnarBatch])
             val partitionMeta = if (isFromShuffle) {
               // get the array of dataType from the info.attrs
               val factDataTypes = info.attrs.map(_.dataType)
-              LoreRDDPartitionMeta(batchIdx, factDataTypes, isFromShuffle)
+              LoreRDDPartitionMeta(batchIdx, factDataTypes)
             } else {
-              LoreRDDPartitionMeta(batchIdx, GpuColumnVector.extractTypes(ret), isFromShuffle)
+              LoreRDDPartitionMeta(batchIdx, GpuColumnVector.extractTypes(ret))
             }
             GpuLore.dumpObject(partitionMeta, pathOfPartitionMeta(split.index),
               info.hadoopConf.value.value)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/replay.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/replay.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/replay.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/replay.scala
@@ -84,7 +84,6 @@ class GpuLoreReplayRDD(sc: SparkContext, rootPathStr: String,
                   GpuColumnVector.from(restoredTable, partitionMeta.dataType.toArray)
                 }
               }
-
             }
             batchIdx += 1
             ret

--- a/tests/src/test/scala/com/nvidia/spark/rapids/DumpUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/DumpUtilsSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  DataInputStream,
+  DataOutputStream,
+  File,
+  FileOutputStream
+}
+import java.nio.file.Files
+
+import ai.rapids.cudf.{HostMemoryBuffer, JCudfSerialization, Table}
+import ai.rapids.cudf.JCudfSerialization.SerializedTableHeader
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import org.scalatest.funsuite.AnyFunSuite
+
+class DumpUtilsSuite extends AnyFunSuite {
+
+  test("dumpToParquet handles SerializedTableColumn") {
+    // Create a simple table
+    withResource(
+      new Table.TestBuilder()
+        .column(
+          1L.asInstanceOf[java.lang.Long],
+          2L.asInstanceOf[java.lang.Long],
+          3L.asInstanceOf[java.lang.Long])
+        .column("a", "b", "c")
+        .build()) { table =>
+      // Serialize the table to a SerializedTableColumn
+      val byteOut = new ByteArrayOutputStream()
+      val out = new DataOutputStream(byteOut)
+      JCudfSerialization.writeToStream(table, out, 0, table.getRowCount)
+      out.close()
+      val bytes = byteOut.toByteArray
+      val in = new ByteArrayInputStream(bytes)
+      val din = new DataInputStream(in)
+      val header = new SerializedTableHeader(din)
+      assert(header.wasInitialized())
+      closeOnExcept(HostMemoryBuffer.allocate(header.getDataLen)) { hostBuffer =>
+        JCudfSerialization.readTableIntoBuffer(din, header, hostBuffer)
+        assert(header.wasDataRead())
+        // Create a ColumnarBatch with a SerializedTableColumn
+        withResource(SerializedTableColumn.from(header, hostBuffer)) { batch =>
+          // Create a temporary output file
+          val tempFile = File.createTempFile("dumptest", ".parquet")
+          tempFile.deleteOnExit()
+          // Test dumping the SerializedTableColumn to parquet
+          withResource(new FileOutputStream(tempFile)) { fileOut =>
+            DumpUtils.dumpToParquet(batch, fileOut)
+          }
+          // Verify the file was created and has content
+          assert(tempFile.exists())
+          assert(tempFile.length() > 0)
+          // Clean up
+          Files.delete(tempFile.toPath)
+        }
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/lore/GpuLoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/lore/GpuLoreSuite.scala
@@ -184,6 +184,24 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
     }
   }
 
+  test("GpuShuffledSymmetricHashJoin with in Kudo mode") {
+    doTestReplay("56[*]") { spark =>
+      // Disable broadcast join, force hash join
+      spark.conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+      spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      // in Kudo mode
+      spark.conf.set(RapidsConf.SHUFFLE_KUDO_SERIALIZER_ENABLED.key, "true")
+
+      // Create larger tables to ensure shuffle
+      val df1 = spark.range(0, 1000, 1, 100)
+        .selectExpr("id % 10 as key", "id as value")
+      val df2 = spark.range(0, 1000, 1, 100)
+        .selectExpr("id % 10 as key", "id as value")
+      // Join with equality condition to trigger hash join
+      df1.join(df2, Seq("key"))
+    }
+  }
+
   private def doTestReplay(loreDumpIds: String)(dfFunc: SparkSession => DataFrame) = {
     val loreId = OutputLoreId.parse(loreDumpIds).head._1
     withGpuSparkSession { spark =>


### PR DESCRIPTION
To fix: #12466 

Consider the following case:
![image](https://github.com/user-attachments/assets/017c74f0-9fc9-41cf-9b0d-67c4e2c900e6)
We want to replay the execution of `GpuShuffledSymmetricHashJoin`, thus we need to dump the data for its child `GpuCustomShuffleReader` and `GpuHashAggregate`.

GpuCustomShuffleReader gives out batches of `SerializedTableColumn` or `KudoSerializedTableColumn` that current LoRE framework doesn't support to dump and load.

To dump it this PR:

- detects if it's a SerializedTableColumn or KudoSerializedTableColumn case
- if so convert it back to Table as a normal case(Table) to leverage existing dump methods
- get the real data types from its plan meta and dump it along with the data

This PR aims to add support for such case.