### PR TITLE
Output more information of the current GPU before an executor exits due to fatal cuda exceptions

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -662,7 +662,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
     try {
       val nvidiaSmiStdout = new StringBuilder
       val nvidiaSmiStderr = new StringBuilder
-      val cmd = "nvidia-smi".run(
+      val cmd = "nvidia-smi -q".run(
         ProcessLogger(s => nvidiaSmiStdout.append(s + "\n"), s => nvidiaSmiStderr.append(s + "\n")))
       waitForProcess(cmd, 10000) match {
         case Some(exitStatus) =>


### PR DESCRIPTION
This is related to https://github.com/NVIDIA/spark-rapids/issues/12573

Add the `-q` option to the `nvidia-smi` command to display more details about the current GPU to know the state of the GPU hardware better when exceptions happen, especially the ECC errors information that possbibly has something to do with the `cudaErrorIllegalAddress` error. 