### PR TITLE
HybridScan SQL HINT: adapt the spec change of LogicalRelation in spark400 [dataBricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
@@ -449,10 +449,11 @@ object HybridExecOverrides extends Logging {
     plan.resolveOperatorsWithPruning(_.containsPattern(TreePattern.UNRESOLVED_HINT)) {
       case UnresolvedHint(n, Nil, child) if n.toUpperCase(Locale.ROOT).equals(HYBRID_SCAN_HINT) =>
         child.transformUp {
-          case op@LogicalRelation(rel: HadoopFsRelation, _, _, _) =>
-            val newOptions = rel.options.updated(HYBRID_SCAN_TAG, "")
-            val newRelation = rel.copy(options = newOptions)(rel.sparkSession)
-            op.copy(relation = newRelation)
+          case rel: LogicalRelation if rel.relation.isInstanceOf[HadoopFsRelation] =>
+            val hdfsRel = rel.relation.asInstanceOf[HadoopFsRelation]
+            val newOptions = hdfsRel.options.updated(HYBRID_SCAN_TAG, "")
+            val newRelation = hdfsRel.copy(options = newOptions)(hdfsRel.sparkSession)
+            rel.copy(relation = newRelation)
         }
     }
   }


### PR DESCRIPTION
fixes #12538

The specification of `LogicalRelation` changed in latest Spark. In spark 3.5 or below, the specification was
```scala
case class LogicalRelation(
    relation: BaseRelation,
    output: Seq[AttributeReference],
    catalogTable: Option[CatalogTable],
    override val isStreaming: Boolean)
```
In latest main branch, it becomes:
```scala
case class LogicalRelation(
    relation: BaseRelation,
    output: Seq[AttributeReference],
    catalogTable: Option[CatalogTable],
    override val isStreaming: Boolean,
    @transient stream: Option[SparkDataStream])
```

This PR fixes the incompatible problem by getting rid of applying full pattern match of `LogicalRelation`  to capture our target pattern.