### PR TITLE
Propagate errors to JVM while initializing GPU memory in python worker

### DIFF
--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -37,6 +37,6 @@ markers =
     pyarrow_test: Mark pyarrow tests
     datagen_overrides: Mark that allows overriding datagen settings (i.e. seed) for a test
     tz_sensitive_test: Mark the test as a time zone sensitive test which will be tested against extra timezones
-    spark_job_timeout(seconds, dump_threads): Override the default timeout settrings
+    spark_job_timeout(seconds, dump_threads): Override the default timeout setting
 filterwarnings =
     ignore:.*pytest.mark.order.*:_pytest.warning_types.PytestUnknownMarkWarning

--- a/python/rapids/daemon.py
+++ b/python/rapids/daemon.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -26,12 +26,72 @@ import time
 import gc
 from errno import EINTR, EAGAIN
 from socket import AF_INET, SOCK_STREAM, SOMAXCONN
-from signal import SIGHUP, SIGTERM, SIGCHLD, SIG_DFL, SIG_IGN
+from signal import SIGHUP, SIGTERM, SIGCHLD, SIG_DFL, SIG_IGN, SIGINT
 
-from pyspark.serializers import read_int, write_int
-from pyspark.daemon import worker
+from pyspark.serializers import read_int, write_int, write_with_length, UTF8Deserializer
+from pyspark.worker import main as worker_main
 
-from rapids.worker import initialize_gpu_mem
+from rapids.worker import initialize_gpu_mem, handle_worker_exception
+
+
+def compute_real_exit_code(exit_code):
+    """
+    Copied over from pyspark/daemon.py.
+    """
+    # SystemExit's code can be integer or string, but os._exit only accepts integers
+    if isinstance(exit_code, numbers.Integral):
+        return exit_code
+    else:
+        return 1
+
+
+def worker(sock, authenticated):
+    """
+    Called by a worker process after the fork().
+
+    Copied over from pyspark/daemon.py and slightly modified for GPU memory initialization.
+    """
+    signal.signal(SIGHUP, SIG_DFL)
+    signal.signal(SIGCHLD, SIG_DFL)
+    signal.signal(SIGTERM, SIG_DFL)
+    # restore the handler for SIGINT,
+    # it's useful for debugging (show the stacktrace before exit)
+    signal.signal(SIGINT, signal.default_int_handler)
+
+    # Read the socket using fdopen instead of socket.makefile() because the latter
+    # seems to be very slow; note that we need to dup() the file descriptor because
+    # otherwise writes also cause a seek that makes us miss data on the read side.
+    buffer_size = int(os.environ.get("SPARK_BUFFER_SIZE", 65536))
+    infile = os.fdopen(os.dup(sock.fileno()), "rb", buffer_size)
+    outfile = os.fdopen(os.dup(sock.fileno()), "wb", buffer_size)
+
+    if not authenticated:
+        client_secret = UTF8Deserializer().loads(infile)
+        if os.environ["PYTHON_WORKER_FACTORY_SECRET"] == client_secret:
+            write_with_length("ok".encode("utf-8"), outfile)
+            outfile.flush()
+        else:
+            write_with_length("err".encode("utf-8"), outfile)
+            outfile.flush()
+            sock.close()
+            return 1
+
+    exit_code = 0
+    try:
+        # GPU context setup
+        initialize_gpu_mem()
+        worker_main(infile, outfile)
+    except SystemExit as exc:
+        exit_code = compute_real_exit_code(exc.code)
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        exit_code = -1
+    finally:
+        try:
+            outfile.flush()
+        except Exception:
+            pass
+    return exit_code
 
 
 def manager():
@@ -128,9 +188,6 @@ def manager():
                     devnull.close()
 
                     try:
-                        # GPU context setup
-                        initialize_gpu_mem()
-
                         # Acknowledge that the fork was successful
                         outfile = sock.makefile(mode="wb")
                         write_int(os.getpid(), outfile)

--- a/python/rapids/daemon_databricks.py
+++ b/python/rapids/daemon_databricks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -26,13 +26,71 @@ import time
 import gc
 from errno import EINTR, EAGAIN
 from socket import AF_INET, SOCK_STREAM, SOMAXCONN
-from signal import SIGHUP, SIGTERM, SIGCHLD, SIG_DFL, SIG_IGN
+from signal import SIGHUP, SIGTERM, SIGCHLD, SIG_DFL, SIG_IGN, SIGINT
 
