### PR TITLE
Fix dataframe writer option for delta optimizeWrite on Databricks

### DIFF
--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -203,7 +203,7 @@ class GpuOptimisticTransaction(
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryPhysicalPlan,
         partitioningColumns, constraints)
       val optimizedPlan =
-        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize)
+        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize, writeOptions)
       val planWithInvariants = addInvariantChecks(optimizedPlan, constraints)
       val physicalPlan = convertToGpu(planWithInvariants)
 

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -139,10 +139,12 @@ abstract class GpuOptimisticTransactionBase
       spark: SparkSession,
       physicalPlan: SparkPlan,
       partitionSchema: StructType,
-      isOptimize: Boolean): SparkPlan = {
+      isOptimize: Boolean,
+      writeOptions: Option[DeltaOptions]): SparkPlan = {
     val optimizeWriteEnabled = !isOptimize &&
         spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED)
-            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata)).getOrElse(false)
+            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata))
+            .orElse(writeOptions.flatMap(_.optimizeWrite)).getOrElse(false)
     if (optimizeWriteEnabled) {
       val planWithoutTopRepartition =
         DeltaShufflePartitionsUtil.removeTopRepartition(physicalPlan)

--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -204,7 +204,7 @@ class GpuOptimisticTransaction(
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryPhysicalPlan,
         partitioningColumns, constraints)
       val optimizedPlan =
-        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize)
+        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize, writeOptions)
       val planWithInvariants = addInvariantChecks(optimizedPlan, constraints)
       val physicalPlan = convertToGpu(planWithInvariants)
 

--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -139,10 +139,12 @@ abstract class GpuOptimisticTransactionBase
       spark: SparkSession,
       physicalPlan: SparkPlan,
       partitionSchema: StructType,
-      isOptimize: Boolean): SparkPlan = {
+      isOptimize: Boolean,
+      writeOptions: Option[DeltaOptions]): SparkPlan = {
     val optimizeWriteEnabled = !isOptimize &&
         spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED)
-            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata)).getOrElse(false)
+            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata))
+            .orElse(writeOptions.flatMap(_.optimizeWrite)).getOrElse(false)
     if (optimizeWriteEnabled) {
       val planWithoutTopRepartition =
         DeltaShufflePartitionsUtil.removeTopRepartition(physicalPlan)

--- a/delta-lake/delta-spark341db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark341db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -206,7 +206,7 @@ class GpuOptimisticTransaction(
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryPhysicalPlan,
         partitioningColumns, constraints)
       val optimizedPlan =
-        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize)
+        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize, writeOptions)
       val planWithInvariants = addInvariantChecks(optimizedPlan, constraints)
       val physicalPlan = convertToGpu(planWithInvariants)
 

--- a/delta-lake/delta-spark341db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/delta-spark341db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -139,10 +139,12 @@ abstract class GpuOptimisticTransactionBase
       spark: SparkSession,
       physicalPlan: SparkPlan,
       partitionSchema: StructType,
-      isOptimize: Boolean): SparkPlan = {
+      isOptimize: Boolean,
+      writeOptions: Option[DeltaOptions]): SparkPlan = {
     val optimizeWriteEnabled = !isOptimize &&
         spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED)
-            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata)).getOrElse(false)
+            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata))
+            .orElse(writeOptions.flatMap(_.optimizeWrite)).getOrElse(false)
     if (optimizeWriteEnabled) {
       val planWithoutTopRepartition =
         DeltaShufflePartitionsUtil.removeTopRepartition(physicalPlan)

--- a/delta-lake/delta-spark350db143/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark350db143/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -205,7 +205,7 @@ class GpuOptimisticTransaction(
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryPhysicalPlan,
         partitioningColumns, constraints)
       val optimizedPlan =
-        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize)
+        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize, writeOptions)
       val planWithInvariants = addInvariantChecks(optimizedPlan, constraints)
       val physicalPlan = convertToGpu(planWithInvariants)
 

--- a/delta-lake/delta-spark350db143/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/delta-spark350db143/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -140,10 +140,12 @@ abstract class GpuOptimisticTransactionBase
       spark: SparkSession,
       physicalPlan: SparkPlan,
       partitionSchema: StructType,
-      isOptimize: Boolean): SparkPlan = {
+      isOptimize: Boolean,
+      writeOptions: Option[DeltaOptions]): SparkPlan = {
     val optimizeWriteEnabled = !isOptimize &&
         spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED)
