### PR TITLE
companion metrics for all timing metrics

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
@@ -248,7 +248,7 @@ final case class WrappedGpuMetric(sqlMetric: SQLMetric, withMetricsExclSemWait: 
   if (withMetricsExclSemWait) {
     //  SQLMetrics.NS_TIMING_METRIC and SQLMetrics.TIMING_METRIC is private,
     //  so we have to use the string directly
-    if (sqlMetric.metricType == "nsTiming") {
+    if (sqlMetric.metricType.toLowerCase.contains("timing")) {
       companionGpuMetric = Some(WrappedGpuMetric.apply(SQLMetrics.createNanoTimingMetric(
         SparkSession.getActiveSession.get.sparkContext, sqlMetric.name.get + " (excl. SemWait)")))
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
@@ -70,6 +70,7 @@ class GpuMetricFactory(metricsConf: MetricsLevel, context: SparkContext) {
 object GpuMetric extends Logging {
   // Metric names.
   val BUFFER_TIME = "bufferTime"
+  val SCAN_TIME = "scanTime"
   val COPY_BUFFER_TIME = "copyBufferTime"
   val GPU_DECODE_TIME = "gpuDecodeTime"
   val NUM_INPUT_ROWS = "numInputRows"
@@ -126,6 +127,7 @@ object GpuMetric extends Logging {
   val DESCRIPTION_AGG_TIME = "aggregation time"
   val DESCRIPTION_JOIN_TIME = "join time"
   val DESCRIPTION_FILTER_TIME = "filter time"
+  val DESCRIPTION_SCAN_TIME = "scan time"
   val DESCRIPTION_BUILD_DATA_SIZE = "build side size"
   val DESCRIPTION_BUILD_TIME = "build time"
   val DESCRIPTION_STREAM_TIME = "stream time"

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -23,7 +23,7 @@ import java.nio.channels.Channels
 import java.nio.charset.StandardCharsets
 import java.time.ZoneId
 import java.util
-import java.util.concurrent.{Callable, TimeUnit}
+import java.util.concurrent.Callable
 import java.util.regex.Pattern
 
 import scala.annotation.tailrec
@@ -632,28 +632,26 @@ case class GpuOrcMultiFilePartitionReaderFactory(
     // we must split the different compress files into different ColumnarBatch.
     // So here try the best to group the same compression files together before hand.
     val compressionAndStripes = LinkedHashMap[CompressionKind, ArrayBuffer[OrcSingleStripeMeta]]()
-    val startTime = System.nanoTime()
-    files.map { file =>
-      val orcPartitionReaderContext = filterHandler.filterStripes(file, dataSchema,
-        readDataSchema, partitionSchema)
-      compressionAndStripes.getOrElseUpdate(orcPartitionReaderContext.compressionKind,
-        new ArrayBuffer[OrcSingleStripeMeta]) ++=
-        orcPartitionReaderContext.blockIterator.map(block =>
-          OrcSingleStripeMeta(
-            orcPartitionReaderContext.filePath,
-            OrcDataStripe(OrcStripeWithMeta(block, orcPartitionReaderContext)),
-            file.partitionValues,
-            OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
-            readDataSchema,
-            OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
+
+    metrics.getOrElse(FILTER_TIME, NoopMetric).ns {
+      metrics.getOrElse(SCAN_TIME, NoopMetric).ns {
+        files.map { file =>
+          val orcPartitionReaderContext = filterHandler.filterStripes(file, dataSchema,
+            readDataSchema, partitionSchema)
+          compressionAndStripes.getOrElseUpdate(orcPartitionReaderContext.compressionKind,
+            new ArrayBuffer[OrcSingleStripeMeta]) ++=
+            orcPartitionReaderContext.blockIterator.map(block =>
+              OrcSingleStripeMeta(
+                orcPartitionReaderContext.filePath,
+                OrcDataStripe(OrcStripeWithMeta(block, orcPartitionReaderContext)),
+                file.partitionValues,
+                OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
+                readDataSchema,
+                OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
+        }
+      }
     }
-    val filterTime = System.nanoTime() - startTime
-    metrics.get(FILTER_TIME).foreach {
-      _ += filterTime
-    }
-    metrics.get("scanTime").foreach {
-      _ += TimeUnit.NANOSECONDS.toMillis(filterTime)
-    }
+
     val clippedStripes = compressionAndStripes.values.flatten.toSeq
     new MultiFileOrcPartitionReader(conf, files, clippedStripes, readDataSchema,
       debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.hive.rapids
 
 import java.net.URI
-import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.HashSet
@@ -26,7 +25,7 @@ import scala.collection.mutable
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, NvtxColor, RegexProgram, Scalar, Schema, Table}
 import com.nvidia.spark.rapids.{ColumnarPartitionReaderWithPartitionValues, CSVPartitionReaderBase, DateUtils, GpuColumnVector, GpuExec, GpuMetric, HostStringColBufferer, HostStringColBuffererFactory, NvtxWithMetrics, PartitionReaderIterator, PartitionReaderWithBytesRead, RapidsConf}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, DEBUG_LEVEL, DESCRIPTION_BUFFER_TIME, DESCRIPTION_FILTER_TIME, DESCRIPTION_GPU_DECODE_TIME, ESSENTIAL_LEVEL, FILTER_TIME, GPU_DECODE_TIME, MODERATE_LEVEL, NUM_OUTPUT_ROWS}
+import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, DEBUG_LEVEL, DESCRIPTION_BUFFER_TIME, DESCRIPTION_FILTER_TIME, DESCRIPTION_GPU_DECODE_TIME, DESCRIPTION_SCAN_TIME, ESSENTIAL_LEVEL, FILTER_TIME, GPU_DECODE_TIME, MODERATE_LEVEL, NUM_OUTPUT_ROWS, SCAN_TIME}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.shims.{ShimFilePartitionReaderFactory, ShimSparkPlan, SparkShimImpl}
@@ -177,7 +176,7 @@ case class GpuHiveTableScanExec(requestedAttributes: Seq[Attribute],
     GPU_DECODE_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_GPU_DECODE_TIME),
     BUFFER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_BUFFER_TIME),
     FILTER_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_FILTER_TIME),
-    "scanTime" -> createTimingMetric(ESSENTIAL_LEVEL, "scan time")
+    SCAN_TIME -> createNanoTimingMetric(ESSENTIAL_LEVEL, DESCRIPTION_SCAN_TIME)
   )
 
   private lazy val driverMetrics: mutable.HashMap[String, Long] = mutable.HashMap.empty
@@ -359,16 +358,16 @@ case class GpuHiveTableScanExec(requestedAttributes: Seq[Attribute],
 
   override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {
     val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
-    val scanTime = gpuLongMetric("scanTime")
+    val scanTime = gpuLongMetric(SCAN_TIME)
     inputRDD.mapPartitionsInternal { batches =>
       new Iterator[ColumnarBatch] {
 
         override def hasNext: Boolean = {
           // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
-          val startNs = System.nanoTime()
-          val res = batches.hasNext
-          scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
-          res
+          scanTime.ns {
+            val res = batches.hasNext
+            res
+          }
         }
 
         override def next(): ColumnarBatch = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -18,17 +18,17 @@ package org.apache.spark.sql.rapids
 
 import java.io.{FileNotFoundException, IOException, OutputStream}
 import java.net.URI
-import java.util.concurrent.{Callable, TimeUnit}
+import java.util.concurrent.{Callable}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
 import scala.language.implicitConversions
 
-import ai.rapids.cudf.{AvroOptions => CudfAvroOptions, HostMemoryBuffer, NvtxColor, NvtxRange, Table}
+import ai.rapids.cudf.{AvroOptions => CudfAvroOptions,HostMemoryBuffer, NvtxColor, NvtxRange, Table}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, FILTER_TIME, GPU_DECODE_TIME, NUM_OUTPUT_BATCHES, READ_FS_TIME, WRITE_BUFFER_TIME}
+import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, FILTER_TIME, GPU_DECODE_TIME, NUM_OUTPUT_BATCHES, READ_FS_TIME, SCAN_TIME, WRITE_BUFFER_TIME}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
 import com.nvidia.spark.rapids.jni.RmmSpark
@@ -261,41 +261,38 @@ case class GpuAvroMultiFilePartitionReaderFactory(
     val clippedBlocks = ArrayBuffer[AvroSingleDataBlockInfo]()
     val mapPathHeader = LinkedHashMap[Path, Header]()
     val filterHandler = AvroFileFilterHandler(conf, options)
-    val startTime = System.nanoTime()
-    files.foreach { file =>
-      val singleFileInfo = try {
-        filterHandler.filterBlocks(file)
-      } catch {
-        case e: FileNotFoundException if ignoreMissingFiles =>
-          logWarning(s"Skipped missing file: ${file.filePath}", e)
-          AvroBlockMeta(null, 0L, Seq.empty)
-        // Throw FileNotFoundException even if `ignoreCorruptFiles` is true
-        case e: FileNotFoundException if !ignoreMissingFiles => throw e
-        case e @(_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
-          logWarning(
-            s"Skipped the rest of the content in the corrupted file: ${file.filePath}", e)
-          AvroBlockMeta(null, 0L, Seq.empty)
+
+    metrics.getOrElse(FILTER_TIME, NoopMetric).ns {
+      metrics.getOrElse(SCAN_TIME, NoopMetric).ns {
+        files.foreach { file =>
+          val singleFileInfo = try {
+            filterHandler.filterBlocks(file)
+          } catch {
+            case e: FileNotFoundException if ignoreMissingFiles =>
+              logWarning(s"Skipped missing file: ${file.filePath}", e)
+              AvroBlockMeta(null, 0L, Seq.empty)
+            // Throw FileNotFoundException even if `ignoreCorruptFiles` is true
+            case e: FileNotFoundException if !ignoreMissingFiles => throw e
+            case e@(_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+              logWarning(
+                s"Skipped the rest of the content in the corrupted file: ${file.filePath}", e)
+              AvroBlockMeta(null, 0L, Seq.empty)
+          }
+          val fPath = new Path(new URI(file.filePath.toString()))
+          clippedBlocks ++= singleFileInfo.blocks.map(block =>
+            AvroSingleDataBlockInfo(
+              fPath,
+              AvroDataBlock(block),
+              file.partitionValues,
+              AvroSchemaWrapper(SchemaConverters.toAvroType(readDataSchema)),
+              readDataSchema,
+              AvroExtraInfo()))
+          if (singleFileInfo.blocks.nonEmpty) {
+            // No need to check the header since it can not be null when blocks is not empty here.
+            mapPathHeader.put(fPath, singleFileInfo.header)
+          }
+        }
       }
-      val fPath = new Path(new URI(file.filePath.toString()))
-      clippedBlocks ++= singleFileInfo.blocks.map(block =>
-        AvroSingleDataBlockInfo(
-            fPath,
-            AvroDataBlock(block),
-            file.partitionValues,
-            AvroSchemaWrapper(SchemaConverters.toAvroType(readDataSchema)),
-            readDataSchema,
-            AvroExtraInfo()))
-      if (singleFileInfo.blocks.nonEmpty) {
-        // No need to check the header since it can not be null when blocks is not empty here.
-        mapPathHeader.put(fPath, singleFileInfo.header)
-      }
-    }
-    val filterTime = System.nanoTime() - startTime
-    metrics.get(FILTER_TIME).foreach {
-      _ += filterTime
-    }
-    metrics.get("scanTime").foreach {
-      _ += TimeUnit.NANOSECONDS.toMillis(filterTime)
     }
     new GpuMultiFileAvroPartitionReader(conf, files, clippedBlocks.toSeq, readDataSchema,
       partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, maxGpuColumnSizeBytes,


### PR DESCRIPTION
This PR closes https://github.com/NVIDIA/spark-rapids/issues/12532 by 
1. both the SQLMetrics.NS_TIMING_METRIC and SQLMetrics.TIMING_METRIC should have companion metrics
2. use the GPUMetrics.ns{} untility for can related code.

![image](https://github.com/user-attachments/assets/cfe9e0ee-ccc7-4919-be39-9049a633383f)
