### PR TITLE
Fix iceberg 2.13 build

### DIFF
--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -32,6 +32,7 @@
     <version>25.06.0-SNAPSHOT</version>
 
     <properties>
+        <rapids.module>iceberg</rapids.module>
         <rapids.compressed.artifact>false</rapids.compressed.artifact>
         <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
         <maven.scaladoc.skip>true</maven.scaladoc.skip>

--- a/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
+++ b/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
@@ -30,7 +30,7 @@ class IcebergProviderImpl extends IcebergProvider {
     Seq(new ScanRule[Scan](
       (a, conf, p, r) => new ScanMeta[Scan](a, conf, p, r) {
         private lazy val convertedScan: Try[GpuSparkBatchQueryScan] = GpuSparkBatchQueryScan
-          .tryConvert(a, conf)
+          .tryConvert(a, this.conf)
 
         override def supportsRuntimeFilters: Boolean = true
 

--- a/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
+++ b/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
@@ -172,6 +172,7 @@ trait GpuIcebergParquetReader extends Iterator[ColumnarBatch] with AutoCloseable
             bloomFilter.shouldRead(typeWithIds, rowGroup, reader.getBloomFilterDataReader(rowGroup))
       }
     }.getOrElse(blocks)
+      .toSeq
   }
 
   def clipBlocksToSchema(fileReadSchema: ShadedMessageType,

--- a/iceberg/src/main/scala/org/apache/iceberg/spark/source/GpuSparkPartitioningAwareScan.scala
+++ b/iceberg/src/main/scala/org/apache/iceberg/spark/source/GpuSparkPartitioningAwareScan.scala
@@ -36,5 +36,5 @@ abstract class GpuSparkPartitioningAwareScan[T <: PartitionScanTask](
 
   override def groupingKeyType(): Types.StructType = cpuScan.groupingKeyType()
 
-  override def taskGroups(): Seq[_ <: ScanTaskGroup[_]] = cpuScan.taskGroups().asScala
+  override def taskGroups(): Seq[_ <: ScanTaskGroup[_]] = cpuScan.taskGroups().asScala.toSeq
 }

--- a/scala2.13/iceberg/pom.xml
+++ b/scala2.13/iceberg/pom.xml
@@ -32,6 +32,7 @@
     <version>25.06.0-SNAPSHOT</version>
 
     <properties>
+        <rapids.module>iceberg</rapids.module>
         <rapids.compressed.artifact>false</rapids.compressed.artifact>
         <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
         <maven.scaladoc.skip>true</maven.scaladoc.skip>


### PR DESCRIPTION
Fix #12770 

Due to the lack of `rapids.module` property, iceberg was not included in scala 2.13 build. 
