### PR TITLE
Disable Databricks 11.3 shim build [databricks]

### DIFF
--- a/delta-lake/README.md
+++ b/delta-lake/README.md
@@ -9,16 +9,16 @@ version it supports.
 The following table shows the mapping of Delta Lake versions to their supported Spark version
 and directory contains the corresponding support code.
 
-| Delta Lake Version | Spark Version   | Directory          |
-|--------------------|-----------------|--------------------|
-| 2.0.x              | Spark 3.2.x     | `delta-20x`        |
-| 2.1.x              | Spark 3.3.x     | `delta-21x`        |
-| 2.2.x              | Spark 3.3.x     | `delta-22x`        |
-| 2.3.x              | Spark 3.3.x     | `delta-23x`        |
-| 2.4.x              | Spark 3.4.x     | `delta-24x`        |
-| Databricks 11.3    | Databricks 11.3 | `delta-spark330db` |
-| Databricks 12.2    | Databricks 12.2 | `delta-spark332db` |
-| Databricks 13.3    | Databricks 13.3 | `delta-spark341db` |
+| Delta Lake Version | Spark Version   | Directory              |
+|--------------------|-----------------|------------------------|
+| 2.0.x              | Spark 3.2.x     | `delta-20x`            |
+| 2.1.x              | Spark 3.3.x     | `delta-21x`            |
+| 2.2.x              | Spark 3.3.x     | `delta-22x`            |
+| 2.3.x              | Spark 3.3.x     | `delta-23x`            |
+| 2.4.x              | Spark 3.4.x     | `delta-24x`            |
+| Databricks 12.2    | Databricks 12.2 | `delta-spark332db`     |
+| Databricks 13.3    | Databricks 13.3 | `delta-spark341db`     |
+| Databricks 14.3    | Databricks 14.3 | `delta-spark3510db143` |
 
 Delta Lake is not supported on all Spark versions, and for Spark versions where it is not
 supported the `delta-stub` project is used.

--- a/delta-lake/README.md
+++ b/delta-lake/README.md
@@ -9,16 +9,15 @@ version it supports.
 The following table shows the mapping of Delta Lake versions to their supported Spark version
 and directory contains the corresponding support code.
 
