### PR TITLE
Add a metric to represent the max number of open writers

### DIFF
--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaTaskStatisticsTracker.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaTaskStatisticsTracker.scala
@@ -138,6 +138,8 @@ class GpuDeltaTaskStatisticsTracker(
 
   override def newPartition(partitionValues: InternalRow): Unit = { }
 
+  override def writersNumber(numWriters: Int): Unit = { }
+
   protected def initializeAggBuf(buffer: SpecificInternalRow): InternalRow =
     initializeStats.target(buffer).apply(EmptyRow)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
@@ -42,6 +42,7 @@ import org.apache.spark.util.SerializableConfiguration
 case class BasicColumnarWriteTaskStats(
     partitions: Seq[InternalRow],
     numFiles: Int,
+    numWriters: Int,
     numBytes: Long,
     numRows: Long)
     extends WriteTaskStats
@@ -61,6 +62,7 @@ class BasicColumnarWriteTaskStatsTracker(
   private[this] var numSubmittedFiles: Int = 0
   private[this] var numBytes: Long = 0L
   private[this] var numRows: Long = 0L
+  private[this] var maxNumWriters: Int = 0
 
   private[this] val submittedFiles = mutable.HashSet[String]()
 
@@ -159,6 +161,17 @@ class BasicColumnarWriteTaskStatsTracker(
     numRows += batch.numRows()
   }
 
+  /**
+   * Update the number of open writers.
+   * It will be a noop if the given number is not larger than the current one. Since
+   * only the max value is needed. This is designed for the concurrent writers case.
+   */
+  override def writersNumber(numWriters: Int): Unit = {
+    if (numWriters > maxNumWriters) {
+      maxNumWriters = numWriters
+    }
+  }
+
   override def getFinalStats(taskCommitTime: Long): WriteTaskStats = {
 
     // Reports bytesWritten and recordsWritten to the Spark output metrics.
@@ -173,7 +186,7 @@ class BasicColumnarWriteTaskStatsTracker(
         "or files being not immediately visible in the filesystem.")
     }
     taskCommitTimeMetric.foreach(_ += taskCommitTime)
-    BasicColumnarWriteTaskStats(partitions.toSeq, numFiles, numBytes, numRows)
+    BasicColumnarWriteTaskStats(partitions.toSeq, numFiles, maxNumWriters, numBytes, numRows)
   }
 }
 