-from pyspark.serializers import read_int, write_int, UTF8Deserializer
-from pyspark.daemon import worker
+from pyspark.serializers import read_int, write_int, write_with_length, UTF8Deserializer
+from pyspark.worker import main as worker_main
+from pyspark.wrapped_python import do_all_setup_for_username
 
-from rapids.worker import initialize_gpu_mem
+from rapids.worker import initialize_gpu_mem, handle_worker_exception
 utf8_deserializer = UTF8Deserializer()
+
+
+def compute_real_exit_code(exit_code):
+    # SystemExit's code can be integer or string, but os._exit only accepts integers
+    if isinstance(exit_code, numbers.Integral):
+        return exit_code
+    else:
+        return 1
+
+
+def worker(sock, authenticated, executor_username):
+    """
+    Called by a worker process after the fork().
+    """
+    signal.signal(SIGHUP, SIG_DFL)
+    signal.signal(SIGCHLD, SIG_DFL)
+    signal.signal(SIGTERM, SIG_DFL)
+    # restore the handler for SIGINT,
+    # it's useful for debugging (show the stacktrace before exit)
+    signal.signal(SIGINT, signal.default_int_handler)
+
+    # Read the socket using fdopen instead of socket.makefile() because the latter
+    # seems to be very slow; note that we need to dup() the file descriptor because
+    # otherwise writes also cause a seek that makes us miss data on the read side.
+    buffer_size = int(os.environ.get("SPARK_BUFFER_SIZE", 65536))
+    infile = os.fdopen(os.dup(sock.fileno()), "rb", buffer_size)
+    outfile = os.fdopen(os.dup(sock.fileno()), "wb", buffer_size)
+
+    if not authenticated:
+        client_secret = UTF8Deserializer().loads(infile)
+        if os.environ["PYTHON_WORKER_FACTORY_SECRET"] == client_secret:
+            write_with_length("ok".encode("utf-8"), outfile)
+            outfile.flush()
+        else:
+            write_with_length("err".encode("utf-8"), outfile)
+            outfile.flush()
+            sock.close()
+            return 1
+
+    exit_code = 0
+    try:
+        # Do the exact same security setup that we do for the Python REPL process on the driver
+        do_all_setup_for_username(executor_username)
+        # GPU context setup
+        initialize_gpu_mem()
+        worker_main(infile, outfile)
+    except SystemExit as exc:
+        exit_code = compute_real_exit_code(exc.code)
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        exit_code = -1
+    finally:
+        try:
+            outfile.flush()
+        except Exception:
+            pass
+    return exit_code
 
 
 def manager():
@@ -129,9 +187,6 @@ def manager():
                     devnull.close()
 
                     try:
-                        # GPU context setup
-                        initialize_gpu_mem()
-
                         infile = sock.makefile(mode="rb")
                         executor_username = utf8_deserializer.loads(infile)
                         # Acknowledge that the fork was successful

--- a/python/rapids/worker.py
+++ b/python/rapids/worker.py
@@ -16,7 +16,11 @@
 ##
 
 import os
+import sys
+import traceback
+from typing import IO, Optional
 from pyspark.worker import local_connect_and_auth, main as worker_main
+from pyspark.serializers import write_int, write_with_length, SpecialLengths
 
 
 def initialize_gpu_mem():
@@ -67,10 +71,54 @@ def initialize_gpu_mem():
         pass
 
 