-            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata)).getOrElse(false)
+            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata))
+            .orElse(writeOptions.flatMap(_.optimizeWrite)).getOrElse(false)
     if (optimizeWriteEnabled) {
       val planWithoutTopRepartition =
         DeltaShufflePartitionsUtil.removeTopRepartition(physicalPlan)

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -865,6 +865,19 @@ def test_delta_write_aqe_join(spark_tmp_path, enable_deletion_vectors):
         conf=confs)
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
+def do_test_optimize_write(spark_tmp_path, aqe_enabled, do_write, num_chunks):
+    confs=copy_and_update(delta_writes_enabled_conf, {
+        "spark.sql.adaptive.enabled" : str(aqe_enabled)
+    })
+    data_path = spark_tmp_path + "/DELTA_DATA1"
+    do_write(confs, data_path, is_optimize_write=False)
+    opmetrics = get_last_operation_metrics(data_path + "/GPU")
+    assert int(opmetrics["numFiles"]) == num_chunks
+    data_path = spark_tmp_path + "/DELTA_DATA2"
+    do_write(confs, data_path, is_optimize_write=True)
+    opmetrics = get_last_operation_metrics(data_path + "/GPU")
+    assert int(opmetrics["numFiles"]) == 1
+
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -874,27 +887,63 @@ def test_delta_write_aqe_join(spark_tmp_path, enable_deletion_vectors):
     "spark.databricks.delta.optimizeWrite.enabled",
     "spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite"], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", [True, False], ids=idfn)
-def test_delta_write_optimized_aqe(spark_tmp_path, enable_conf_key, aqe_enabled):
+def test_delta_write_optimized_sql_conf_aqe(spark_tmp_path, enable_conf_key, aqe_enabled):
     num_chunks = 20
-    def do_write(data_path, is_optimize_write):
-        confs=copy_and_update(delta_writes_enabled_conf, {
-            enable_conf_key : str(is_optimize_write),
-            "spark.sql.adaptive.enabled" : str(aqe_enabled)
+
+    def do_write(conf, data_path, is_optimize_write):
+        confs=copy_and_update(conf, {
+            enable_conf_key : str(is_optimize_write)
         })
         assert_gpu_and_cpu_writes_are_equal_collect(
-            lambda spark, path: unary_op_df(spark, int_gen)\
+            lambda spark, path: unary_op_df(spark, int_gen)
                 .repartition(num_chunks).write.format("delta").save(path),
             lambda spark, path: spark.read.format("delta").load(path),
             data_path,
             conf=confs)
-    data_path = spark_tmp_path + "/DELTA_DATA1"
-    do_write(data_path, is_optimize_write=False)
-    opmetrics = get_last_operation_metrics(data_path + "/GPU")
-    assert int(opmetrics["numFiles"]) == num_chunks
-    data_path = spark_tmp_path + "/DELTA_DATA2"
-    do_write(data_path, is_optimize_write=True)
-    opmetrics = get_last_operation_metrics(data_path + "/GPU")
-    assert int(opmetrics["numFiles"]) == 1
+    do_test_optimize_write(spark_tmp_path, aqe_enabled, do_write, num_chunks)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("confkey", ["optimizeWrite"], ids=idfn)
+@pytest.mark.parametrize("aqe_enabled", [True, False], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+@pytest.mark.skipif(not is_databricks_runtime(), reason="Optimized write is supported on Databricks")
+def test_delta_write_optimized_write_opts_aqe(spark_tmp_path, confkey, aqe_enabled):
+    num_chunks = 20
+
+    def do_write(conf, data_path, is_optimize_write):
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            lambda spark, path: unary_op_df(spark, int_gen)
+                .repartition(num_chunks).write.format("delta")
+                .option(confkey, str(is_optimize_write)).save(path),
+            lambda spark, path: spark.read.format("delta").load(path),
+            data_path,
+            conf=conf)
+    do_test_optimize_write(spark_tmp_path, aqe_enabled, do_write, num_chunks)
+
+@allow_non_gpu(*delta_meta_allow, "CreateTableExec", "ExecutedCommandExec")
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("confkey", ["delta.autoOptimize.optimizeWrite"], ids=idfn)
+@pytest.mark.parametrize("aqe_enabled", [True, False], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+@pytest.mark.skipif(not is_databricks_runtime(), reason="Auto optimize only supported on Databricks")
+def test_delta_write_optimized_table_props_aqe(spark_tmp_path, confkey, aqe_enabled):
+    num_chunks = 20
+
+    def do_write(conf, data_path, is_optimize_write):
+        def setup_tables(spark):
+            spark.sql("CREATE TABLE delta.`{}/CPU` (a INT) USING DELTA TBLPROPERTIES ({} = {})".format(data_path, confkey, is_optimize_write))
+            spark.sql("CREATE TABLE delta.`{}/GPU` (a INT) USING DELTA TBLPROPERTIES ({} = {})".format(data_path, confkey, is_optimize_write))
+        with_cpu_session(setup_tables)
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            lambda spark, path: unary_op_df(spark, int_gen).repartition(num_chunks)
+                .write.format("delta").mode("append").save(path),
+            lambda spark, path: spark.read.format("delta").load(path),
+            data_path,
+            conf=conf)
+    do_test_optimize_write(spark_tmp_path, aqe_enabled, do_write, num_chunks)
 
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/12758. 

`DeltaOptions` should be taken into account to check if the optimizeWrite is enabled while constructing the query plan. Integration tests are added to cover not only the fix, but also the case when it is enabled via the table property which was also missing previously.