### PR TITLE
Add DEV_MODE in nightly build script for dev build job [skip ci]

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -38,6 +38,8 @@ fi
 export WORKSPACE=${WORKSPACE:-$(pwd)}
 ## export 'M2DIR' so that shims can get the correct Spark dependency info
 export M2DIR=${M2DIR:-"$WORKSPACE/.m2"}
+## DEV_MODE: if true, copy M2DIR to SHIM_M2DIR for dev job
+export DEV_MODE=${DEV_MODE:-'false'}
 
 function mvnEval {
     $MVN help:evaluate -q -pl $DIST_PL $MVN_URM_MIRROR -Prelease320 -Dmaven.repo.local=$M2DIR -DforceStdout -Dexpression=$1
@@ -102,6 +104,11 @@ function build_shim() {
   if [ ! -d "${CODE_PATH}" ]; then
     mkdir -p "${SHIM_WORKSPACE}"
     cp -r "${WORKSPACE}/" "${CODE_PATH}"
+
+    # update SHIM_M2DIR for dev job
+    if [[ "$DEV_MODE" == "true" ]]; then
+      SHIM_M2DIR=${CODE_PATH}/.m2
+    fi
   fi
   cd "${CODE_PATH}"
   echo "Workspace at ${CODE_PATH}..."


### PR DESCRIPTION
Add a option to enable dev mode in nightly build script for spark-rapids-dev build job.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
