### PR TITLE
Unified priority task life-cycle

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -31,9 +31,10 @@ import ai.rapids.cudf.{Cuda, CudaException, CudaFatalException, CudfException, M
 import com.nvidia.spark.DFUDFPlugin
 import com.nvidia.spark.rapids.RapidsConf.AllowMultipleJars
 import com.nvidia.spark.rapids.RapidsPluginUtils.buildInfoEvent
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.filecache.{FileCache, FileCacheLocalityManager, FileCacheLocalityMsg}
 import com.nvidia.spark.rapids.io.async.TrafficController
-import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
+import com.nvidia.spark.rapids.jni.{GpuTimeZoneDB, TaskPriority}
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import org.apache.commons.lang3.exception.ExceptionUtils
 
@@ -721,7 +722,13 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   }
 
   override def onTaskStart(): Unit = {
-    startTaskNvtx(TaskContext.get)
+    val tc = TaskContext.get
+    startTaskNvtx(tc)
+    // Set the priority for the task as soon as it is launched
+    TaskPriority.getTaskPriority(tc.taskAttemptId())
+    onTaskCompletion(tc, tc => {
+      TaskPriority.taskDone(tc.taskAttemptId())
+    })
     extraExecutorPlugins.foreach(_.onTaskStart())
     ProfilerOnExecutor.onTaskStart()
     // Make sure that the thread/task is registered before we try and block

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.{ExecutionException, Future, LinkedBlockingQueue, Ti
 
 import ai.rapids.cudf.{HostMemoryBuffer, PinnedMemoryPool, Rmm, RmmAllocationMode}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.jni.{RmmSpark, RmmSparkThreadState}
+import com.nvidia.spark.rapids.jni.{RmmSpark, RmmSparkThreadState, TaskPriority}
 import com.nvidia.spark.rapids.spill._
 import org.mockito.Mockito.when
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -55,7 +55,10 @@ class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
         with Future[Void]{
       override def toString = "TASK DONE"
 
-      override def doIt(): Void = null
+      override def doIt(): Void = {
+        TaskPriority.taskDone(wrapped.taskId)
+        null
+      }
 
       override def cancel(b: Boolean) = false
 
@@ -126,7 +129,10 @@ class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
       setDaemon(true)
       start()
       val waitForStart = doIt(new TaskThreadOp[Void]() {
-        override def doIt(): Void = null
+        override def doIt(): Void = {
+          TaskPriority.getTaskPriority(taskId)
+          null
+        }
 
         override def toString: String = s"INIT TASK $name TASK $taskId"
       })


### PR DESCRIPTION
This depends on https://github.com/NVIDIA/spark-rapids-jni/pull/3286

This is just updating task life-cycle to inform the TaskPriority when something happens. This is a step before changing the priority implementation. This makes it so that the tests don't fail.