### PR TITLE
Add support for DeltaScan without DV for Delta Lake 3.3.0

### DIFF
--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -70,4 +70,14 @@ object Delta33xProvider extends DeltaIOProvider {
     throw new UnsupportedOperationException("Not implemented")
   }
 
+  override def tagForGpu(cpuExec: AtomicCreateTableAsSelectExec,
+    meta: AtomicCreateTableAsSelectExecMeta): Unit = {
+    meta.willNotWorkOnGpu("Delta write is not supported at the moment")
+  }
+
+  override def tagForGpu(cpuExec: AtomicReplaceTableAsSelectExec,
+    meta: AtomicReplaceTableAsSelectExecMeta): Unit = {
+    meta.willNotWorkOnGpu("Delta write is not supported at the moment")
+  }
+
 }

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -22,13 +22,10 @@ import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
 import org.apache.spark.sql.delta.DeltaParquetFileFormat
 import org.apache.spark.sql.delta.DeltaParquetFileFormat.{IS_ROW_DELETED_COLUMN_NAME, ROW_INDEX_COLUMN_NAME}
-import org.apache.spark.sql.delta.catalog.DeltaCatalog
-import org.apache.spark.sql.delta.rapids.DeltaRuntimeShim
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation}
 import org.apache.spark.sql.execution.datasources.v2.{AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec}