-| Delta Lake Version | Spark Version   | Directory              |
-|--------------------|-----------------|------------------------|
-| 2.0.x              | Spark 3.2.x     | `delta-20x`            |
-| 2.1.x              | Spark 3.3.x     | `delta-21x`            |
-| 2.2.x              | Spark 3.3.x     | `delta-22x`            |
-| 2.3.x              | Spark 3.3.x     | `delta-23x`            |
-| 2.4.x              | Spark 3.4.x     | `delta-24x`            |
-| Databricks 12.2    | Databricks 12.2 | `delta-spark332db`     |
-| Databricks 13.3    | Databricks 13.3 | `delta-spark341db`     |
-| Databricks 14.3    | Databricks 14.3 | `delta-spark3510db143` |
+| Delta Lake Version | Spark Version   | Directory          |
+|--------------------|-----------------|--------------------|
+| 2.0.x              | Spark 3.2.x     | `delta-20x`        |
+| 2.1.x              | Spark 3.3.x     | `delta-21x`        |
+| 2.2.x              | Spark 3.3.x     | `delta-22x`        |
+| 2.3.x              | Spark 3.3.x     | `delta-23x`        |
+| 2.4.x              | Spark 3.4.x     | `delta-24x`        |
+| Databricks 12.2    | Databricks 12.2 | `delta-spark332db` |
+| Databricks 13.3    | Databricks 13.3 | `delta-spark341db` |
 
 Delta Lake is not supported on all Spark versions, and for Spark versions where it is not
 supported the `delta-stub` project is used.

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -93,7 +93,7 @@ pipeline {
                         // 'name' and 'value' only supprt literal string in the declarative Jenkins
                         // Refer to Jenkins issue https://issues.jenkins.io/browse/JENKINS-62127
                         name 'DB_RUNTIME'
-                        values '11.3', '12.2', '13.3', '14.3'
+                        values '12.2', '13.3', '14.3'
                     }
                 }
                 stages {

--- a/jenkins/databricks/common_vars.sh
+++ b/jenkins/databricks/common_vars.sh
@@ -28,10 +28,10 @@ SPARK_VER=${SPARK_VER:-$(< /databricks/spark/VERSION)}
 # notebooks but not when running Spark manually.
 #
 # At the OS level the DBR version can be obtailed via
-# 1. DATABRICKS_RUNTIME_VERSION environment set by Databricks, e.g., 11.3
-# 2. File at /databricks/DBR_VERSION created by Databricks, e.g., 11.3
+# 1. DATABRICKS_RUNTIME_VERSION environment set by Databricks, e.g., 12.2
+# 2. File at /databricks/DBR_VERSION created by Databricks, e.g., 12.2
 # 3. The value for Spark conf in file /databricks/common/conf/deploy.conf created by Databricks,
-#    e.g. 11.3.x-gpu-ml-scala2.12
+#    e.g. 12.2.x-gpu-ml-scala2.12
 #
 # For cases 1 and 2 append '.' for version matching in 3XYdb SparkShimServiceProvider
 #
@@ -76,7 +76,7 @@ fi
 
 # Set PYSPARK_PYTHON to keep the version of driver/workers python consistent.
 export PYSPARK_PYTHON=${PYSPARK_PYTHON:-"$(which python)"}
-# Get Python version (major.minor). i.e., python3.8 for DB10.4 and python3.9 for DB11.3
+# Get Python version (major.minor). i.e., python3.8 for DB10.4 and python3.9 for DB12.2
 PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("python{}.{}".format(sys.version_info.major, sys.version_info.minor))')
 # Set the path of python site-packages, packages were installed here by 'jenkins/databricks/setup.sh'.
 PYTHON_SITE_PACKAGES=${PYTHON_SITE_PACKAGES:-"$HOME/.local/lib/${PYTHON_VERSION}/site-packages"}

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -40,7 +40,7 @@ fi
 
 # Set PYSPARK_PYTHON to keep the version of driver/workers python consistent.
 export PYSPARK_PYTHON=${PYSPARK_PYTHON:-"$(which python)"}
-# Get Python version (major.minor). i.e., python3.8 for DB10.4 and python3.9 for DB11.3
+# Get Python version (major.minor). i.e., python3.8 for DB10.4 and python3.9 for DB12.2
 PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
 [[ $(printf "%s\n" "3.9" "$PYTHON_VERSION" | sort -V | head -n1) = "3.9" ]] && IS_PY39_OR_LATER=1 || IS_PY39_OR_LATER=0
 # Install if python pip does not exist.

--- a/pom.xml
+++ b/pom.xml
@@ -851,7 +851,8 @@
 
     <properties>
         <!-- start dyn.shim properties -->
-	<dyn.shim.excluded.releases></dyn.shim.excluded.releases>
+        <!--  TODO: Will remove 330db from the execluding list after the issue is fixed: https://github.com/NVIDIA/spark-rapids/issues/12694 -->
+	<dyn.shim.excluded.releases>330db</dyn.shim.excluded.releases>
         <!-- end dyn.shim properties -->
 
         <rapids.module>.</rapids.module>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -851,7 +851,8 @@
 
     <properties>
         <!-- start dyn.shim properties -->
-	<dyn.shim.excluded.releases></dyn.shim.excluded.releases>
+        <!--  TODO: Will remove 330db from the execluding list after the issue is fixed: https://github.com/NVIDIA/spark-rapids/issues/12694 -->
+	<dyn.shim.excluded.releases>330db</dyn.shim.excluded.releases>
         <!-- end dyn.shim properties -->
 
         <rapids.module>.</rapids.module>


### PR DESCRIPTION
We'll not support Databricks 11.3 shim in spark-rapids v25.06.0 release

To fix part of https://github.com/NVIDIA/spark-rapids/issues/12694