### PR TITLE
Update 'maxNumWriters' metric only when it exists [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
@@ -238,8 +238,8 @@ class BasicColumnarWriteJobStatsTracker(
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.NUM_OUTPUT_BYTES_KEY).add(totalNumBytes)
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.NUM_OUTPUT_ROWS_KEY).add(totalNumOutput)
     driverSideMetrics(BasicColumnarWriteJobStatsTracker.NUM_PARTS_KEY).add(partitionsSet.size)
-    driverSideMetrics(BasicColumnarWriteJobStatsTracker.MAX_WRITERS_NUM_KEY).add(maxNumWriters)
-
+    driverSideMetrics.get(BasicColumnarWriteJobStatsTracker.MAX_WRITERS_NUM_KEY)
+      .foreach(_.add(maxNumWriters))
 
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     SQLMetrics.postDriverMetricUpdates(sparkContext, executionId,


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/12702

Delta write sometimes does not use the GPU write metrics, so this PR changes to update the 'maxNumWriters' metric only when it exists.

This is a quick fix to unblock CIs. Another alternative is to add in this metric for all the delta shims, but this requires more work than this quick fix. So we can do it in the future. 


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
