### PR TITLE
AsyncOutputStream should copy the buffer before scheduling write task

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
@@ -130,7 +130,7 @@ abstract class ColumnarOutputWriter(context: TaskAttemptContext,
   protected def getOutputStream: OutputStream = {
     if (useAsyncWrite) {
       logWarning("Async output write enabled")
-      new AsyncOutputStream(() => openOutputStream(), trafficController, statsTrackers)
+      AsyncOutputStream(() => openOutputStream(), trafficController, statsTrackers)
     } else {
       openOutputStream()
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStream.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStream.scala
@@ -25,26 +25,33 @@ import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.spark.sql.rapids.ColumnarWriteTaskStatsTracker
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
-/**
- * OutputStream that performs writes asynchronously. Writes are scheduled on a background thread
- * and executed in the order they were scheduled. This class is not thread-safe and should only be
- * used by a single thread.
- *
- * @param openFn a function that creates an underlying delegate OutputStream
- * @param trafficController a TrafficController that controls the flow of data to the underlying
- *                          delegate
- * @param statsTrackers a sequence of ColumnarWriteTaskStatsTracker
- * @param writeDelayMs used only for testing. A delay in milliseconds to add before each write
- */
-class AsyncOutputStream(openFn: Callable[OutputStream], trafficController: TrafficController,
-    statsTrackers: Seq[ColumnarWriteTaskStatsTracker], writeDelayMs: Long = 0L)
+object AsyncOutputStream {
+
+  /**
+   * OutputStream that performs writes asynchronously. Writes are scheduled on a background thread
+   * and executed in the order they were scheduled. This class is not thread-safe and should only be
+   * used by a single thread.
+   *
+   * @param openFn a function that creates an underlying delegate OutputStream
+   * @param trafficController a TrafficController that controls the flow of data to the underlying
+   *                          delegate
+   * @param statsTrackers a sequence of ColumnarWriteTaskStatsTracker
+   */
+  def apply(
+      openFn: Callable[OutputStream],
+      trafficController: TrafficController,
+      statsTrackers: Seq[ColumnarWriteTaskStatsTracker]): AsyncOutputStream = {
+    val executor = new ThrottlingExecutor(
+      TrampolineUtil.newDaemonCachedThreadPool("AsyncOutputStream", 1, 1), trafficController,
+      statsTrackers)
+    new AsyncOutputStream(openFn, executor)
+  }
+}
+
+class AsyncOutputStream(openFn: Callable[OutputStream], executor: ThrottlingExecutor)
   extends OutputStream {
 
   private var closed = false
-
-  private val executor = new ThrottlingExecutor(
-    TrampolineUtil.newDaemonCachedThreadPool("AsyncOutputStream", 1, 1), trafficController,
-    statsTrackers)
 
   // Open the underlying stream asynchronously as soon as the AsyncOutputStream is constructed,
   // so that the open can be done in parallel with other operations. This could help with
@@ -99,9 +106,6 @@ class AsyncOutputStream(openFn: Callable[OutputStream], trafficController: Traff
 
     metrics.numBytesScheduled += bytesToWrite
     executor.submit(() => {
-      if (writeDelayMs > 0) {
-        Thread.sleep(writeDelayMs)
-      }
       throwIfError()
       ensureOpen()
 

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
@@ -16,7 +16,8 @@
 
 package com.nvidia.spark.rapids.io.async
 
-import java.io.{BufferedOutputStream, File, FileOutputStream, IOException, OutputStream}
+import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, File, FileInputStream, FileOutputStream, IOException, OutputStream}
+import java.nio.ByteBuffer
 import java.util.concurrent.Callable
 
 import com.nvidia.spark.rapids.Arm.withResource
@@ -25,22 +26,22 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
 
-  private val bufLen = 128 * 1024
+  private val bufLen = 4
   private val buf: Array[Byte] = new Array[Byte](bufLen)
   private val maxBufCount = 10
   private val trafficController = new TrafficController(
     new HostMemoryThrottle(bufLen * maxBufCount))
 
-  def openStream(): AsyncOutputStream = {
-    new AsyncOutputStream(() => {
-      val file = File.createTempFile("async-write-test", "tmp")
+  def openStream(delayMs: Long = 0L): (AsyncOutputStream, String) = {
+    val file = File.createTempFile("async-write-test", "tmp")
+    (new AsyncOutputStream(() => {
       new BufferedOutputStream(new FileOutputStream(file))
-    }, trafficController, Seq.empty)
+    }, trafficController, Seq.empty, delayMs), file.getAbsolutePath)
   }
 
   test("open, write, and close") {
     val numBufs = 1000
-    val stream = openStream()
+    val (stream, _) = openStream()
     withResource(stream) { os =>
       for (_ <- 0 until numBufs) {
         os.write(buf)
@@ -50,8 +51,77 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
     assertResult(bufLen * numBufs)(stream.metrics.numBytesWritten.get())
   }
 
+  def testWrite(writeCall: (AsyncOutputStream, Int) => Unit,
+      readCall: DataInputStream => Int): Unit = {
+    val numInts = 50
+    val (asyncStream, outputPath) = openStream(10)
+    withResource(asyncStream) { asyncStream =>
+      for (i <- 0 until numInts) {
+        writeCall(asyncStream, i)
+      }
+    }
+
+    val file = new File(outputPath)
+
+    withResource(new FileInputStream(file)) {
+      fis => withResource(new BufferedInputStream(fis)) {
+        bis => withResource(new DataInputStream(bis)) {
+          dis =>
+            for (i <- 0 until numInts) {
+              val value = readCall(dis)
+              assert(value == i, s"Expected $i but got $value")
+            }
+        }
+      }
+    }
+  }
+
+  test("write ints") {
+    testWrite(
+      { (asyncStream, i) =>
+        asyncStream.write(i)
+      },
+      { dis =>
+        dis.read()
+      }
+    )
+  }
+
+  test("write byte arrays") {
+    val buf = new Array[Byte](Integer.BYTES)
+    val bb = ByteBuffer.wrap(buf)
+    testWrite(
+      { (asyncStream, i) =>
+        bb.clear()
+        bb.putInt(i)
+        asyncStream.write(buf)
+      },
+      { dis =>
+        dis.readInt()
+      }
+    )
+  }
+
+  test("write byte arrays with offset") {
+    // We will use only the Integer.BYTES bytes in the middle of the buffer
+    val buf = new Array[Byte](Integer.BYTES * 3)
+    val bb = ByteBuffer.wrap(buf)
+    bb.position(Integer.BYTES)
+    bb.mark()
+    testWrite(
+      { (asyncStream, i) =>
+        bb.reset()
+        bb.putInt(i)
+        asyncStream.write(buf, Integer.BYTES, Integer.BYTES)
+      },
+      { dis =>
+        dis.readInt()
+      }
+    )
+  }
+
   test("write after closed") {
-    val os = openStream()
+    val (os, _) = openStream()
     os.close()
     assertThrows[IOException] {
       os.write(buf)
@@ -59,7 +129,7 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test("flush after closed") {
-    val os = openStream()
+    val (os, _) = openStream()
     os.close()
     assertThrows[IOException] {
       os.flush()


### PR DESCRIPTION
Fixes a bug in `AsyncOutputStream` that content in the output file can be corrupted if the caller reuses the same buffer to the `write` calls, which is almost always the case. Since the write task in `AsyncOutputStream` accesses the buffer by reference in the lambda, the buffer might have been updated already when `delegate.write()` is called later by `ThrottlingExecutor`.  To fix this, `AsyncOutputStream` should copy the input buffer in `write`.