### PR TITLE
Accelerate premerge CI with non-PVC workspace

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -192,6 +192,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
 
                     steps {
                         script {
+                            unstash "source_tree"
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
                                     try {

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -24,7 +24,7 @@ import hudson.model.Result
 import hudson.model.Run
 import jenkins.model.CauseOfInterruption.UserInterruption
 
-@Library('blossom-lib')
+@Library('blossom-lib@yinqing/fix_sync_workspace')
 @Library('blossom-github-lib@master')
 import ipp.blossom.*
 
@@ -37,8 +37,6 @@ def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:
 def PREMERGE_TAG
 def skipped = false
 def db_build = false
-def sourcePattern = 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,' +
-    'sql-plugin/src/main/java/,sql-plugin/src/main/scala/'
 // The path where the CI_PART1 job shares rapids plugin built tars with the CI_PART job
 def plugin_built_dir = "dbfs:/cicd/$BUILD_TAG"
 
@@ -78,6 +76,7 @@ pipeline {
         PVC = credentials("pvc")
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
         CLASSIFIER = 'cuda11'
+        TMP_WORKSPACE = "/tmp/${BUILD_TAG}"
     }
 
     stages {
@@ -193,19 +192,22 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         script {
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
-                                    try {
-                                        sh "$PREMERGE_SCRIPT mvn_verify"
-                                        step([$class                : 'JacocoPublisher',
-                                              execPattern           : '**/target/jacoco.exec',
-                                              classPattern          : 'target/jacoco_classes/',
-                                              sourceInclusionPattern: '**/*.java,**/*.scala',
-                                              sourcePattern         : sourcePattern
-                                        ])
-                                    } finally {
-                                        common.publishPytestResult(this, "${STAGE_NAME}")
-                                        common.printJVMCoreDumps(this)
+                                    def sourcePattern = '${TMP_WORKSPACE}/shuffle-plugin/src/main/scala/,${TMP_WORKSPACE}/udf-compiler/src/main/scala/,' +
+                                                        '${TMP_WORKSPACE}/sql-plugin/src/main/java/,${TMP_WORKSPACE}/sql-plugin/src/main/scala/'
+                                    common.syncWorkspace(this, env.CUSTOM_WORKSPACE, env.TMP_WORKSPACE) {
+                                        try {
+                                            sh "cd $TMP_WORKSPACE && WORKSPACE=$TMP_WORKSPACE $PREMERGE_SCRIPT mvn_verify"
+                                            step([$class                : 'JacocoPublisher',
+                                                  execPattern           : '${TMP_WORKSPACE}/**/target/jacoco.exec',
+                                                  classPattern          : '${TMP_WORKSPACE}/target/jacoco_classes/',
+                                                  sourceInclusionPattern: '${TMP_WORKSPACE}/**/*.java,${TMP_WORKSPACE}/**/*.scala',
+                                                  sourcePattern         : sourcePattern
+                                            ])
+                                        } finally {
+                                            common.publishPytestResult(this, "${STAGE_NAME}", env.TMP_WORKSPACE)
+                                            common.printJVMCoreDumps(this, env.TMP_WORKSPACE)
+                                        }
                                     }
-                                    deleteDir() // cleanup content if no error
                                 }
                             }
                         }
@@ -231,13 +233,14 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             unstash "source_tree"
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
-                                    try {
-                                        sh "$PREMERGE_SCRIPT ci_2"
-                                    } finally {
-                                        common.publishPytestResult(this, "${STAGE_NAME}")
-                                        common.printJVMCoreDumps(this)
+                                    common.syncWorkspace(this, env.CUSTOM_WORKSPACE, env.TMP_WORKSPACE) {
+                                        try {
+                                            sh "cd $TMP_WORKSPACE && WORKSPACE=$TMP_WORKSPACE $PREMERGE_SCRIPT ci_2"
+                                        } finally {
+                                            common.publishPytestResult(this, "${STAGE_NAME}", env.TMP_WORKSPACE)
+                                            common.printJVMCoreDumps(this, env.TMP_WORKSPACE)
+                                        }
                                     }
-                                    deleteDir() // cleanup content if no error
                                 }
                             }
                         }
@@ -263,13 +266,14 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             unstash "source_tree"
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
-                                    try {
-                                        sh "$PREMERGE_SCRIPT ci_scala213"
-                                    } finally {
-                                        common.publishPytestResult(this, "${STAGE_NAME}")
-                                        common.printJVMCoreDumps(this)
+                                    common.syncWorkspace(this, env.CUSTOM_WORKSPACE, env.TMP_WORKSPACE) {
+                                        try {
+                                            sh "cd $TMP_WORKSPACE && WORKSPACE=$TMP_WORKSPACE $PREMERGE_SCRIPT ci_scala213"
+                                        } finally {
+                                            common.publishPytestResult(this, "${STAGE_NAME}", env.TMP_WORKSPACE)
+                                            common.printJVMCoreDumps(this, env.TMP_WORKSPACE)
+                                        }
                                     }
-                                    deleteDir() // cleanup content if no error
                                 }
                             }
                         }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -24,7 +24,7 @@ import hudson.model.Result
 import hudson.model.Run
 import jenkins.model.CauseOfInterruption.UserInterruption
 
