### PR TITLE
Fallback Delta scan if deletion vectors are being read in Databricks 13.3 [databricks]

### DIFF
--- a/delta-lake/delta-spark332db/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
@@ -17,7 +17,6 @@
 package com.nvidia.spark.rapids.delta
 
 import com.databricks.sql.transaction.tahoe.{DeltaColumnMappingMode, DeltaParquetFileFormat, IdMapping}
-import com.databricks.sql.transaction.tahoe.DeltaParquetFileFormat.IS_ROW_DELETED_COLUMN_NAME
 import com.nvidia.spark.rapids.SparkPlanMeta
 import org.apache.hadoop.fs.Path
 
@@ -51,11 +50,11 @@ object GpuDeltaParquetFileFormat {
   def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     val format = meta.wrapped.relation.fileFormat.asInstanceOf[DeltaParquetFileFormat]
     val requiredSchema = meta.wrapped.requiredSchema
-    if (requiredSchema.exists(_.name == IS_ROW_DELETED_COLUMN_NAME)) {
+    if (requiredSchema.exists(_.name.startsWith("_databricks_internal"))) {
       meta.willNotWorkOnGpu(
-        s"reading metadata column $IS_ROW_DELETED_COLUMN_NAME is not supported")
+        s"reading metadata columns starting with prefix _databricks_internal is not supported")
     }
-    if (format.hasDeletionVectorMap()) {
+    if (format.hasDeletionVectorMap) {
       meta.willNotWorkOnGpu("deletion vectors are not supported")
     }
   }

--- a/delta-lake/delta-spark341db/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
+++ b/delta-lake/delta-spark341db/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta
 import java.net.URI
 
 import com.databricks.sql.transaction.tahoe.{DeltaColumnMappingMode, DeltaParquetFileFormat, IdMapping}
-import com.databricks.sql.transaction.tahoe.DeltaParquetFileFormat.{DeletionVectorDescriptorWithFilterType, IS_ROW_DELETED_COLUMN_NAME}
+import com.databricks.sql.transaction.tahoe.DeltaParquetFileFormat.DeletionVectorDescriptorWithFilterType
 import com.nvidia.spark.rapids.{GpuMetric, RapidsConf, SparkPlanMeta}
 import com.nvidia.spark.rapids.delta.GpuDeltaParquetFileFormatUtils.addMetadataColumnToIterator
 import org.apache.hadoop.conf.Configuration
@@ -107,9 +107,9 @@ object GpuDeltaParquetFileFormat {
   def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     val format = meta.wrapped.relation.fileFormat.asInstanceOf[DeltaParquetFileFormat]
     val requiredSchema = meta.wrapped.requiredSchema
-    if (requiredSchema.exists(_.name == IS_ROW_DELETED_COLUMN_NAME)) {
+    if (requiredSchema.exists(_.name.startsWith("_databricks_internal"))) {
       meta.willNotWorkOnGpu(
-        s"reading metadata column $IS_ROW_DELETED_COLUMN_NAME is not supported")
+        s"reading metadata columns starting with prefix _databricks_internal is not supported")
     }
     if (format.hasDeletionVectorMap) {
       meta.willNotWorkOnGpu("deletion vectors are not supported")


### PR DESCRIPTION
This was a long-standing bug in the plugin where we falsely put the Delta scan on the GPU, causing nothing to be returned as a result in the project.

fixes #12539 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
