### PR TITLE
Update CICD defaults to ubuntu 22.04

### DIFF
--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Sample Dockerfile to install UCX in a Ubuntu 20.04 image
+# Sample Dockerfile to install UCX in a Ubuntu 22.04 image
 #
 # The parameters are: 
 #   - CUDA_VER: 11.8.0 by default
@@ -21,14 +21,14 @@
 #       Used to pick a package matching a specific UCX version and
 #       CUDA runtime from the UCX github repo.
 #       See: https://github.com/openucx/ucx/releases/
-#   - UBUNTU_VER: 20.04 by default
+#   - UBUNTU_VER: 22.04 by default
 #
 
 ARG CUDA_VER=11.8.0
 ARG UCX_VER=1.18.0
 ARG UCX_CUDA_VER=11
 ARG UCX_ARCH=x86_64
-ARG UBUNTU_VER=20.04
+ARG UBUNTU_VER=22.04
 
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
 ARG UCX_VER

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-# Sample Dockerfile to install UCX in a Unbuntu 20.04 image with RDMA support.
+# Sample Dockerfile to install UCX in a Unbuntu 22.04 image with RDMA support.
 #
 # The parameters are: 
 #   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest 
@@ -24,7 +24,7 @@
 #       Used to pick a package matching a specific UCX version and
 #       CUDA runtime from the UCX github repo.
 #       See: https://github.com/openucx/ucx/releases/
-#   - UBUNTU_VER: 20.04 by default
+#   - UBUNTU_VER: 22.04 by default
 #
 # The Dockerfile first fetches and builds `rdma-core` to satisfy requirements for
 # the ucx-ib and ucx-rdma RPMs.
@@ -38,7 +38,7 @@ ARG CUDA_VER=11.8.0
 ARG UCX_VER=1.18.0
 ARG UCX_CUDA_VER=11
 ARG UCX_ARCH=x86_64
-ARG UBUNTU_VER=20.04
+ARG UBUNTU_VER=22.04
 
 # Throw away image to build rdma_core
 FROM ubuntu:${UBUNTU_VER} as rdma_core

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@
 #
 # Arguments:
 #    CUDA_VER=11.X.Y
-#    UBUNTU_VER=20.04 or 22.04
+#    UBUNTU_VER=22.04
 #    CUDF_VER=<cudf-py version>
 ###
 
 ARG CUDA_VER=11.8.0
-ARG UBUNTU_VER=20.04
+ARG UBUNTU_VER=22.04
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
 ARG CUDA_VER
 ARG CUDF_VER

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -20,15 +20,15 @@
 #
 # Arguments:
 #       CUDA_VER=[11.X.Y,12.X.Y]
-#       UBUNTU_VER=[20.04,22.0.4]
+#       UBUNTU_VER=22.04
 #       UCX_VER=1.18.0
 #       TARGETPLATFORM=[linux/amd64,linux/arm64]
 #       ARCH=[amd64,arm64]
 #       UCX_ARCH=[x86_64,aarch64]
 ###
 
-ARG CUDA_VER=11.8.0
-ARG UBUNTU_VER=20.04
+ARG CUDA_VER=12.0.1
+ARG UBUNTU_VER=22.04
 ARG UCX_VER=1.18.0
 ARG TARGETPLATFORM=linux/amd64
 # multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
@@ -48,21 +48,19 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk openjdk-17-jdk python3.9 python3.9-distutils python3-setuptools \
-    tzdata git zip unzip wget parallel \
+    openjdk-8-jdk openjdk-11-jdk openjdk-17-jdk \
+    python3.10-distutils python3-setuptools \
+    tzdata git zip unzip bzip2 wget parallel \
     inetutils-ping expect wget libnuma1 libgomp1 locales
-
-# apt python3-pip would install pip for OS default python3 version only
-# like for ubuntu 18.04, it would only install pip for python3.6
-# so we install pip for specific python version explicitly
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3.9 get-pip.py
 
 # Set default jdk as 1.8.0
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-${ARCH}
 
-RUN ln -sfn /usr/bin/python3.9 /usr/bin/python
-RUN ln -sfn /usr/bin/python3.9 /usr/bin/python3
-RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist pre-commit pytest-order fastparquet==2024.5.0
+RUN ln -sfn /usr/bin/python3 /usr/bin/python
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+COPY integration_tests/requirements.txt /tmp/requirements.txt
+RUN python -m pip install -r /tmp/requirements.txt
+RUN python -m pip install requests pre-commit pytest-order
 
 RUN UCX_CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f1` && \
     mkdir -p /tmp/ucx && \

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -1,6 +1,6 @@
 #!/usr/local/env groovy
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import ipp.blossom.*
 
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
-def CUDA_NAME = 'cuda11.0.3' // hardcode cuda version for docker build part
+def CUDA_NAME = 'cuda12.0.1' // hardcode cuda version for docker build part
 def PREMERGE_DOCKERFILE = 'jenkins/Dockerfile-blossom.ubuntu'
 def IMAGE_PREMERGE // temp image for premerge test
 def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks")
@@ -146,7 +146,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         }
 
                         if (TEMP_IMAGE_BUILD) {
-                            IMAGE_TAG = "dev-ubuntu20-${CUDA_NAME}"
+                            IMAGE_TAG = "dev-ubuntu22-${CUDA_NAME}"
                             PREMERGE_TAG = "${IMAGE_TAG}-${BUILD_TAG}"
                             IMAGE_PREMERGE = "${ARTIFACTORY_NAME}/sw-spark-docker-local/plugin:${PREMERGE_TAG}"
                             def CUDA_VER = "$CUDA_NAME" - "cuda"
@@ -154,7 +154,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             uploadDocker(IMAGE_PREMERGE)
                         } else {
                             // if no pre-merge dockerfile change, use nightly image
-                            IMAGE_PREMERGE = "$ARTIFACTORY_NAME/sw-spark-docker-local/plugin:dev-ubuntu20-$CUDA_NAME-blossom-dev"
+                            IMAGE_PREMERGE = "$ARTIFACTORY_NAME/sw-spark-docker-local/plugin:dev-ubuntu22-$CUDA_NAME-blossom-dev"
                         }
                     }
                 }


### PR DESCRIPTION
part of https://github.com/NVIDIA/spark-rapids/issues/12390

Update below to use ubuntu22 as default
1. pre-merge build, integration tests dockerfiles
2. shuffle examples dockerfiles

NOTE: support ubuntu 24.04 build will not be covered in this change due to 
1. We are waiting for the official releases of 1.18.1 to provide ubuntu 24.04 support https://github.com/openucx/ucx/releases
2. We will need some extra ops to support default python 3.12 in ubuntu 24.04

Hybrid will still support Ubuntu 20.04 separately due to customer requirement