### PR TITLE
Exclude parent operator time in GpuShuffledSymmetricHashJoin build time

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -722,15 +722,11 @@ object GpuShuffledSymmetricHashJoinExec {
           }
           metrics(BUILD_DATA_SIZE).set(buildSize)
           val buildProcessingTime = new LocalGpuMetric
-          val buildIter = {
-            val baseBuildIter = buildProcessingTime.ns {
-              setupForJoin(buildQueue, Iterator.empty, exprs.buildTypes,
+          val buildIter = buildProcessingTime.ns {
+            val baseBuildIter = setupForJoin(buildQueue, Iterator.empty, exprs.buildTypes,
                 gpuBatchSizeBytes, metrics)
-            }
             if (exprs.buildSideNeedsNullFilter) {
-              buildProcessingTime.ns {
-                new NullFilteredBatchIterator(baseBuildIter, exprs.boundBuildKeys, metrics(OP_TIME))
-              }
+              new NullFilteredBatchIterator(baseBuildIter, exprs.boundBuildKeys, metrics(OP_TIME))
             } else {
               baseBuildIter
             }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -720,8 +720,9 @@ object GpuShuffledSymmetricHashJoinExec {
               streamTime += rightTime.value
               (leftQueue, leftSize, rightQueue, rawRightIter)
           }
+          metrics(BUILD_DATA_SIZE).set(buildSize)
           val baseBuildIter = setupForJoin(buildQueue, Iterator.empty, exprs.buildTypes,
-              gpuBatchSizeBytes, metrics)
+            gpuBatchSizeBytes, metrics)
           val buildIter = new CollectTimeIterator("build time",
             if (exprs.buildSideNeedsNullFilter) {
               new NullFilteredBatchIterator(baseBuildIter, exprs.boundBuildKeys, metrics(OP_TIME))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -720,18 +720,14 @@ object GpuShuffledSymmetricHashJoinExec {
               streamTime += rightTime.value
               (leftQueue, leftSize, rightQueue, rawRightIter)
           }
-          metrics(BUILD_DATA_SIZE).set(buildSize)
-          val buildProcessingTime = new LocalGpuMetric
-          val buildIter = buildProcessingTime.ns {
-            val baseBuildIter = setupForJoin(buildQueue, Iterator.empty, exprs.buildTypes,
-                gpuBatchSizeBytes, metrics)
+          val baseBuildIter = setupForJoin(buildQueue, Iterator.empty, exprs.buildTypes,
+              gpuBatchSizeBytes, metrics)
+          val buildIter = new CollectTimeIterator("build time",
             if (exprs.buildSideNeedsNullFilter) {
               new NullFilteredBatchIterator(baseBuildIter, exprs.boundBuildKeys, metrics(OP_TIME))
             } else {
               baseBuildIter
-            }
-          }
-          buildTime += buildProcessingTime.value
+            }, buildTime)
 
           val streamIter = new CollectTimeIterator("fetch join stream",
             setupForJoin(streamQueue, rawStreamIter, exprs.streamTypes, gpuBatchSizeBytes, metrics),


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/12529

This pr fixes `build time` metric in `GpuShuffledSymmetricHashJoin` to exclude parent operator time, and only included the real time to build.

Before this pr:
![Screenshot 2025-04-18 at 15 23 35](https://github.com/user-attachments/assets/d79206f8-17de-40d2-9bb3-3600e68c6b91)



After this pr:

![Screenshot 2025-04-18 at 15 15 08](https://github.com/user-attachments/assets/b648743d-c32e-44a4-9cf9-b1ecf1670392)


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
