### PR TITLE
refine bookkeeping logs to ease OOM related troubleshooting

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -647,9 +647,7 @@ object RmmRapidsRetryIterator extends Logging {
         }
         firstAttempt = false
         if (splitReason != SplitReason.NONE) {
-          if (BOOKKEEP_MEMORY) {
-            logMemoryBookkeeping()
-          }
+          preSplit()
           attemptIter.split(splitReason)
         }
         splitReason = SplitReason.NONE
@@ -681,6 +679,7 @@ object RmmRapidsRetryIterator extends Logging {
           clearInjectedOOMIfNeeded()
         } catch {
           case ex: Throwable =>
+            log.debug("got a throwable in RmmRapidsRetryIterator.next():", ex)
             // handle a retry as the top-level exception
             val (topLevelIsRetry, topLevelIsSplit, isGpuOom) = isRetryOrSplitAndRetry(ex)
             if (topLevelIsSplit) {
@@ -835,50 +834,64 @@ object RmmRapidsRetryIterator extends Logging {
   /**
    * Log memory footprint when GPU OOM or CPU OOM happens.
    */
-
   val BOOKKEEP_MEMORY: Boolean =
     java.lang.Boolean.getBoolean("ai.rapids.memory.bookkeep")
   // track the callstack for each memory allocation, don't enable it unless really needed
   val BOOKKEEP_MEMORY_CALLSTACK: Boolean =
     java.lang.Boolean.getBoolean("ai.rapids.memory.bookkeep.callstack")
   // By default, only print first time to avoid too much log
-  val BOOKKEEP_MEMORY_PRINT_ALL: Boolean =
-    java.lang.Boolean.getBoolean("ai.rapids.memory.bookkeep.printall")
-  var bookkeepPrinted = false
+  val PRE_SPLIT_PRINT_ALL: Boolean = {
+    java.lang.Boolean.getBoolean("ai.rapids.memory.preSplit.printAll")
+  }
+  var preSplitPrinted = false
 
   val threadCountBlockedUntilReady: AtomicInteger = new AtomicInteger(0)
 
-  private def logMemoryBookkeeping(): Unit = synchronized { // use synchronized to keep neat
-    if (!bookkeepPrinted || BOOKKEEP_MEMORY_PRINT_ALL) {
+  private def preSplit(): Unit = synchronized { // use synchronized to keep neat
+    if (!preSplitPrinted || PRE_SPLIT_PRINT_ALL) {
+      log.info(s"Current threadCountBlockedUntilReady pre split: " +
+        s"${threadCountBlockedUntilReady.get()}")
 
-      // print spillable status
-      logInfo(SpillFramework.getHostStoreSpillableSummary)
-      logInfo(SpillFramework.getDeviceStoreSpillableSummary)
-
-      // print host memory bookkeeping
-      logInfo(HostAlloc.getHostAllocBookkeepSummary())
-
-      // print device memory bookkeeping
-      // TODO: uncomment this once we have device memory bookkeeping in spark-rapids-jni
-      // logInfo(BaseDeviceMemoryBuffer.getDeviceMemoryBookkeepSummary)
-
-      // print stack trace
-      val sb = new StringBuilder("<<Jstack Details>>\n\n")
-      Thread.getAllStackTraces.forEach((thread: Thread, stackTrace: Array[StackTraceElement])
-      => {
-        // Print the thread name and its state
-        sb.append(s"Thread: ${thread.getName} - State: ${thread.getState} " +
-          s"- Thread ID: ${thread.getId}\n")
-        // Print the stack trace for this thread
-        for (element <- stackTrace) {
-          sb.append(s"\tat $element")
-        }
-        sb.append("\n\n")
-      })
-      logInfo(sb.toString())
-
-      bookkeepPrinted = true
+      logSpillFrameworkSummary()
+      if (BOOKKEEP_MEMORY) {
+        logMemoryBookkeeping()
+      }
+      logStacktrace()
+      preSplitPrinted = true
     }
+  }
+
+  private def logSpillFrameworkSummary(): Unit = {
+    // print spillable status
+    logInfo(SpillFramework.getHostStoreSpillableSummary)
+    logInfo(SpillFramework.getDeviceStoreSpillableSummary)
+  }
+
+  // For GPU/CPU SplitAndRetryOOM, we are very interested what each task is doing when one
+  // of the tasks try to split and retry (in the context of WithRetryNoSplit).
+  private def logStacktrace(): Unit = {
+    val sb = new StringBuilder("<<Jstack Details>>\n\n")
+    Thread.getAllStackTraces.forEach((thread: Thread, stackTrace: Array[StackTraceElement])
+    => {
+      // Print the thread name and its state
+      sb.append(s"Thread: ${thread.getName} - State: ${thread.getState} " +
+        s"- Thread ID: ${thread.getId}\n")
+      // Print the stack trace for this thread
+      for (element <- stackTrace) {
+        sb.append(s"\tat $element")
+      }
+      sb.append("\n\n")
+    })
+    logInfo(sb.toString())
+  }
+
+  private def logMemoryBookkeeping(): Unit = { // use synchronized to keep neat
+    // print host memory bookkeeping
+    logInfo(HostAlloc.getHostAllocBookkeepSummary())
+
+    // print device memory bookkeeping
+    // TODO: uncomment this once we have device memory bookkeeping in spark-rapids-jni
+    // logInfo(BaseDeviceMemoryBuffer.getDeviceMemoryBookkeepSummary)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -840,9 +840,8 @@ object RmmRapidsRetryIterator extends Logging {
   val BOOKKEEP_MEMORY_CALLSTACK: Boolean =
     java.lang.Boolean.getBoolean("ai.rapids.memory.bookkeep.callstack")
   // By default, only print first time to avoid too much log
-  val PRE_SPLIT_PRINT_ALL: Boolean = {
+  val PRE_SPLIT_PRINT_ALL: Boolean =
     java.lang.Boolean.getBoolean("ai.rapids.memory.preSplit.printAll")
-  }
   var preSplitPrinted = false
 
   val threadCountBlockedUntilReady: AtomicInteger = new AtomicInteger(0)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -647,7 +647,7 @@ object RmmRapidsRetryIterator extends Logging {
         }
         firstAttempt = false
         if (splitReason != SplitReason.NONE) {
-          preSplit()
+          preSplitLogging()
           attemptIter.split(splitReason)
         }
         splitReason = SplitReason.NONE
@@ -847,7 +847,7 @@ object RmmRapidsRetryIterator extends Logging {
 
   val threadCountBlockedUntilReady: AtomicInteger = new AtomicInteger(0)
 
-  private def preSplit(): Unit = synchronized { // use synchronized to keep neat
+  private def preSplitLogging(): Unit = synchronized { // use synchronized to keep neat
     if (!preSplitPrinted || PRE_SPLIT_PRINT_ALL) {
       log.info(s"Current threadCountBlockedUntilReady pre split: " +
         s"${threadCountBlockedUntilReady.get()}")


### PR DESCRIPTION
When trouble shooting GPU/CPU related issues, memory bookkeepings, spill framework summaries and jstack info are proved to be very helpful. We know that memory bookkeeping is costly to track, so it is by default off. However spill framework summaries and jstack are almost free to track and print.

So it would be nice if we can separate spill framework summaries and jstack logging from existing `logMemoryBookkeeping`, and print them even if memory bookkeeping are off.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
