### PR TITLE
async threads for shuffle read

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleAsyncCoalesceIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleAsyncCoalesceIterator.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util.concurrent.{Callable, Future}
+
+import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+
+import org.apache.spark.TaskContext
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * Similar as GpuShuffleCoalesceIterator, but pulling in host batches asynchronously, to
+ * overlap the host batch reading and the downstream GPU operations.
+ */
+class GpuShuffleAsyncCoalesceIterator(iter: Iterator[CoalescedHostResult],
+    dataTypes: Array[DataType],
+    outputBatchesMetric: GpuMetric = NoopMetric,
+    outputRowsMetric: GpuMetric = NoopMetric,
+    asyncReadTimeMetric: GpuMetric = NoopMetric,
+    opTimeMetric: GpuMetric = NoopMetric) extends Iterator[ColumnarBatch] {
+
+  private val readExecutor =
+    TrampolineUtil.newDaemonSingleThreadExecutor("async shuffle read")
+
+  Option(TaskContext.get()).foreach( tc =>
+    // Install a listener to to close the async read thread.
+    tc.addTaskCompletionListener[Unit](_ => readExecutor.shutdown())
+  )
+
+  private lazy val readCallable = new Callable[CoalescedHostResult]() {
+    // The actual async read, including the host batches read and concatenation in
+    // "HostCoalesceIteratorBase.next()".
+    override def call(): CoalescedHostResult = {
+      val nvRangeName = s"Task ${TaskContext.get().taskAttemptId()}-Async Read Batch"
+      withResource(new NvtxRange(nvRangeName, NvtxColor.BLUE)) { _ =>
+        iter.next()
+      }
+    }
+  }
+
+  private var readFutureOpt: Option[Future[CoalescedHostResult]] = None
+
+  override def hasNext(): Boolean = GpuMetric.ns(asyncReadTimeMetric, opTimeMetric) {
+    readFutureOpt.isDefined || {
+      // No async read is running when it comes here, so no need synchronization
+      // when accessing the input iterator. "iter.hasNext" should be lightweight
+      // enough, since it just read in a header which is very small.
+      iter.hasNext
+    }
+  }
+
+  override def next(): ColumnarBatch = {
+    if (!hasNext()) {
+      throw new NoSuchElementException("No more batches")
+    }
+    val nvRangeName = s"Task ${TaskContext.get().taskAttemptId()}-Batch to GPU"
+    withResource(new NvtxRange(nvRangeName, NvtxColor.BLUE)) { _ =>
+      val hostConcatedRet = GpuMetric.ns(asyncReadTimeMetric, opTimeMetric) {
+        readFutureOpt.map { readFuture =>
+          // An async read is running, waiting for the result
+          readFuture.get()
+        }.getOrElse { // The first batch, just read it directly
+          iter.next()
+        }
+      }
+      val gpuCB = withResource(hostConcatedRet) { _ =>
+        // We acquire the GPU regardless of whether the concatenated batch is an empty batch
+        // or not, because the downstream tasks expect the `GpuShuffleCoalesceIterator`
+        // to acquire the semaphore and may generate GPU data from batches that are empty.
+        GpuSemaphore.acquireIfNecessary(TaskContext.get())
+        GpuMetric.ns(opTimeMetric)(hostConcatedRet.toGpuBatch(dataTypes))
+      }
+      closeOnExcept(gpuCB) { _ =>
+        val hasNextCB = GpuMetric.ns(asyncReadTimeMetric, opTimeMetric)(iter.hasNext)
+        GpuMetric.ns(opTimeMetric) {
+          // No need synchronization here since the async read is already done.
+          if (hasNextCB) {
+            // Prefetch and concatenate the next one asynchronously.
+            readFutureOpt = Some(readExecutor.submit(readCallable))
+          } else {
+            readFutureOpt = None
+          }
+          outputBatchesMetric += 1
+          outputRowsMetric += gpuCB.numRows()
+          gpuCB
+        }
+      }
+    }
+  }
+
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -353,7 +353,7 @@ object GpuShuffledHashJoinExec extends Logging {
           val gpuBuildIter = if (isBuildSerialized) {
             // batches on host, move them to GPU
             new GpuShuffleCoalesceIterator(safeIter.asInstanceOf[Iterator[CoalescedHostResult]],
-              buildDataType, coalesceMetrics)
+              buildDataType)
           } else { // batches already on GPU
             safeIter.asInstanceOf[Iterator[ColumnarBatch]]
           }
@@ -501,16 +501,19 @@ object GpuShuffledHashJoinExec extends Logging {
       coalesceMetrics: Map[String, GpuMetric]): Option[Iterator[CoalescedHostResult]] = {
     var retIter: Option[Iterator[CoalescedHostResult]] = None
     if (iter.hasNext && iter.head.numCols() == 1) {
+      val concatTime = coalesceMetrics(GpuMetric.CONCAT_TIME)
       iter.head.column(0) match {
         case _: KudoSerializedTableColumn =>
-          retIter = Some(new KudoHostShuffleCoalesceIterator(iter, targetSize, coalesceMetrics,
-            dataTypes, readOption))
+          retIter = Some(new KudoHostShuffleCoalesceIterator(iter, targetSize, dataTypes,
+            concatTimeMetric = concatTime, readOption = readOption))
         case _: SerializedTableColumn =>
-          retIter = Some(new HostShuffleCoalesceIterator(iter, targetSize, coalesceMetrics))
+          retIter = Some(new HostShuffleCoalesceIterator(iter, targetSize,
+            concatTimeMetric = concatTime))
         case _ => // should be gpu batches
       }
     }
     retIter
   }
 }
