### PR TITLE
A quick fix for the rmm import issue [databricks]

### DIFF
--- a/python/rapids/worker.py
+++ b/python/rapids/worker.py
@@ -1,5 +1,5 @@
 ##
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ def initialize_gpu_mem():
     pool_enabled = os.environ.get('RAPIDS_POOLED_MEM_ENABLED', 'false').lower() == 'true'
     uvm_enabled = os.environ.get('RAPIDS_UVM_ENABLED', 'false').lower() == 'true'
     if pool_enabled:
-        from cudf import rmm
+        import rmm
         '''
         RMM will be initialized with default configures (pool disabled) when importing cudf
         as above. So overwrite the initialization when asking for pooled memory,
@@ -60,7 +60,7 @@ def initialize_gpu_mem():
         base_t = rmm.mr.ManagedMemoryResource if uvm_enabled else rmm.mr.CudaMemoryResource
         rmm.mr.set_current_device_resource(rmm.mr.PoolMemoryResource(base_t(), pool_size, pool_max_size))
     elif uvm_enabled:
-        from cudf import rmm
+        import rmm
         rmm.mr.set_current_device_resource(rmm.mr.ManagedMemoryResource())
     else:
         # Do nothing, whether to use RMM (default mode) or not depends on UDF definition.


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/12566

This PR chagnes to import the `rmm` module from the top level ([suggestion from comment](https://github.com/rapidsai/cudf/commit/302e3063ecf33243c2dcda01d38645e071a320bd#diff-b3aa785bdc03bbb6ecc2d9021ea7f24ad5006fd36d10d989465eef2020af8f82R108-R125)), because rmm is deleted from cudf namesapce by [the cudf change here](https://github.com/rapidsai/cudf/commit/302e3063ecf33243c2dcda01d38645e071a320bd#diff-b3aa785bdc03bbb6ecc2d9021ea7f24ad5006fd36d10d989465eef2020af8f82R108-R125.).