-import org.apache.spark.sql.execution.datasources.v2.rapids.{GpuAtomicCreateTableAsSelectExec, GpuAtomicReplaceTableAsSelectExec}
 
 object Delta33xProvider extends DeltaIOProvider {
 
@@ -64,32 +61,13 @@ object Delta33xProvider extends DeltaIOProvider {
   override def convertToGpu(
     cpuExec: AtomicCreateTableAsSelectExec,
     meta: AtomicCreateTableAsSelectExecMeta): GpuExec = {
-
-    val cpuCatalog = cpuExec.catalog.asInstanceOf[DeltaCatalog]
-    GpuAtomicCreateTableAsSelectExec(
-      DeltaRuntimeShim.getGpuDeltaCatalog(cpuCatalog, meta.conf),
-      cpuExec.ident,
-      cpuExec.partitioning,
-      cpuExec.query,
-      cpuExec.tableSpec,
-      cpuExec.writeOptions,
-      cpuExec.ifNotExists)
+    throw new UnsupportedOperationException("Not implemented")
   }
 
   override def convertToGpu(
     cpuExec: AtomicReplaceTableAsSelectExec,
     meta: AtomicReplaceTableAsSelectExecMeta): GpuExec = {
-
-    val cpuCatalog = cpuExec.catalog.asInstanceOf[DeltaCatalog]
-    GpuAtomicReplaceTableAsSelectExec(
-      DeltaRuntimeShim.getGpuDeltaCatalog(cpuCatalog, meta.conf),
-      cpuExec.ident,
-      cpuExec.partitioning,
-      cpuExec.query,
-      cpuExec.tableSpec,
-      cpuExec.writeOptions,
-      cpuExec.orCreate,
-      cpuExec.invalidateCache)
+    throw new UnsupportedOperationException("Not implemented")
   }
 
 }

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta33x
+
+import com.nvidia.spark.rapids.{AtomicCreateTableAsSelectExecMeta, AtomicReplaceTableAsSelectExecMeta, GpuExec, RunnableCommandRule}
+import com.nvidia.spark.rapids.{GpuReadParquetFileFormat, SparkPlanMeta}
+import com.nvidia.spark.rapids.delta.DeltaIOProvider
+
+import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation}
+import org.apache.spark.sql.execution.datasources.v2.{AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec}
+
+object Delta33xProvider extends DeltaIOProvider {
+
+  override def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
+    val format = meta.wrapped.relation.fileFormat
+    if (format.getClass == classOf[DeltaParquetFileFormat]) {
+      GpuReadParquetFileFormat.tagSupport(meta)
+    } else {
+      meta.willNotWorkOnGpu(s"format ${format.getClass} is not supported")
+    }
+  }
+
+  override def getReadFileFormat(relation: HadoopFsRelation): FileFormat = {
+    val cpuFormat = relation.fileFormat.asInstanceOf[DeltaParquetFileFormat]
+    GpuDelta33xParquetFileFormat(cpuFormat.protocol, cpuFormat.metadata,
+      tablePath = cpuFormat.tablePath)
+  }
+
+  def convertToGpu(cpuExec: AtomicReplaceTableAsSelectExec, meta: AtomicReplaceTableAsSelectExecMeta): GpuExec = {
+    throw new UnsupportedOperationException("We don't support AtomicReplaceTableAsSelectExec")
+  }
+
+  def convertToGpu(cpuExec: AtomicCreateTableAsSelectExec, meta: AtomicCreateTableAsSelectExecMeta): GpuExec = {
+    throw new UnsupportedOperationException("We don't support AtomicReplaceTableAsSelectExec")
+  }
+  def getRunnableCommandRules: Map[Class[_ <: RunnableCommand], RunnableCommandRule[_ <: RunnableCommand]] = {
+    throw new UnsupportedOperationException("We don't support AtomicReplaceTableAsSelectExec")
+  }
+
+}

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta33x
+
+import com.nvidia.spark.rapids.GpuMetric
+import com.nvidia.spark.rapids.delta.GpuDeltaParquetFileFormat
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaColumnMappingMode, IdMapping, NameMapping, TypeWidening}
+import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.delta.DeltaParquetFileFormat._
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.schema.SchemaMergingUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionedFile}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{MetadataBuilder, StructType}
+
+case class GpuDelta33xParquetFileFormat(
+    protocol: Protocol,
+    metadata: Metadata,
+    nullableRowTrackingFields: Boolean = false,
+    optimizationsEnabled: Boolean = true,
+    tablePath: Option[String] = None,
+    isCDCRead: Boolean = false
+  ) extends GpuDeltaParquetFileFormat {
+
+  // Validate either we have all arguments for DV enabled read or none of them.
+  if (hasTablePath) {
+    SparkSession.getActiveSession.map { session =>
+      val useMetadataRowIndex =
+        session.sessionState.conf.getConf(DeltaSQLConf.DELETION_VECTORS_USE_METADATA_ROW_INDEX)
+      require(useMetadataRowIndex == optimizationsEnabled,
+        "Wrong arguments for Delta table scan with deletion vectors")
+    }
+  }
+
+  if (SparkSession.getActiveSession.isDefined) {
+    val session = SparkSession.getActiveSession.get
+    TypeWidening.assertTableReadable(session.sessionState.conf, protocol, metadata)
+  }
+
+  val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
+  val referenceSchema: StructType = metadata.schema
+
+  if (columnMappingMode == IdMapping) {
+    val requiredReadConf = SQLConf.PARQUET_FIELD_ID_READ_ENABLED
+    require(SparkSession.getActiveSession.exists(_.sessionState.conf.getConf(requiredReadConf)),
+      s"${requiredReadConf.key} must be enabled to support Delta id column mapping mode")
+    val requiredWriteConf = SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED
+    require(SparkSession.getActiveSession.exists(_.sessionState.conf.getConf(requiredWriteConf)),
+      s"${requiredWriteConf.key} must be enabled to support Delta id column mapping mode")
+  }
+
+  /**
+   * prepareSchemaForRead must only be used for parquet read.
+   * It removes "PARQUET_FIELD_ID_METADATA_KEY" for name mapping mode which address columns by
+   * physical name instead of id.
+   */
+  def prepareSchemaForRead(inputSchema: StructType): StructType = {
+    val schema = DeltaColumnMapping.createPhysicalSchema(
+      inputSchema, referenceSchema, columnMappingMode)
+    if (columnMappingMode == NameMapping) {
+      SchemaMergingUtils.transformColumns(schema) { (_, field, _) =>
+        field.copy(metadata = new MetadataBuilder()
+          .withMetadata(field.metadata)
+          .remove(DeltaColumnMapping.PARQUET_FIELD_ID_METADATA_KEY)
+          .remove(DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY)
+          .build())
+      }
+    } else schema
+  }
+
+  override def isSplitable(sparkSession: SparkSession,
+     options: Map[String, String],
+     path: Path): Boolean = optimizationsEnabled
+
+  def hasTablePath: Boolean = tablePath.isDefined
+
+  override def hashCode(): Int = getClass.getCanonicalName.hashCode()
+
+  override def buildReaderWithPartitionValuesAndMetrics(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration,
+      metrics: Map[String, GpuMetric])
+  : PartitionedFile => Iterator[InternalRow] = {
+
+    val useMetadataRowIndexConf = DeltaSQLConf.DELETION_VECTORS_USE_METADATA_ROW_INDEX
+    val useMetadataRowIndex = sparkSession.sessionState.conf.getConf(useMetadataRowIndexConf)
+
+    val dataReader = super.buildReaderWithPartitionValuesAndMetrics(
+      sparkSession,
+      prepareSchemaForRead(dataSchema),
+      prepareSchemaForRead(partitionSchema),
+      prepareSchemaForRead(requiredSchema),
+      filters,
+      options,
+      hadoopConf,
+      metrics)
+
+    val schemaWithIndices = requiredSchema.fields.zipWithIndex
+    def findColumn(name: String): Option[ColumnMetadata] = {
+      val results = schemaWithIndices.filter(_._1.name == name)
+      if (results.length > 1) {
+        throw new IllegalArgumentException(
+          s"There are more than one column with name=`$name` requested in the reader output")
+      }
+      results.headOption.map(e => ColumnMetadata(e._2, e._1))
+    }
+
+    val isRowDeletedColumn = findColumn(IS_ROW_DELETED_COLUMN_NAME)
+    val rowIndexColumn = findColumn(ROW_INDEX_COLUMN_NAME)
+
+    // We don't have any additional columns to generate, just return the original reader as is.
+    if (isRowDeletedColumn.isEmpty && rowIndexColumn.isEmpty) return dataReader
+
+    // We are using the row_index col generated by the parquet reader and there are no more
+    // columns to generate.
+    if (useMetadataRowIndex && isRowDeletedColumn.isEmpty) return dataReader
+
+    // We should never come here as we should have fallen back to the CPU
+    throw new IllegalStateException("We don't support reading deletion vectors on the GPU")
+  }
+}
+
+object GpuDelta33xParquetFileFormat {
+  def convertToGpu(relation: HadoopFsRelation): GpuDelta33xParquetFileFormat = {
+    val fmt = relation.fileFormat.asInstanceOf[DeltaParquetFileFormat]
+    GpuDelta33xParquetFileFormat(fmt.protocol, fmt.metadata, fmt.nullableRowTrackingFields,
+      fmt.optimizationsEnabled, fmt.tablePath, fmt.isCDCRead)
+  }
+}

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
@@ -24,12 +24,11 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaColumnMappingMode, IdMapping, NameMapping, TypeWidening}
-import org.apache.spark.sql.delta.DeltaParquetFileFormat
 import org.apache.spark.sql.delta.DeltaParquetFileFormat._
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{MetadataBuilder, StructType}
@@ -143,13 +142,5 @@ case class GpuDelta33xParquetFileFormat(
 
     // We should never come here as we should have fallen back to the CPU
     throw new IllegalStateException("We don't support reading deletion vectors on the GPU")
-  }
-}
-
-object GpuDelta33xParquetFileFormat {
-  def convertToGpu(relation: HadoopFsRelation): GpuDelta33xParquetFileFormat = {
-    val fmt = relation.fileFormat.asInstanceOf[DeltaParquetFileFormat]
-    GpuDelta33xParquetFileFormat(fmt.protocol, fmt.metadata, fmt.nullableRowTrackingFields,
-      fmt.optimizationsEnabled, fmt.tablePath, fmt.isCDCRead)
   }
 }

