### PR TITLE
Fix explainMode to work when GPU isn't present

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -392,6 +392,7 @@ else
     fi
 
     SPARK_SHELL_SMOKE_TEST="${SPARK_SHELL_SMOKE_TEST:-0}"
+    EXPLAIN_ONLY_CPU_SMOKE_TEST="${EXPLAIN_ONLY_CPU_SMOKE_TEST:-0}"
     if [[ "${SPARK_SHELL_SMOKE_TEST}" != "0" ]]; then
         echo "Running spark-shell smoke test..."
         SPARK_SHELL_ARGS_ARR=(
@@ -424,6 +425,20 @@ else
             "${SPARK_HOME}"/bin/spark-shell "${SPARK_SHELL_ARGS_ARR[@]}" 2>/dev/null \
             | grep -F 'res0: Array[org.apache.spark.sql.Row] = Array([4950])'
         echo "SUCCESS spark-shell smoke test"
+    elif [[ "${EXPLAIN_ONLY_CPU_SMOKE_TEST}" != "0" ]]; then
+        echo "Running explainOnly mode on CPU smoke test..."
+        SPARK_SHELL_ARGS_ARR=(
+            --master local-cluster[1,2,1024]
+            --jars "${PYSP_TEST_spark_jars}"
+            --conf spark.plugins=com.nvidia.spark.SQLPlugin
+            --conf spark.deploy.maxExecutorRetries=0
+            --conf spark.rapids.sql.mode=explainOnly
+        )
+        output=$(<<< 'spark.range(100).agg(Map("id" -> "sum")).collect()' \
+            CUDA_VISIBLE_DEVICES="" "${SPARK_HOME}"/bin/spark-shell "${SPARK_SHELL_ARGS_ARR[@]}" 2>&1)
+        grep 'WARN RapidsPluginUtils: RAPIDS Accelerator is in explain only mode' <<< "$output"
+        grep -F 'res0: Array[org.apache.spark.sql.Row] = Array([4950])' <<< "$output"
+        echo "SUCCESS explainOnly mode on CPU smoke test"
     elif ((${#TEST_PARALLEL_OPTS[@]} > 0));
     then
         exec python "${RUN_TESTS_COMMAND[@]}" "${TEST_PARALLEL_OPTS[@]}" "${TEST_COMMON_OPTS[@]}"

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -428,7 +428,7 @@ else
     elif [[ "${EXPLAIN_ONLY_CPU_SMOKE_TEST}" != "0" ]]; then
         echo "Running explainOnly mode on CPU smoke test..."
         SPARK_SHELL_ARGS_ARR=(
-            --master local-cluster[1,2,1024]
+            --master local[2]
             --jars "${PYSP_TEST_spark_jars}"
             --conf spark.plugins=com.nvidia.spark.SQLPlugin
             --conf spark.deploy.maxExecutorRetries=0

--- a/integration_tests/src/main/python/explain_mode_test.py
+++ b/integration_tests/src/main/python/explain_mode_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/explain_mode_test.py
+++ b/integration_tests/src/main/python/explain_mode_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,12 @@ all_gen = [StringGen(), ByteGen()]
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-def test_explain_only_sortmerge_join(data_gen, join_type):
+@pytest.mark.parametrize('disable_cuda_devices', [True, False])
+def test_explain_only_sortmerge_join(data_gen, join_type, disable_cuda_devices, monkeypatch):
+    # ensure that explainMode works when no GPU is available
+    if disable_cuda_devices:
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 500)
         return left.join(right, left.a == right.r_a, join_type)

--- a/integration_tests/src/main/python/explain_mode_test.py
+++ b/integration_tests/src/main/python/explain_mode_test.py
@@ -41,12 +41,7 @@ all_gen = [StringGen(), ByteGen()]
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize('disable_cuda_devices', [True, False])
-def test_explain_only_sortmerge_join(data_gen, join_type, disable_cuda_devices, monkeypatch):
-    # ensure that explainMode works when no GPU is available
-    if disable_cuda_devices:
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
-
+def test_explain_only_sortmerge_join(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 500)
         return left.join(right, left.a == right.r_a, join_type)

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -291,6 +291,9 @@ if [[ $TEST_MODE == "DEFAULT" ]]; then
   PYSP_TEST_spark_shuffle_manager=com.nvidia.spark.rapids.${SHUFFLE_SPARK_SHIM}.RapidsShuffleManager \
     ./run_pyspark_from_build.sh
 
+  EXPLAIN_ONLY_CPU_SMOKE_TEST=1 \
+    ./run_pyspark_from_build.sh
+
   # As '--packages' only works on the default cuda11 jar, it does not support classifiers
   # refer to issue : https://issues.apache.org/jira/browse/SPARK-20075
   # "$CLASSIFIER" == ''" is usally for the case running by developers,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -531,7 +531,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       // Checks if the current GPU architecture is supported by the
       // spark-rapids-jni and cuDF libraries.
       // Note: We allow this check to be skipped for off-chance cases.
-      if (!conf.skipGpuArchCheck && conf.isSqlEnabled && conf.isSqlExecuteOnGPU) {
+      if (!conf.skipGpuArchCheck && conf.isSqlExecuteOnGPU) {
         RapidsPluginUtils.validateGpuArchitecture()
       }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -531,7 +531,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       // Checks if the current GPU architecture is supported by the
       // spark-rapids-jni and cuDF libraries.
       // Note: We allow this check to be skipped for off-chance cases.
-      if (!conf.skipGpuArchCheck) {
+      if (!conf.skipGpuArchCheck && conf.isSqlEnabled && conf.isSqlExecuteOnGPU) {
         RapidsPluginUtils.validateGpuArchitecture()
       }
 


### PR DESCRIPTION
Resolves #12723 to bypass the GPU arch validation check if explainMode is on. 