### PR TITLE
Skip generating scaladoc for iceberg module [skip ci]

### DIFF
--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -34,6 +34,7 @@
     <properties>
         <rapids.compressed.artifact>false</rapids.compressed.artifact>
         <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+        <maven.scaladoc.skip>true</maven.scaladoc.skip>
     </properties>
 
     <dependencies>

--- a/scala2.13/iceberg/pom.xml
+++ b/scala2.13/iceberg/pom.xml
@@ -34,6 +34,7 @@
     <properties>
         <rapids.compressed.artifact>false</rapids.compressed.artifact>
         <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+        <maven.scaladoc.skip>true</maven.scaladoc.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Related to #12659 

A temporary workaround to skip generating scaladoc for iceberg module to avoid building break. 