--- a/delta-lake/delta-33x/src/main/scala/org/apache/spark/sql/delta/rapids/delta33x/Delta33xRuntimeShim.scala
+++ b/delta-lake/delta-33x/src/main/scala/org/apache/spark/sql/delta/rapids/delta33x/Delta33xRuntimeShim.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta33x
+
+import com.nvidia.spark.rapids.RapidsConf
+import com.nvidia.spark.rapids.delta.DeltaProvider
+import com.nvidia.spark.rapids.delta.delta33x.Delta33xProvider
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.rapids.{DeltaRuntimeShim, GpuOptimisticTransactionBase}
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.util.Clock
+
+/**
+ * Delta runtime shim for Delta 3.3.x on Spark 3.5.x.
+ *
+ * @note This class is instantiated via reflection from DeltaProbeImpl
+ */
+class Delta33xRuntimeShim extends DeltaRuntimeShim {
+  override def getDeltaProvider: DeltaProvider = Delta33xProvider
+
+  override def unsafeVolatileSnapshotFromLog(deltaLog: DeltaLog): Snapshot = {
+    deltaLog.unsafeVolatileSnapshot
+  }
+
+  override def fileFormatFromLog(deltaLog: DeltaLog): FileFormat =
+    deltaLog.fileFormat(deltaLog.unsafeVolatileSnapshot.protocol,
+      deltaLog.unsafeVolatileSnapshot.metadata)
+
+  override def getTightBoundColumnOnFileInitDisabled(spark: SparkSession): Boolean = false
+
+  override def getGpuDeltaCatalog(
+     cpuCatalog: DeltaCatalog,
+     rapidsConf: RapidsConf): StagingTableCatalog = {
+    throw new UnsupportedOperationException("Not implemented")
+  }
+
+  def startTransaction(
+     log: DeltaLog,
+     conf: RapidsConf,
+     clock: Clock): GpuOptimisticTransactionBase = {
+    throw new UnsupportedOperationException("Not implemented")
+  }
+
+  override def stringFromStringUdf(f: String => String): UserDefinedFunction = {
+    throw new UnsupportedOperationException("Not implemented")
+  }
+}

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -74,7 +74,7 @@ def test_delta_merge_query(spark_tmp_table_factory):
 @pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
                     reason="Delta Lake deletion vector support is required")
