### PR TITLE
Fix bug where rows dropped if partitioned column size is too large

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,10 @@ class ColumnarPartitionReaderWithPartitionValues(
     partitionValues: InternalRow,
     partitionSchema: StructType,
     maxGpuColumnSizeBytes: Long) extends PartitionReader[ColumnarBatch] {
-  override def next(): Boolean = fileReader.next()
+  override def next(): Boolean = {
+    outputIter.hasNext || fileReader.next()
+  }
   private var outputIter: Iterator[ColumnarBatch] = Iterator.empty
-
 
   override def get(): ColumnarBatch = {
     if (partitionSchema.isEmpty) {


### PR DESCRIPTION
This fixes #12435 

The bug was that in a specific class when checking if another batch was available, it totally missed that the code to add the partition columns might have split the original input batch. This only shows up in perfile as other classes are used in the other modes, and because perfile is not the default it is not super likely to show up in practice.