+
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2087,6 +2087,13 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .booleanConf
     .createWithDefault(false)
 
+  val SHUFFLE_ASYNC_READ_ENABLED = conf("spark.rapids.shuffle.asyncRead.enabled")
+    .doc("Enable or disable the asynchronous read for Shuffle.")
+    .internal()
+    .startupOnly()
+    .booleanConf
+    .createWithDefault(true)
+
   // ["NEVER", "ALWAYS", "ONFAILURE"]
   private val KudoDebugModes = 
     DumpOption.values.map(_.toString.toUpperCase(java.util.Locale.ROOT)).toSet 
@@ -3251,6 +3258,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val shuffleKudoMeasureBufferCopyEnabled: Boolean =
     get(SHUFFLE_KUDO_SERIALIZER_MEASURE_BUFFER_COPY_ENABLED)
+
+  lazy val shuffleAsyncReadEnabled: Boolean = get(SHUFFLE_ASYNC_READ_ENABLED)
 
   lazy val shuffleKudoSerializerDebugMode: DumpOption = {
     val mode = get(SHUFFLE_KUDO_SERIALIZER_DEBUG_MODE)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.execution
 
-import java.util.concurrent.{ScheduledExecutorService, ThreadPoolExecutor}
+import java.util.concurrent.{ExecutorService, ScheduledExecutorService, ThreadPoolExecutor}
 
 import org.apache.hadoop.conf.Configuration
 import org.json4s.JsonAST
@@ -237,6 +237,10 @@ object TrampolineUtil {
 
   def newDaemonSingleThreadScheduledExecutor(threadName: String): ScheduledExecutorService = {
     ThreadUtils.newDaemonSingleThreadScheduledExecutor(threadName)
+  }
+
+  def newDaemonSingleThreadExecutor(threadName: String): ExecutorService = {
+    ThreadUtils.newDaemonSingleThreadExecutor(threadName)
   }
 
   def postEvent(sc: SparkContext, sparkEvent: SparkListenerEvent): Unit = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.execution
 
-import java.util.concurrent.{ExecutorService, ScheduledExecutorService, ThreadPoolExecutor}
+import java.util.concurrent.{ScheduledExecutorService, ThreadPoolExecutor}
 
 import org.apache.hadoop.conf.Configuration
 import org.json4s.JsonAST
@@ -237,10 +237,6 @@ object TrampolineUtil {
 
   def newDaemonSingleThreadScheduledExecutor(threadName: String): ScheduledExecutorService = {
     ThreadUtils.newDaemonSingleThreadScheduledExecutor(threadName)
-  }
-
-  def newDaemonSingleThreadExecutor(threadName: String): ExecutorService = {
-    ThreadUtils.newDaemonSingleThreadExecutor(threadName)
   }
 
   def postEvent(sc: SparkContext, sparkEvent: SparkListenerEvent): Unit = {


### PR DESCRIPTION
This PR closes https://github.com/NVIDIA/spark-rapids/issues/12673 by hiding "concatenateTablesInHost" and "bufferNextBatch" in backend thread pool. A significant part of this work is made by @firestarman and I'm wrapping all things together.

Our local tests have shown that the code change is very beneficial, e2e time for the shuffle read stage has reduced from 50s to 30s.

![image](https://github.com/user-attachments/assets/4adc3eca-cef1-46e9-b98d-00a9b6bc8565)

_"only async read but no async concat (run 2 times)" corresponds to a half baked version (a9b85c1761f5851f87739eed4190189672fdcd52 where we combined "concatenateTablesInHost" and "bufferNextBatch" in a same background thread._

The query we used for evaluation:

```
bin/spark-shell --master 'local[16]' --driver-memory 80g \
--conf spark.plugins=com.nvidia.spark.SQLPlugin --conf spark.rapids.memory.gpu.allocFraction=0.5  --conf spark.sql.autoBroadcastJoinThreshold=1 \
--conf spark.kryo.registrator=com.nvidia.spark.rapids.GpuKryoRegistrator \
--conf spark.rapids.cudfVersionOverride=true \
--conf spark.shuffle.service.enabled=false \
--conf spark.uimeta.enabled=false \
--conf spark.memory.offHeap.size=15g \
--conf spark.rapids.memory.host.offHeapLimit.enabled=true  \
--conf spark.rapids.memory.host.offHeapLimit.size=54424509440 \
--conf spark.sql.files.maxPartitionBytes=128m \
--conf spark.memory.offHeap.enabled=true \
--conf spark.rapids.sql.agg.fallbackAlgorithm=repartition \
--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=1000 \
--conf spark.eventLog.enabled=true \
--conf spark.rapids.sql.concurrentGpuTasks=3 \
--conf spark.sql.files.maxPartitionBytes=1280m \
--conf spark.rapids.sql.metrics.level=DEBUG --conf spark.rapids.shuffle.asyncRead.enabled=true \
--conf spark.rapids.shuffle.kudo.serializer.enabled=true \
--jars /home/hongbin/develop/spark-3.2.1-bin-hadoop2.7/rapids_jars/2506_fresh.jar


spark.conf.set("spark.sql.shuffle.partitions", 1)
spark.conf.set("spark.sql.adaptive.enabled", "false")

val smallDF = {
          val data = 1 to 500000000
         val rdd = spark.sparkContext.parallelize(data)
          val df1 = rdd.toDF("id")
         df1.withColumn("value", concat(lit("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"), col("id")))
}

smallDF.createOrReplaceTempView("small_table")

val df = spark.sql(
  """
  select sum(a), b from (
   SELECT
      s.id as a,
      s.value as b
    FROM
      small_table s
  ) group by b

  """
)
df.show(100)
df.explain() 

``` 
