### PR TITLE
fix broken nvtx_ranges link [skip ci]

### DIFF
--- a/docs/dev/nvtx_profiling.md
+++ b/docs/dev/nvtx_profiling.md
@@ -53,7 +53,7 @@ try {
   nvtxRange.close()
 }
 ```
-See [nvtx_ranges.md](https://nvidia.github.io/spark-rapids/docs/dev/nvtx_ranges.html) for documentation on existing ranges and registering a new range.
+See [nvtx_ranges.md](nvtx_ranges.md) for documentation on existing ranges and registering a new range.
 
 In C++ land:
 ```


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
closes https://github.com/NVIDIA/spark-rapids/issues/12561

fix internal doc link to point to internal relative path instead of published path since the referenced doc is new and not yet published to the github page