### PR TITLE
Fix bug when join side is outer side

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -86,20 +86,11 @@ object GpuShuffledSizedHashJoinExec {
       val flippedCondition = condition.map { c =>
         GpuBindReferences.bindGpuReference(c, conditionLeftAttrs ++ conditionRightAttrs)
       }
-      // For join types other than FullOuter and outer joins where the build side matches the
-      // outer side, we simply set compareNullsEqual as true to adapt struct keys with nullable
-      // children. Non-nested keys can also be correctly processed with compareNullsEqual = true,
-      // because we filter all null records from build table before join.
-      // For full outer and outer joins with build side matching outer side, we need to keep the
-      // nulls in the build table and thus cannot compare nulls as equal.
-      // For details, see https://github.com/NVIDIA/spark-rapids/issues/2126.
-      val treatNullsEqual = joinType match {
-        case FullOuter => false
-        case LeftOuter if buildSide == GpuBuildLeft => false
-        case RightOuter if buildSide == GpuBuildRight => false
-        case _ => GpuHashJoin.anyNullableStructChild(boundStreamKeys)
-      }
-      val needNullFilter = treatNullsEqual && boundStreamKeys.exists(_.nullable)
+
+      val treatNullsEqual = GpuHashJoin.compareNullsEqual(joinType, boundStreamKeys)
+      val needNullFilter = GpuHashJoin.buildSideNeedsNullFilter(
+        joinType, treatNullsEqual, buildSide, boundBuildKeys)
+
       BoundJoinExprs(boundStreamKeys, streamTypes, streamOutput,
         boundBuildKeys, buildTypes, buildOutput,
         flippedCondition, conditionLeftAttrs.size, treatNullsEqual, needNullFilter)
@@ -134,13 +125,13 @@ object GpuShuffledSizedHashJoinExec {
         GpuBindReferences.bindGpuReference(c, streamOutput ++ buildOutput)
       }
 
-      val compareNullsEqual = GpuHashJoin.compareNullsEqual(joinType, boundBuildKeys)
+      val treatNullsEqual = GpuHashJoin.compareNullsEqual(joinType, boundBuildKeys)
       val needNullFilter = GpuHashJoin.buildSideNeedsNullFilter(
-        joinType, compareNullsEqual, buildSide, boundBuildKeys)
+        joinType, treatNullsEqual, buildSide, boundBuildKeys)
 
       BoundJoinExprs(boundBuildKeys, buildTypes, buildOutput,
         boundStreamKeys, streamTypes, streamOutput,
-        boundCondition, streamOutput.size, compareNullsEqual, needNullFilter)
+        boundCondition, streamOutput.size, treatNullsEqual, needNullFilter)
     }
   }
 


### PR DESCRIPTION
closes #12530

### Analysis
#12285 introduced a bug as described in #12530
Why this issue occurs?
Originaly if build side is outer side and join on struct column with nullabe child, it will treat nulls as equal and filter out null for the build/outer side, which results in incorrect result. 

Refer to [link](https://github.com/NVIDIA/spark-rapids/blob/v25.02.0/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala#L1152-L1160)
```scala
    val builtAnyNullable = compareNullsEqual && buildKeys.exists(_.nullable)   // does not consider build side.

    val nullFiltered = if (builtAnyNullable) {
      val sb = closeOnExcept(builtBatch)(
        SpillableColumnarBatch(_, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
      GpuHashJoin.filterNullsWithRetryAndClose(sb, boundBuildKeys)
    } else {
      builtBatch
    }
```
### Fix
If build side is outer side and join on struct column with nullabe child, only treat nulls as equal  and do not filter out nulls from outer/build side.
Extract a utility function in GpuHashJoin object. If build side is outer side, skip the filter out nulls.
Note: GpuShuffledSizedHashJoinExec already avoid the case, Refer to [link](https://github.com/NVIDIA/spark-rapids/blob/v25.02.0/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala#L45-L58)

```scala
object GpuShuffledSizedHashJoinExec {
  def useSizedJoin(
      conf: RapidsConf,
      joinType: JoinType,
      leftKeys: Seq[Expression],
      rightKeys: Seq[Expression]): Boolean = {
    if (conf.useShuffledSymmetricHashJoin) {
      joinType match {
        case Inner | FullOuter => true
        case LeftOuter | RightOuter if conf.useShuffledAsymmetricHashJoin =>
          // currently cannot handle the case where the outer join becomes the build side
          // and there are nullable struct children in the join keys
          !GpuHashJoin.anyNullableStructChild(leftKeys) &&
            !GpuHashJoin.anyNullableStructChild(rightKeys)
        case _ => false
      }
    } else {
      false
    }
  }
```
But GpuShuffledSizedHashJoinExec also has this bug although it does not trigger.
Anyway, also update GpuShuffledSizedHashJoinExec.scala.

### future work
Investigate to avoid the workaround approach described in https://github.com/NVIDIA/spark-rapids/issues/2126
Update `useSizedJoin` to enable join on struct(with nullable child).

Signed-off-by: Chong Gao <res_life@163.com>
