### PR TITLE
Explicitly disable LTO in shuffle example dockerfiles [skip ci]

### DIFF
--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -42,7 +42,7 @@ RUN CUDA_UBUNTU_VER=`echo "$UBUNTU_VER"| sed -s 's/\.//'` && \
   apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$CUDA_UBUNTU_VER/x86_64/3bf863cc.pub
 
 RUN apt update
-RUN apt-get install -y wget
+RUN apt-get install -y wget bzip2
 RUN mkdir /tmp/ucx_install && cd /tmp/ucx_install && \
   wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -17,7 +17,7 @@
 # Sample Dockerfile to install UCX in a Unbuntu 22.04 image with RDMA support.
 #
 # The parameters are: 
-#   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest 
+#   - RDMA_CORE_VERSION: Set to 36.14 to match the rdma-core line in the latest
 #                        released MLNX_OFED 5.x driver
 #   - CUDA_VER: 11.8.0 by default
 #   - UCX_VER, UCX_CUDA_VER, and UCX_ARCH: 
@@ -33,7 +33,7 @@
 #
 
 
-ARG RDMA_CORE_VERSION=32.1
+ARG RDMA_CORE_VERSION=36.14
 ARG CUDA_VER=11.8.0
 ARG UCX_VER=1.18.0
 ARG UCX_CUDA_VER=11
@@ -55,7 +55,8 @@ RUN CUDA_UBUNTU_VER=`echo "$UBUNTU_VER"| sed -s 's/\.//'` && \
 # hack to get tzdata to install
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 
-RUN apt update && apt install -y dh-make wget build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc dh-python
+RUN apt update && apt install -y dh-make wget build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev \
+    ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc dh-python
 
 RUN wget https://github.com/linux-rdma/rdma-core/releases/download/v${RDMA_CORE_VERSION}/rdma-core-${RDMA_CORE_VERSION}.tar.gz
 RUN tar -xvf *.tar.gz && cd rdma-core*/ && dpkg-buildpackage -b -d
@@ -72,7 +73,7 @@ RUN mkdir /tmp/ucx_install
 COPY --from=rdma_core /*.deb /tmp/ucx_install/
 
 RUN apt update
-RUN apt-get install -y wget
+RUN apt-get install -y wget bzip2
 RUN cd /tmp/ucx_install && \
   wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -17,7 +17,7 @@
 # Sample Dockerfile to install UCX in a Unbuntu 22.04 image with RDMA support.
 #
 # The parameters are: 
-#   - RDMA_CORE_VERSION: Set to 36.14 to match the rdma-core line in the latest
+#   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest 
 #                        released MLNX_OFED 5.x driver
 #   - CUDA_VER: 11.8.0 by default
 #   - UCX_VER, UCX_CUDA_VER, and UCX_ARCH: 
@@ -33,7 +33,7 @@
 #
 
 
-ARG RDMA_CORE_VERSION=36.14
+ARG RDMA_CORE_VERSION=32.1
 ARG CUDA_VER=11.8.0
 ARG UCX_VER=1.18.0
 ARG UCX_CUDA_VER=11
@@ -59,7 +59,8 @@ RUN apt update && apt install -y dh-make wget build-essential cmake gcc libudev-
     ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc dh-python
 
 RUN wget https://github.com/linux-rdma/rdma-core/releases/download/v${RDMA_CORE_VERSION}/rdma-core-${RDMA_CORE_VERSION}.tar.gz
-RUN tar -xvf *.tar.gz && cd rdma-core*/ && dpkg-buildpackage -b -d
+RUN tar -xvf *.tar.gz && cd rdma-core*/ && \
+    DEB_CFLAGS_APPEND="-fno-lto" DEB_LDFLAGS_APPEND="-fno-lto" dpkg-buildpackage -b -d
 
 # Now start the main container
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids/issues/12523

But for testing, I tried both bumping up rdma-core to 36.xx and explicitly disable LTO for 32.1
But in Ubuntu22, the ucx_perftest will always failed 
```
libperf.c:2091 UCX  ERROR Unsupported memory types cuda<->cuda
```
due to incompatible linux kernel vs nvidia_peer_memory. As our purpose is to verify the dockerfile instead of helping maintain the compatiblity of all MLNX stuffs, I have changed internal verification pipeine to test UCX with cuda<->host for now to make sure the dockerfiles are working as expected