### PR TITLE
Ignore `dyn.shim.excluded.releases` when shimplifying 

### DIFF
--- a/build/dyn_shim_detection.py
+++ b/build/dyn_shim_detection.py
@@ -31,5 +31,8 @@ buildvers = project.getProperty("dyn.shim.buildver")
 
 sys.path.append("{}/build/".format(spark_rapids_source_basedir))
 from get_buildvers import _get_buildvers
+# Because we need all versions to generate new shims correctly, we get all the supported plugin 
+# versions, including the ones that have been asked to be ignored by the setting 
+# `dyn.shim.excluded.releases` in the POM.xml
 value = _get_buildvers(buildvers, "{}/pom.xml".format(multi_module_project_dir), _log, ignore_excluded_shims=True)
 project.setProperty("included_buildvers", value)

--- a/build/dyn_shim_detection.py
+++ b/build/dyn_shim_detection.py
@@ -31,5 +31,5 @@ buildvers = project.getProperty("dyn.shim.buildver")
 
 sys.path.append("{}/build/".format(spark_rapids_source_basedir))
 from get_buildvers import _get_buildvers
-value = _get_buildvers(buildvers, "{}/pom.xml".format(multi_module_project_dir), _log, isShimplify=True)
+value = _get_buildvers(buildvers, "{}/pom.xml".format(multi_module_project_dir), _log, ignore_excluded_shims=True)
 project.setProperty("included_buildvers", value)

--- a/build/dyn_shim_detection.py
+++ b/build/dyn_shim_detection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,5 +31,5 @@ buildvers = project.getProperty("dyn.shim.buildver")
 
 sys.path.append("{}/build/".format(spark_rapids_source_basedir))
 from get_buildvers import _get_buildvers
-value = _get_buildvers(buildvers, "{}/pom.xml".format(multi_module_project_dir), _log)
+value = _get_buildvers(buildvers, "{}/pom.xml".format(multi_module_project_dir), _log, isShimplify=True)
 project.setProperty("included_buildvers", value)

--- a/build/get_buildvers.py
+++ b/build/get_buildvers.py
@@ -16,7 +16,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 
-def _get_buildvers(buildvers, pom_file, logger=None):
+def _get_buildvers(buildvers, pom_file, logger=None, isShimplify=False):
     pom = ET.parse(pom_file)
     ns = {"pom": "http://maven.apache.org/POM/4.0.0"}
     releases = []
@@ -33,17 +33,18 @@ def _get_buildvers(buildvers, pom_file, logger=None):
             snapshots.append(release)
         else:
             no_snapshots.append(release)
-    excluded_shims = pom.find(".//pom:dyn.shim.excluded.releases", ns)
-    if excluded_shims is not None and excluded_shims.text:
-        for removed_shim in [x.strip() for x in excluded_shims.text.split(",")]:
-            if removed_shim in snapshots:
-                snapshots.remove(removed_shim)
-            elif removed_shim in no_snapshots:
-                no_snapshots.remove(removed_shim)
-            else:
-                raise Exception(
-                    "Shim {} listed in dyn.shim.excluded.releases in pom.xml not present in releases".format(
-                        removed_shim))
+    if (not isShimplify):
+        excluded_shims = pom.find(".//pom:dyn.shim.excluded.releases", ns)
+        if excluded_shims is not None and excluded_shims.text:
+            for removed_shim in [x.strip() for x in excluded_shims.text.split(",")]:
+                if removed_shim in snapshots:
+                    snapshots.remove(removed_shim)
+                elif removed_shim in no_snapshots:
+                    no_snapshots.remove(removed_shim)
+                else:
+                    raise Exception(
+                        "Shim {} listed in dyn.shim.excluded.releases in pom.xml not present in releases".format(
+                            removed_shim))
 
     if "scala2.13" in pom_file:
         no_snapshots = list(filter(lambda x: not x.endswith("cdh"), no_snapshots))
@@ -67,7 +68,7 @@ def _get_buildvers(buildvers, pom_file, logger=None):
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
-        print("usage: get_buildvers.py <pom_file> <buildvers>")
+        print("usage: get_buildvers.py <buildvers> <pom_file>")
         print("  supported buildvers: databricks, no_snapshots, ...")
     else:
         print(_get_buildvers(sys.argv[1], sys.argv[2]))

--- a/build/get_buildvers.py
+++ b/build/get_buildvers.py
@@ -15,8 +15,19 @@
 import sys
 import xml.etree.ElementTree as ET
 
-
+# This method is used by shimplify.py and various build scripts. The build scripts use the 
+# default values for the `logger` and `ignore_excluded_shims`
 def _get_buildvers(buildvers, pom_file, logger=None, ignore_excluded_shims=False):
+    """Returns the spark versions supported for the specified arguments
+
+    Positional Arguments:
+    buildvers -- no_snap_with_databricks, snap_and_no_snap_with_databricks, no_snapshots, snap_and_no_snap, databricks
+    pom_file -- The POM file to use to get the release profiles
+
+    Keyword arguments:
+    logger -- logger to use for logging
+    ignore_excluded_shims -- Whether to honor the dyn.shim.excluded.releases defined in the pom
+    """
     pom = ET.parse(pom_file)
     ns = {"pom": "http://maven.apache.org/POM/4.0.0"}
     releases = []

--- a/build/get_buildvers.py
+++ b/build/get_buildvers.py
@@ -16,7 +16,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 
-def _get_buildvers(buildvers, pom_file, logger=None, isShimplify=False):
+def _get_buildvers(buildvers, pom_file, logger=None, ignore_excluded_shims=False):
     pom = ET.parse(pom_file)
     ns = {"pom": "http://maven.apache.org/POM/4.0.0"}
     releases = []
@@ -33,7 +33,7 @@ def _get_buildvers(buildvers, pom_file, logger=None, isShimplify=False):
             snapshots.append(release)
         else:
             no_snapshots.append(release)
-    if (not isShimplify):
+    if (not ignore_excluded_shims):
         excluded_shims = pom.find(".//pom:dyn.shim.excluded.releases", ns)
         if excluded_shims is not None and excluded_shims.text:
             for removed_shim in [x.strip() for x in excluded_shims.text.split(",")]:


### PR DESCRIPTION
This PR ignores the `dyn.shim.excluded.releases` when generating shims otherwise, shims don't get generated for files whose root directory is in the shim that is excluded

fixes #12806 