### PR TITLE
Redefine the companionGpuMetric of time metric

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
@@ -35,13 +35,11 @@ class NvtxWithMetrics(name: String, color: NvtxColor, val metrics: GpuMetric*)
   extends NvtxRange(name, color) {
 
   val needTracks = metrics.map(_.tryActivateTimer())
-  private val start = System.nanoTime()
 
   override def close(): Unit = {
-    val time = System.nanoTime() - start
     metrics.toSeq.zip(needTracks).foreach { pair =>
       if (pair._2) {
-        pair._1.deactivateTimer(time)
+        pair._1.deactivateTimer()
       }
     }
     super.close()
@@ -50,13 +48,11 @@ class NvtxWithMetrics(name: String, color: NvtxColor, val metrics: GpuMetric*)
 
 class MetricRange(val metrics: GpuMetric*) extends AutoCloseable {
   val needTracks = metrics.map(_.tryActivateTimer())
-  private val start = System.nanoTime()
 
   override def close(): Unit = {
-    val time = System.nanoTime() - start
     metrics.toSeq.zip(needTracks).foreach { pair =>
       if (pair._2) {
-        pair._1.deactivateTimer(time)
+        pair._1.deactivateTimer()
       }
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -339,6 +339,8 @@ class GpuTaskMetrics extends Serializable {
     }
   }
 
+  def getSemaphoreHoldingTime(): Long = semaphoreHoldingTime.value.value
+
   def addSemaphoreHoldingTime(duration: Long): Unit = semaphoreHoldingTime.add(duration)
 
   def getSemWaitTime(): Long = semWaitTimeNs.value.value


### PR DESCRIPTION
Closes #12706 #12660

This PR tries to accomplish two things:
1. Redefine and rework the companionGpuMetric of time metric, which was used to record the corresponding excluding semaphore time. With this PR, the companionGpuMetric records the duration of holding the semaphore, instead. The new metric can better reflect the actual overhead of tracked blocks in terms of GPU resource.
2. Support the companionGpuMetric for buffer time and filter time of multi-thread reader. During the period of waiting multi-thread I/O buffers, the semaphore wait time will always be zero. Because the semaphore is ether not acquired yet or already being acquired, considering that the requiring of I/O buffers takes place in the very beginning of the process of each batch.

How to compute `withSemaphoreTime`:
```
Inc(withSemaphoreTime) = Inc(GpuTaskMetrics.semaphoreHoldingTime) 
                         + (duration of onHold sem. after end)
                         - (duration of onHold sem. before start)
```
1. GpuTaskMetrics.semaphoreHoldingTime will only be updated after the release of semaphore. So, we need to take care of the ongoing semaphore (before/start) via other approach.
2. `SemaphoreTaskInfo.lastAcquired` and `lastReleased` can be used to determine if current Spark task is holding a semaphore at this point (lastAcquired > lastReleased) and how long it has been holding the semaphore (Now - lastAcquired).

<img width="514" alt="image" src="https://github.com/user-attachments/assets/32c14337-346e-438f-bdcb-8c8f0ed7e368" />