-def test_delta_deletion_vector_read(spark_tmp_path, use_cdf):
+def test_delta_scan_read(spark_tmp_path, use_cdf):
     data_path = spark_tmp_path + "/DELTA_DATA"
     def setup_tables(spark):
         setup_delta_dest_table(spark, data_path,

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -77,8 +77,6 @@ def test_delta_scan_read(spark_tmp_path):
         setup_delta_dest_table(spark, data_path,
                                dest_table_func=lambda spark: unary_op_df(spark, int_gen),
                                use_cdf=use_cdf, enable_deletion_vectors=False)
-        spark.sql("INSERT INTO delta.`{}` VALUES(1)".format(data_path))
-        spark.sql("DELETE FROM delta.`{}` WHERE a = 1".format(data_path))
     with_cpu_session(setup_tables)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.sql("SELECT * FROM delta.`{}`".format(data_path)))

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -68,6 +68,24 @@ def test_delta_merge_query(spark_tmp_table_factory):
     result = with_cpu_session(lambda spark: spark.sql("SELECT * FROM t1 ORDER BY c0").collect(), conf=_conf)
     assert [Row(c0='a', c1=40), Row(c0='b', c1=20), Row(c0='c', c1=30)] == result
 
+@allow_non_gpu("ColumnarToRowExec", *delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
+                    reason="Delta Lake deletion vector support is required")
+def test_delta_deletion_vector_read(spark_tmp_path, use_cdf):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    def setup_tables(spark):
+        setup_delta_dest_table(spark, data_path,
+                               dest_table_func=lambda spark: unary_op_df(spark, int_gen),
+                               use_cdf=use_cdf, enable_deletion_vectors=False)
+        spark.sql("INSERT INTO delta.`{}` VALUES(1)".format(data_path))
+        spark.sql("DELETE FROM delta.`{}` WHERE a = 1".format(data_path))
+    with_cpu_session(setup_tables)
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.sql("SELECT * FROM delta.`{}`".format(data_path)))
+
 @allow_non_gpu("FileSourceScanExec", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -71,10 +71,7 @@ def test_delta_merge_query(spark_tmp_table_factory):
 @allow_non_gpu("ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
-@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
-                    reason="Delta Lake deletion vector support is required")
-def test_delta_scan_read(spark_tmp_path, use_cdf):
+def test_delta_scan_read(spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     def setup_tables(spark):
         setup_delta_dest_table(spark, data_path,


### PR DESCRIPTION
This PR adds support for Delta Scan to be on the GPU when deletion vectors are disabled. 

There is an integration test added to query the delta table with deletion vectors disabled to make sure we run the scan on the GPU

fixes #12757 