-if __name__ == '__main__':
-    # GPU context setup
-    initialize_gpu_mem()
+def handle_worker_exception(
+        e: BaseException, outfile: IO, hide_traceback: Optional[bool] = None
+) -> None:
+    """
+    Copied over from pyspark/util.py.
 
+    Handles exception for Python worker which writes SpecialLengths.PYTHON_EXCEPTION_THROWN (-2)
+    and exception traceback info to outfile. JVM could then read from the outfile and perform
+    exception handling there.
+
+    Parameters
+    ----------
+    e : BaseException
+        Exception handled
+    outfile : IO
+        IO object to write the exception info
+    hide_traceback : bool, optional
+        Whether to hide the traceback in the output.
+        By default, hides the traceback if environment variable SPARK_HIDE_TRACEBACK is set.
+    """
+
+    if hide_traceback is None:
+        hide_traceback = bool(os.environ.get("SPARK_HIDE_TRACEBACK", False))
+
+    def format_exception() -> str:
+        if hide_traceback:
+            return "".join(traceback.format_exception_only(type(e), e))
+        if os.environ.get("SPARK_SIMPLIFIED_TRACEBACK", False):
+            tb = try_simplify_traceback(sys.exc_info()[-1])  # type: ignore[arg-type]
+            if tb is not None:
+                e.__cause__ = None
+                return "".join(traceback.format_exception(type(e), e, tb))
+        return traceback.format_exc()
+
+    try:
+        exc_info = format_exception()
+        write_int(SpecialLengths.PYTHON_EXCEPTION_THROWN, outfile)
+        write_with_length(exc_info.encode("utf-8"), outfile)
+    except IOError:
+        # JVM close the socket
+        pass
+    except BaseException:
+        # Write the error to stderr if it happened while serializing
+        print("PySpark worker failed with exception:", file=sys.stderr)
+        print(traceback.format_exc(), file=sys.stderr)
+
+
+if __name__ == '__main__':
     # Code below is all copied from Pyspark/worker.py
     java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
     auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
@@ -80,4 +128,10 @@ if __name__ == '__main__':
     # with that in `pyspark/daemon.py`.
     buffer_size = int(os.environ.get("SPARK_BUFFER_SIZE", 65536))
     outfile = os.fdopen(os.dup(sock.fileno()), "wb", buffer_size)
+    try:
+        # GPU context setup
+        initialize_gpu_mem()
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        sys.exit(-1)
     worker_main(sock_file, outfile)

--- a/python/rapids/worker.py
+++ b/python/rapids/worker.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     try:
         # GPU context setup
         initialize_gpu_mem()
+        worker_main(sock_file, outfile)
     except BaseException as e:
         handle_worker_exception(e, outfile)
         sys.exit(-1)
-    worker_main(sock_file, outfile)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/12608.

This PR adds an error propagation mechanism for the errors occurred while initializing GPU memory for python workers. Previously, if an error occurs while initializing GPU memory (more properly speaking any errors in the `initialize_gpu_mem()` function), the JVM stack trace used to show only the `EOFException` that was caused by the python process stopped which in turn closed the socket connection to the Java process. One example of such stack traces can be found in #12566. After this PR, the stack trace now shows the error from the python side properly. The below shows the python error propagated to the JVM side when the same import error as the one in #12566 occurs.

```
=========================== short test summary info ============================
FAILED ../../src/main/python/udf_cudf_test.py::test_with_column[small data][DATAGEN_SEED=1746825161, TZ=UTC, INJECT_OOM] - py4j.protocol.Py4JJavaError: An error occurred while calling o488.collectToPython.
: org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 1.0 failed 1 times, most recent failure: Lost task 1.0 in stage 1.0 (TID 5) (10.110.47.50 executor driver): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/home/jihoons/Projects/spark-rapids/dist/target/rapids-4-spark_2.12-25.06.0-SNAPSHOT-cuda12.jar/rapids/daemon.py", line 77, in worker
    initialize_gpu_mem()
    ~~~~~~~~~~~~~~~~~~^^
  File "/home/jihoons/Projects/spark-rapids/dist/target/rapids-4-spark_2.12-25.06.0-SNAPSHOT-cuda12.jar/rapids/worker.py", line 27, in initialize_gpu_mem
    from cudf import rmm
ImportError: cannot import name 'rmm' from 'cudf' (/home/jihoons/miniforge3/envs/cudf_dev/lib/python3.13/site-packages/cudf/__init__.py)

	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:572)
	at org.apache.spark.sql.rapids.execution.python.shims.GpuArrowPythonOutput$$anon$1.read(GpuArrowPythonOutput.scala:105)
	at org.apache.spark.sql.rapids.execution.python.shims.GpuArrowPythonOutput$$anon$1.read(GpuArrowPythonOutput.scala:73)
...
```

Once the GPU memory is initialized, we call the `main()` function in `pyspark/worker.py` in Apache Spark. Any errors occurred in this function are already being handled properly in the Spark implementation and we don't have to worry about propagating them.

Unlike what was suggested in #12608, it doesn't seem to me that this change will help with the cases like #12603. #12603 is about process hangs due to some potential bug in the pyarrow library. The test in question writes some data first with pyarrow and tries to read it back with the plugin (and the other way around as well). This test doesn't seem to involve the python worker in its testing.