### PR TITLE
Add sort time metrics for GPU write exec

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -748,9 +748,15 @@ class GpuDynamicPartitionDataConcurrentWriter(
           withResource(pendingBatches.dequeue())(_.getColumnarBatch())
         }
       }
+      val (sortMetric, sortOpTime) =
+        statsTrackers.find(_.isInstanceOf[GpuWriteTaskStatsTracker]).map { tc =>
+          val tt = tc.asInstanceOf[GpuWriteTaskStatsTracker]
+          (tt.sortTime, tt.sortOpTime)
+        }.getOrElse((NoopMetric, NoopMetric))
+
       val sortIter = GpuOutOfCoreSortIterator(pendingCbsIter ++ iterator,
         new GpuSorter(spec.sortOrder, spec.output), GpuSortExec.targetSize(spec.batchSize),
-        NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+        sortOpTime, sortMetric, NoopMetric, NoopMetric)
       while (sortIter.hasNext) {
         // write with sort-based sequential writer
         super.write(sortIter.next())

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
@@ -35,6 +35,14 @@ class GpuWriteTaskStatsTracker(
     taskMetrics(GpuWriteJobStatsTracker.GPU_TIME_KEY) += nanos
   }
 
+  def sortTime: GpuMetric = taskMetrics(GpuWriteJobStatsTracker.SORT_TIME_KEY)
+
+  def sortOpTime: GpuMetric = taskMetrics(GpuWriteJobStatsTracker.SORT_OP_TIME_KEY)
+
+  def setSortTime(nanos: Long): Unit = sortTime.set(nanos)
+
+  def setSortOpTime(nanos: Long): Unit = sortOpTime.set(nanos)
+
   def addWriteTime(nanos: Long): Unit = {
     taskMetrics(GpuWriteJobStatsTracker.WRITE_TIME_KEY) += nanos
   }
@@ -73,6 +81,8 @@ class GpuWriteJobStatsTracker(
 object GpuWriteJobStatsTracker {
   val GPU_TIME_KEY = "gpuTime"
   val WRITE_TIME_KEY = "writeTime"
+  val SORT_TIME_KEY = "writeSortTime"
+  val SORT_OP_TIME_KEY = "writeSortOpTime"
   val ASYNC_WRITE_TOTAL_THROTTLE_TIME_KEY = "asyncWriteTotalThrottleTime"
   val ASYNC_WRITE_AVG_THROTTLE_TIME_KEY = "asyncWriteAvgThrottleTime"
   val ASYNC_WRITE_MIN_THROTTLE_TIME_KEY = "asyncWriteMinThrottleTime"
@@ -86,9 +96,14 @@ object GpuWriteJobStatsTracker {
       RapidsConf.METRICS_LEVEL.defaultValue))
     val metricFactory = new GpuMetricFactory(metricsConf, sparkContext)
     Map(
-      GPU_TIME_KEY -> metricFactory.createNanoTiming(GpuMetric.ESSENTIAL_LEVEL, "GPU time"),
+      GPU_TIME_KEY -> metricFactory.createNanoTiming(GpuMetric.ESSENTIAL_LEVEL,
+        "GPU encode and buffer time"),
       WRITE_TIME_KEY -> metricFactory.createNanoTiming(GpuMetric.ESSENTIAL_LEVEL,
         "write time"),
+      SORT_OP_TIME_KEY -> metricFactory.createNanoTiming(GpuMetric.MODERATE_LEVEL,
+        "GPU sort op time"),
+      SORT_TIME_KEY -> metricFactory.createNanoTiming(GpuMetric.DEBUG_LEVEL,
+        "GPU sort time"),
       TASK_COMMIT_TIME -> basicMetrics(TASK_COMMIT_TIME),
       ASYNC_WRITE_TOTAL_THROTTLE_TIME_KEY -> metricFactory.createNanoTiming(
         GpuMetric.DEBUG_LEVEL, "total throttle time"),

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,13 +226,14 @@ object GpuFileFormatWriter extends Logging {
           }
           // TODO: Using a GPU ordering as a CPU ordering here. Should be OK for now since we do not
           //       support bucket expressions yet and the rest should be simple attributes.
+          val sortTrackers = statsTrackers.filter(_.isInstanceOf[GpuWriteJobStatsTracker])
           val sort = GpuSortExec(
             orderingExpr,
             global = false,
             child = empty2NullPlan,
             sortType = sortType
-          )(orderingExpr).executeColumnar()
-          (sort, None)
+          )(orderingExpr, Some(sortTrackers.asInstanceOf[Seq[GpuWriteJobStatsTracker]]))
+          (sort.executeColumnar(), None)
         }
       }
 


### PR DESCRIPTION
This PR introduces two metrics similar as the op time and sort time in GPU sort to the GPU files write exec. 

For some cases, GPU write exec will perform some sort operation before writing, and currently there is no metric reflecting the operation, making the perf analysis a little difficult for the GPU write. This change tries to resolve this issue.  