-@Library('blossom-lib@yinqing/fix_sync_workspace')
+@Library('blossom-lib')
 @Library('blossom-github-lib@master')
 import ipp.blossom.*
 
@@ -37,6 +37,8 @@ def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:
 def PREMERGE_TAG
 def skipped = false
 def db_build = false
+def sourcePattern = 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,' +
+    'sql-plugin/src/main/java/,sql-plugin/src/main/scala/'
 // The path where the CI_PART1 job shares rapids plugin built tars with the CI_PART job
 def plugin_built_dir = "dbfs:/cicd/$BUILD_TAG"
 
@@ -76,7 +78,8 @@ pipeline {
         PVC = credentials("pvc")
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
         CLASSIFIER = 'cuda11'
-        TMP_WORKSPACE = "/tmp/${BUILD_TAG}"
+        PVC_MOUNT_PATH = "/pvc"
+        PVC_WORKSPACE = "/pvc/workspace/${BUILD_TAG}"
     }
 
     stages {
@@ -182,8 +185,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         kubernetes {
                             label "premerge-ci-1-${BUILD_TAG}"
                             cloud "${common.CLOUD_NAME}"
-                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
-                            workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                            yaml pod.getGPUYAMLwithVolume("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", "${PVC}", "${PVC_MOUNT_PATH}", '8', '32Gi')
                             customWorkspace "${CUSTOM_WORKSPACE}"
                         }
                     }
@@ -192,21 +194,22 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         script {
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
-                                    def sourcePattern = '${TMP_WORKSPACE}/shuffle-plugin/src/main/scala/,${TMP_WORKSPACE}/udf-compiler/src/main/scala/,' +
-                                                        '${TMP_WORKSPACE}/sql-plugin/src/main/java/,${TMP_WORKSPACE}/sql-plugin/src/main/scala/'
-                                    common.syncWorkspace(this, env.CUSTOM_WORKSPACE, env.TMP_WORKSPACE) {
-                                        try {
-                                            sh "cd $TMP_WORKSPACE && WORKSPACE=$TMP_WORKSPACE $PREMERGE_SCRIPT mvn_verify"
-                                            step([$class                : 'JacocoPublisher',
-                                                  execPattern           : '${TMP_WORKSPACE}/**/target/jacoco.exec',
-                                                  classPattern          : '${TMP_WORKSPACE}/target/jacoco_classes/',
-                                                  sourceInclusionPattern: '${TMP_WORKSPACE}/**/*.java,${TMP_WORKSPACE}/**/*.scala',
-                                                  sourcePattern         : sourcePattern
-                                            ])
-                                        } finally {
-                                            common.publishPytestResult(this, "${STAGE_NAME}", env.TMP_WORKSPACE)
-                                            common.printJVMCoreDumps(this, env.TMP_WORKSPACE)
-                                        }
+                                    try {
+                                        error "test sync dir"
+                                        common.pvcM2Cache(this, PVC_MOUNT_PATH)
+                                        sh "$PREMERGE_SCRIPT mvn_verify"
+                                        step([$class                : 'JacocoPublisher',
+                                              execPattern           : '**/target/jacoco.exec',
+                                              classPattern          : 'target/jacoco_classes/',
+                                              sourceInclusionPattern: '**/*.java,**/*.scala',
+                                              sourcePattern         : sourcePattern
+                                        ])
+                                    } catch(e) {
+                                        common.syncDir(this, "${env.CUSTOM_WORKSPACE}", "${env.PVC_WORKSPACE}", false, ['.m2/'])
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                        common.printJVMCoreDumps(this)
                                     }
                                 }
                             }
@@ -222,8 +225,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         kubernetes {
                             label "premerge-ci-2-${BUILD_TAG}"
                             cloud "${common.CLOUD_NAME}"
-                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
-                            workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                            yaml pod.getGPUYAMLwithVolume("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", "${PVC}", "${PVC_MOUNT_PATH}", '8', '32Gi')
                             customWorkspace "${CUSTOM_WORKSPACE}-ci-2" // Use different workspace to avoid conflict with IT
                         }
                     }
