### PR TITLE
Disable ArrayIntersect in hybrid scan filter pushdown

### DIFF
--- a/integration_tests/src/main/python/hybrid_parquet_test.py
+++ b/integration_tests/src/main/python/hybrid_parquet_test.py
@@ -406,9 +406,8 @@ condition_list = [
     "(sort_array(array_int_1) == array_int_1)",
     "(size(array_int_1) == 1)",
     # Array[Int], Array[Int]:
-    # ArrayExcept,ArrayIntersect,ArraysZip
+    # ArrayExcept,ArraysZip
     "(array_except(array_int_1, array_int_2) == array_int_1)",
-    "(array_intersect(array_int_1, array_int_2) == array_int_1)",
     "(arrays_zip(array_int_1, array_int_2) == " + 
     "array(struct(1 as array_int_1, 1 as array_int_2), struct(2 as array_int_1, 2 as array_int_2)))",
     # Array[Array[Int]]:

--- a/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/rapids/hybrid/HybridExecutionUtils.scala
@@ -204,7 +204,6 @@ object HybridExecutionUtils extends PredicateHelper {
     classOf[ArrayExcept],
     classOf[ArrayExists],
     classOf[ArrayForAll],
-    classOf[ArrayIntersect],
     classOf[ArrayMax],
     classOf[ArrayMin],
     classOf[ArrayPosition],


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/12742

A pipeline reported that the array_intersect pushed down to hybrid execution produced different results than Spark. This PR disabled it in the hybrid scan filter pushdown to avoid potential mismatches.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
