### PR TITLE
Add TaskMetrics about the watermark of PinnedMemory and PageableMemory 

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
@@ -31,6 +31,8 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.GpuTaskMetrics
 
+case class HostAllocResult(buffer: HostMemoryBuffer, isPinned: Boolean)
+
 private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with Logging {
   private var currentNonPinnedAllocated: Long = 0L
   private val pinnedLimit: Long = PinnedMemoryPool.getTotalPoolSizeBytes
@@ -82,7 +84,7 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
       currentPinnedAllocated -= amount
     }
     val metrics = GpuTaskMetrics.get
-    metrics.decHostBytesAllocated(amount)
+    metrics.decHostBytesAllocated(amount, isPinned = true)
     logTrace(getHostAllocMetricsLogStr(metrics))
     RmmSpark.cpuDeallocate(ptr, amount)
   }
@@ -92,7 +94,7 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
       currentNonPinnedAllocated -= amount
     }
     val metrics = GpuTaskMetrics.get
-    metrics.decHostBytesAllocated(amount)
+    metrics.decHostBytesAllocated(amount, isPinned = false)
     logTrace(getHostAllocMetricsLogStr(metrics))
     RmmSpark.cpuDeallocate(ptr, amount)
   }
@@ -184,23 +186,22 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
       preferPinned: Boolean,
       blocking: Boolean): (Option[HostMemoryBuffer], Boolean) = {
     var retryCount = 0L
-    var ret = Option.empty[HostMemoryBuffer]
+    var ret = Option.empty[HostAllocResult]
     var shouldRetry = false
     var shouldRetryInternal = true
     val isRecursive = RmmSpark.preCpuAlloc(amount, blocking)
     var allocAttemptFinishedWithoutException = false
     try {
       do {
-        val firstPass = if (preferPinned) {
-          tryAllocPinned(amount)
+        ret = if (preferPinned) {
+          tryAllocPinned(amount).map(HostAllocResult(_, isPinned = true))
         } else {
-          tryAllocNonPinned(amount)
-        }
-        ret = firstPass.orElse {
+          tryAllocNonPinned(amount).map(HostAllocResult(_, isPinned = false))
+        }.orElse {
           if (preferPinned) {
-            tryAllocNonPinned(amount)
+            tryAllocNonPinned(amount).map(HostAllocResult(_, isPinned = false))
           } else {
-            tryAllocPinned(amount)
+            tryAllocPinned(amount).map(HostAllocResult(_, isPinned = true))
           }
         }
         if (ret.isEmpty) {
@@ -213,21 +214,22 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
       } while(ret.isEmpty && shouldRetryInternal && retryCount < 10)
       allocAttemptFinishedWithoutException = true
     } finally {
-      if (ret.isDefined) {
-        val metrics = GpuTaskMetrics.get
-        metrics.incHostBytesAllocated(amount)
-        if (BOOKKEEP_MEMORY) {
-          HostAlloc.bookkeepHostMemoryAlloc(ret.get.getAddress, amount)
-        }
-        logTrace(getHostAllocMetricsLogStr(metrics))
-        RmmSpark.postCpuAllocSuccess(ret.get.getAddress, amount, blocking, isRecursive)
-      } else {
-        // shouldRetry should indicate if spill did anything for us and we should try again.
-        shouldRetry = RmmSpark.postCpuAllocFailed(allocAttemptFinishedWithoutException,
-          blocking, isRecursive)
+      ret match {
+        case Some(HostAllocResult(buffer: HostMemoryBuffer, isPinned: Boolean)) =>
+          val metrics = GpuTaskMetrics.get
+          metrics.incHostBytesAllocated(amount, isPinned)
+          if (BOOKKEEP_MEMORY) {
+            HostAlloc.bookkeepHostMemoryAlloc(buffer.getAddress, amount)
+          }
+          logTrace(getHostAllocMetricsLogStr(metrics))
+          RmmSpark.postCpuAllocSuccess(buffer.getAddress, amount, blocking, isRecursive)
+        case None =>
+          // shouldRetry should indicate if spill did anything for us and we should try again.
+          shouldRetry = RmmSpark.postCpuAllocFailed(allocAttemptFinishedWithoutException,
+            blocking, isRecursive)
       }
     }
-    (ret, shouldRetry)
+    (ret.map(_.buffer), shouldRetry)
   }
 
   def tryAlloc(amount: Long, preferPinned: Boolean = true): Option[HostMemoryBuffer] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostAlloc.scala
@@ -193,11 +193,12 @@ private class HostAlloc(nonPinnedLimit: Long) extends HostMemoryAllocator with L
     var allocAttemptFinishedWithoutException = false
     try {
       do {
-        ret = if (preferPinned) {
-          tryAllocPinned(amount).map(HostAllocResult(_, isPinned = true))
-        } else {
-          tryAllocNonPinned(amount).map(HostAllocResult(_, isPinned = false))
-        }.orElse {
+        ret = (
+          if (preferPinned) {
+            tryAllocPinned(amount).map(HostAllocResult(_, isPinned = true))
+          } else {
+            tryAllocNonPinned(amount).map(HostAllocResult(_, isPinned = false))
+          }).orElse {
           if (preferPinned) {
             tryAllocNonPinned(amount).map(HostAllocResult(_, isPinned = false))
           } else {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #12514

This PR is about to add two more TaskMetrics: 
* gpuMaxPageableMemoryBytes
* gpuMaxPinnedMemoryBytes

, which are collected in the same manner as `MaxHostMemoryBytes`.

In addition, this PR also refined the display of MemoryBytes:
*  111534336000  -> 0.74GB (11534336000 bytes)
*  1289750 -> 1.23MB (1289750 bytes)
*  1044585 -> 1020.10KB (1044585 bytes)

The updated task metric looks like:
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/ac5f50fd-d111-43f9-81b7-8ff652d26750" />