@@ -233,13 +235,16 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             unstash "source_tree"
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
-                                    common.syncWorkspace(this, env.CUSTOM_WORKSPACE, env.TMP_WORKSPACE) {
-                                        try {
-                                            sh "cd $TMP_WORKSPACE && WORKSPACE=$TMP_WORKSPACE $PREMERGE_SCRIPT ci_2"
-                                        } finally {
-                                            common.publishPytestResult(this, "${STAGE_NAME}", env.TMP_WORKSPACE)
-                                            common.printJVMCoreDumps(this, env.TMP_WORKSPACE)
-                                        }
+                                    try {
+                                        error "test sync dir"
+                                        common.pvcM2Cache(this, PVC_MOUNT_PATH)
+                                        sh "$PREMERGE_SCRIPT ci_2"
+                                    } catch(e) {
+                                        common.syncDir(this, "${env.CUSTOM_WORKSPACE}-ci-2", "${env.PVC_WORKSPACE}-ci-2", false, ['.m2/'])
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                        common.printJVMCoreDumps(this)
                                     }
                                 }
                             }
@@ -255,8 +260,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         kubernetes {
                             label "ci-scala213-${BUILD_TAG}"
                             cloud "${common.CLOUD_NAME}"
-                            yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
-                            workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                            yaml pod.getGPUYAMLwithVolume("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", "${PVC}", "${PVC_MOUNT_PATH}", '8', '32Gi')
                             customWorkspace "${CUSTOM_WORKSPACE}-scala-213" // Use different workspace to avoid conflict with IT
                         }
                     }
@@ -266,13 +270,16 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             unstash "source_tree"
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
-                                    common.syncWorkspace(this, env.CUSTOM_WORKSPACE, env.TMP_WORKSPACE) {
-                                        try {
-                                            sh "cd $TMP_WORKSPACE && WORKSPACE=$TMP_WORKSPACE $PREMERGE_SCRIPT ci_scala213"
-                                        } finally {
-                                            common.publishPytestResult(this, "${STAGE_NAME}", env.TMP_WORKSPACE)
-                                            common.printJVMCoreDumps(this, env.TMP_WORKSPACE)
-                                        }
+                                    try {
+                                        error "test sync dir"
+                                        common.pvcM2Cache(this, PVC_MOUNT_PATH)
+                                        sh "$PREMERGE_SCRIPT ci_scala213"
+                                    } catch(e) {
+                                        common.syncDir(this, "${env.CUSTOM_WORKSPACE}-scala-213", "${env.PVC_WORKSPACE}-scala-213", false, ['.m2/'])
+                                        throw e
+                                    } finally {
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
+                                        common.printJVMCoreDumps(this)
                                     }
                                 }
                             }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -195,7 +195,6 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
                                     try {
-                                        error "test sync dir"
                                         common.pvcM2Cache(this, PVC_MOUNT_PATH)
                                         sh "$PREMERGE_SCRIPT mvn_verify"
                                         step([$class                : 'JacocoPublisher',
@@ -236,7 +235,6 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
                                     try {
-                                        error "test sync dir"
                                         common.pvcM2Cache(this, PVC_MOUNT_PATH)
                                         sh "$PREMERGE_SCRIPT ci_2"
                                     } catch(e) {
@@ -271,7 +269,6 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
                                     try {
-                                        error "test sync dir"
                                         common.pvcM2Cache(this, PVC_MOUNT_PATH)
                                         sh "$PREMERGE_SCRIPT ci_scala213"
                                     } catch(e) {

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -252,13 +252,6 @@ nvidia-smi
 
 PREMERGE_PROFILES="-Ppre-merge"
 
-# If possible create '~/.m2' cache from pre-created m2 tarball to minimize the impact of unstable network connection.
-# Please refer to job 'update_premerge_m2_cache' on Blossom about building m2 tarball details.
-M2_CACHE_TAR=${M2_CACHE_TAR:-"/home/jenkins/agent/m2_cache/premerge_m2_cache.tar"}
-if [ -s "$M2_CACHE_TAR" ] ; then
-    tar xf $M2_CACHE_TAR -C ~/
-fi
-
 case $BUILD_TYPE in
 
     all)


### PR DESCRIPTION
Currently the premerge tests run on PVC, which significantly reduces IO performance, resulting in runtimes of 3-4 hrs. This PR is to speed up the premerge tests with non-PVC. 

Major changes in this PR:
1. use local disk as workspace to run the premerge 
2. copy workspace to PVC on failures for troubleshooting
3. move `pvcM2Cache` step to common lib 

With these changes, the runtime can be reduced to ~2.5hrs in my test run.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/82faf21a-f853-4861-a0b7-f395ed2ef007" />
