### PR TITLE
Align the semantics of the `dynamic partitions` metric for GPU write with Spark

### DIFF
--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaTaskStatisticsTracker.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaTaskStatisticsTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from DataSkippingStatsTracker.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -136,7 +136,7 @@ class GpuDeltaTaskStatisticsTracker(
     submittedFiles.remove(filePath)
   }
 
-  override def newPartition(): Unit = { }
+  override def newPartition(partitionValues: InternalRow): Unit = { }
 
   protected def initializeAggBuf(buffer: SpecificInternalRow): InternalRow =
     initializeStats.target(buffer).apply(EmptyRow)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.rapids
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.WriteTaskStats
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -35,7 +36,7 @@ trait ColumnarWriteTaskStatsTracker {
    *       count of partitions without examining the values.
    * //@param partitionValues The values that define this new partition.
    */
-  def newPartition(/*partitionValues: InternalRow*/): Unit
+  def newPartition(partitionValues: InternalRow): Unit
 
   /**
    * Process the fact that a new file is about to be written.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -306,31 +306,31 @@ class GpuDynamicPartitionDataSingleWriter(
   extends GpuFileFormatDataWriter(description, taskAttemptContext, committer) {
   /** Wrapper class to index a unique concurrent output writer. */
   protected class WriterIndex(
-      var partitionPath: Option[String],
-      var bucketId: Option[Int]) extends Product2[Option[String], Option[Int]] {
+      var partitionValues: Option[InternalRow],
+      var bucketId: Option[Int]) extends Product2[Option[InternalRow], Option[Int]] {
 
     override def hashCode(): Int = ScalaMurmur3Hash.productHash(this)
 
     override def equals(obj: Any): Boolean = {
-      if (obj.isInstanceOf[WriterIndex]) {
+      if (canEqual(obj)) {
         val otherWI = obj.asInstanceOf[WriterIndex]
-        partitionPath == otherWI.partitionPath && bucketId == otherWI.bucketId
+        partitionValues == otherWI.partitionValues && bucketId == otherWI.bucketId
       } else {
         false
       }
     }
 
-    override def _1: Option[String] = partitionPath
+    override def _1: Option[InternalRow] = partitionValues
     override def _2: Option[Int] = bucketId
     override def canEqual(that: Any): Boolean = that.isInstanceOf[WriterIndex]
   }
 
   /**
-   * A case class to hold the batch, the optional partition path and the optional bucket
+   * A case class to hold the batch, the optional partition values and the optional bucket
    * ID for a split group. All the rows in the batch belong to the group defined by the
-   * partition path and the bucket ID.
+   * partition values and the bucket ID.
    */
-  private case class SplitPack(split: SpillableColumnarBatch, path: Option[String],
+  private case class SplitPack(split: SpillableColumnarBatch, partValues: Option[InternalRow],
       bucketId: Option[Int]) extends AutoCloseable {
     override def close(): Unit = {
       split.safeClose()
@@ -341,7 +341,7 @@ class GpuDynamicPartitionDataSingleWriter(
    * Avoid JVM GC issue when many short-living `WriterIndex` objects are created
    * if switching between concurrent writers frequently.
    */
-  private val currentWriterId: WriterIndex = new WriterIndex(None, None)
+  protected val currentWriterId: WriterIndex = new WriterIndex(None, None)
 
   /** Flag saying whether or not the data to be written out is partitioned. */
   protected val isPartitioned: Boolean = description.partitionColumns.nonEmpty
@@ -432,7 +432,7 @@ class GpuDynamicPartitionDataSingleWriter(
     }
   }
 
-  protected def genGetPartitionPathFunc(keyHostCb: ColumnarBatch): Int => Option[String] = {
+  protected def genGetPartValuesFunc(keyHostCb: ColumnarBatch): Int => Option[InternalRow] = {
     if (isPartitioned) {
       // Use the existing code to convert each row into a path. It would be nice to do this
       // on the GPU, but the data should be small and there are things we cannot easily
@@ -440,7 +440,7 @@ class GpuDynamicPartitionDataSingleWriter(
       import scala.collection.JavaConverters._
       val partCols = description.partitionColumns.indices.map(keyHostCb.column)
       val iter = new ColumnarBatch(partCols.toArray, keyHostCb.numRows()).rowIterator()
-        .asScala.map(getPartitionPath)
+        .asScala.map(_.copy())
       _ => Some(iter.next)
     } else {
       _ => None
@@ -512,7 +512,7 @@ class GpuDynamicPartitionDataSingleWriter(
     withResource(splits) { _ =>
       withResource(keyHostCb) { _ =>
         val getBucketId = genGetBucketIdFunc(keyHostCb)
-        val getNextPartPath = genGetPartitionPathFunc(keyHostCb)
+        val getNextPartValues = genGetPartValuesFunc(keyHostCb)
         val outDataTypes = description.dataColumns.map(_.dataType).toArray
         (0 until keyHostCb.numRows()).safeMap { idx =>
           val split = splits(idx)
@@ -521,7 +521,7 @@ class GpuDynamicPartitionDataSingleWriter(
             SplitPack(
               SpillableColumnarBatch(split, outDataTypes,
                 SpillPriorities.ACTIVE_BATCHING_PRIORITY),
-              getNextPartPath(idx), getBucketId(idx))
+              getNextPartValues(idx), getBucketId(idx))
           }
         }.toArray
       }
@@ -538,7 +538,7 @@ class GpuDynamicPartitionDataSingleWriter(
       releaseOutWriter(curWriterStatus)
     }
     curWriterStatus.recordsInFile = 0
-    curWriterStatus.writer = newWriter(newWriterId.partitionPath, newWriterId.bucketId,
+    curWriterStatus.writer = newWriter(newWriterId.partitionValues, newWriterId.bucketId,
       curWriterStatus.fileCounter)
   }
 
@@ -557,7 +557,7 @@ class GpuDynamicPartitionDataSingleWriter(
    * If bucket id is specified, we will append it to the end of the file name, but before the
    * file extension, e.g. part-r-00009-ea518ad4-455a-4431-b471-d24e03814677-00002.gz.parquet
    *
-   * @param partDir     the partition directory
+   * @param partValues  the partition values
    * @param bucketId    the bucket which all tuples being written by this OutputWriter belong to,
    *                    currently does not support `bucketId`, it's always None
    * @param fileCounter integer indicating the number of files to be written to `partDir`
@@ -565,8 +565,9 @@ class GpuDynamicPartitionDataSingleWriter(
   @scala.annotation.nowarn(
     "msg=method newTaskTempFile.* in class FileCommitProtocol is deprecated"
   )
-  def newWriter(partDir: Option[String], bucketId: Option[Int],
+  def newWriter(partValues: Option[InternalRow], bucketId: Option[Int],
       fileCounter: Int): ColumnarOutputWriter = {
+    val partDir = partValues.map(getPartitionPath(_))
     partDir.foreach(updatedPartitions.add)
     // Currently will be empty
     val bucketIdStr = bucketId.map(BucketingUtils.bucketIdToString).getOrElse("")
@@ -645,14 +646,14 @@ class GpuDynamicPartitionDataSingleWriter(
     // The input batch that is entirely sorted, so split it up by partitions and (or)
     // bucket ids, and write the split batches one by one.
     withResource(splitBatchByKeyAndClose(batch)) { splitPacks =>
-      splitPacks.zipWithIndex.foreach { case (SplitPack(sp, partPath, bucketId), i) =>
-        val hasDiffPart = partPath != currentWriterId.partitionPath
+      splitPacks.zipWithIndex.foreach { case (SplitPack(sp, partVals, bucketId), i) =>
+        val hasDiffPart = partVals != currentWriterId.partitionValues
         val hasDiffBucket = bucketId != currentWriterId.bucketId
         if (hasDiffPart || hasDiffBucket) {
           preUpdateCurrentWriterStatus(currentWriterId)
           if (hasDiffPart) {
-            currentWriterId.partitionPath = partPath
-            statsTrackers.foreach(_.newPartition())
+            currentWriterId.partitionValues = partVals
+            statsTrackers.foreach(_.newPartition(partVals.get))
           }
           if (hasDiffBucket) {
             currentWriterId.bucketId = bucketId
@@ -861,15 +862,21 @@ class GpuDynamicPartitionDataConcurrentWriter(
     withResource(groups) { _ =>
       withResource(keyHostCb) { _ =>
         val getBucketId = genGetBucketIdFunc(keyHostCb)
-        val getNextPartPath = genGetPartitionPathFunc(keyHostCb)
+        val getNextPartValues = genGetPartValuesFunc(keyHostCb)
         var idx = 0
         while (idx < groups.length && concurrentWriters.size < spec.maxWriters) {
-          val writerId = new WriterIndex(getNextPartPath(idx), getBucketId(idx))
+          val writerId = new WriterIndex(getNextPartValues(idx), getBucketId(idx))
           val writerStatus =
             concurrentWriters.getOrElseUpdate(writerId, new WriterStatusWithBatches)
           if (writerStatus.writer == null) {
             // a new partition or bucket, so create a writer
             renewOutWriter(writerId, writerStatus, closeOldWriter = false)
+            // if due to different part, update the tracker
+            if (currentWriterId.partitionValues != writerId.partitionValues) {
+              currentWriterId.partitionValues = writerId.partitionValues
+              statsTrackers.foreach(_.newPartition(writerId.partitionValues.get))
+            }
+            currentWriterId.bucketId = writerId.bucketId
           }
           withResource(groups(idx)) { gp =>
             groups(idx) = null


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11326

This PR corrects the GPU computation of the `number of dynamic part` metric for GPU write, because it needs to match the CPU behavior and this is an existing Spark metric.

The CPU is combining all of the reported partitions into a set on the driver, not within each task. But the GPU was simply reporting partition counts per task, which means we're probably over counting partitions when multiple tasks end up writing to the same partition.

I verified it locally and it works well.
CPU:
<img width="333" alt="Screen Shot 2025-04-11 at 10 43 17" src="https://github.com/user-attachments/assets/00bdaccc-c9b3-4a05-9817-3b76a2b25853" />
GPU with this fix
<img width="335" alt="Screen Shot 2025-04-11 at 10 43 27" src="https://github.com/user-attachments/assets/7ac1ecb7-9dce-495d-b786-db99f397377d" />
GPU without this fix
<img width="334" alt="Screen Shot 2025-04-11 at 10 43 35" src="https://github.com/user-attachments/assets/ef2aaf69-c1cd-4183-9d8f-97242f3520dd" />