@@ -206,6 +219,7 @@ class BasicColumnarWriteJobStatsTracker(
     var numFiles: Long = 0L
     var totalNumBytes: Long = 0L
     var totalNumOutput: Long = 0L
+    var maxNumWriters: Long = 0L
 
     val basicStats = stats.map(_.asInstanceOf[BasicColumnarWriteTaskStats])
 
@@ -214,6 +228,9 @@ class BasicColumnarWriteJobStatsTracker(
       numFiles += summary.numFiles
       totalNumBytes += summary.numBytes
       totalNumOutput += summary.numRows
+      if (summary.numWriters > maxNumWriters) {
+        maxNumWriters = summary.numWriters
+      }
     }
 
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.JOB_COMMIT_TIME).add(jobCommitTime)
@@ -221,6 +238,8 @@ class BasicColumnarWriteJobStatsTracker(
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.NUM_OUTPUT_BYTES_KEY).add(totalNumBytes)
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.NUM_OUTPUT_ROWS_KEY).add(totalNumOutput)
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.NUM_PARTS_KEY).add(partitionsSet.size)
+    driverSideMetrics(BasicColumnarWriteJobStatsTracker.MAX_WRITERS_NUM_KEY).add(maxNumWriters)
+
 
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     SQLMetrics.postDriverMetricUpdates(sparkContext, executionId,
@@ -233,6 +252,7 @@ object BasicColumnarWriteJobStatsTracker {
   private val NUM_OUTPUT_BYTES_KEY = "numOutputBytes"
   private val NUM_OUTPUT_ROWS_KEY = "numOutputRows"
   private val NUM_PARTS_KEY = "numParts"
+  private val MAX_WRITERS_NUM_KEY = "maxWritersNumber"
   val TASK_COMMIT_TIME = "taskCommitTime"
   val JOB_COMMIT_TIME = "jobCommitTime"
   /** XAttr key of the data length header added in HADOOP-17414. */
@@ -255,7 +275,9 @@ object BasicColumnarWriteJobStatsTracker {
       TASK_COMMIT_TIME -> metricFactory.createTiming(GpuMetric.ESSENTIAL_LEVEL,
         "task commit time"),
       JOB_COMMIT_TIME -> metricFactory.createTiming(GpuMetric.ESSENTIAL_LEVEL,
-        "job commit time")
+        "job commit time"),
+      MAX_WRITERS_NUM_KEY -> metricFactory.create(GpuMetric.DEBUG_LEVEL,
+        "max writers number")
     )
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
@@ -62,6 +62,12 @@ trait ColumnarWriteTaskStatsTracker {
   def newBatch(filePath: String, batch: ColumnarBatch): Unit
 
   /**
+   * Process the fact that how many writers are currently opened.
+   * @param numWriters the current number of open writers
+   */
+  def writersNumber(numWriters: Int): Unit
+
+  /**
    * Returns the final statistics computed so far.
    * @param taskCommitTime Time of committing the task.
    * @note This may only be called once. Further use of the object may lead to undefined behavior.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -184,6 +184,16 @@ abstract class GpuFileFormatDataWriter(
   /** Writes a columnar batch of records */
   def write(batch: ColumnarBatch): Unit
 
+  protected val reportSingleWriter = true
+
+  private def updateWritersNumber(): Unit = {
+    if (currentWriterStatus.writer != null && reportSingleWriter) {
+      // By default, only one writer is opened for write.
+      // And concurrent writer will do this by itself.
+      statsTrackers.foreach(_.writersNumber(1))
+    }
+  }
+
   /**
    * Returns the summary of relative information which
    * includes the list of partition strings written out. The list of partitions is sent back
@@ -191,6 +201,7 @@ abstract class GpuFileFormatDataWriter(
    * driver too and used to e.g. update the metrics in UI.
    */
   override def commit(): WriteTaskResult = {
+    updateWritersNumber()
     releaseResources()
     val (taskCommitMessage, taskCommitTime) = TimingUtils.timeTakenMs {
       committer.commitTask(taskAttemptContext)
@@ -204,6 +215,7 @@ abstract class GpuFileFormatDataWriter(
 
   override def abort(): Unit = {
     try {
+      updateWritersNumber()
       releaseResources()
     } finally {
       committer.abortTask(taskAttemptContext)
@@ -710,6 +722,8 @@ class GpuDynamicPartitionDataConcurrentWriter(
     }
   }
 
+  override protected val reportSingleWriter: Boolean = false
+
   // Keep all the unclosed writers, key is a partition path and(or) bucket id.
   // Note: if fall back to sort-based mode, also use the opened writers in the map.
   private val concurrentWriters = mutable.HashMap[WriterIndex, WriterStatusWithBatches]()
@@ -798,6 +812,8 @@ class GpuDynamicPartitionDataConcurrentWriter(
 
     // Split the batch and cache the result, along with opening the writers.
     splitBatchToCacheAndClose(cb)
+    // Update the maxWriterNumber metric since the writers are already opened and cached.
+    statsTrackers.foreach(_.writersNumber(concurrentWriters.size))
     // Write the cached batches
     val writeFunc: (WriterIndex, WriterStatusWithBatches) => Unit =
       if (pendingBatches.nonEmpty) {


### PR DESCRIPTION
This PR introduces a new metric named "max writers number" in the GPU write exec to show the max number of writers being opened concurrently during the write process, to help the perf analysis.

This is designed for the concurrent write, and it will always be 1 for writer of other types if the data is not empty.

Verified by local tests. 

