### PR TITLE
Enable the companion metric in the static "ns" method

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
@@ -193,12 +193,15 @@ object GpuMetric extends Logging {
   }
 
   def ns[T](metrics: GpuMetric*)(f: => T): T = {
+    val initedMetrics = metrics.map(m => (m, m.tryActivateTimer()))
     val start = System.nanoTime()
     try {
       f
     } finally {
       val taken = System.nanoTime() - start
-      metrics.foreach(_.add(taken))
+      initedMetrics.foreach { case (m, isTrack) =>
+        if (isTrack) m.deactivateTimer(taken)
+      }
     }
   }
 


### PR DESCRIPTION
PR https://github.com/NVIDIA/spark-rapids/pull/11331 introduces the companion metric without semaphore wait time,
but this feature is missing in the static `ns` method. This PR addresses this missing. 