### PR TITLE
Spark-4.0: Skip scala tests when ansi mode is enabled

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/BroadcastNestedLoopJoinSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/BroadcastNestedLoopJoinSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.shims.OperatorsUtilShims
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.functions.broadcast
@@ -35,7 +37,7 @@ class BroadcastNestedLoopJoinSuite extends SparkQueryCompareTestSuite {
       val plan = df3.queryExecution.executedPlan
 
       val nljCount =
-        PlanUtils.findOperators(plan, _.isInstanceOf[GpuBroadcastNestedLoopJoinExec])
+        OperatorsUtilShims.findOperators(plan, _.isInstanceOf[GpuBroadcastNestedLoopJoinExec])
       assert(nljCount.size === 1)
     }, conf)
   }
@@ -56,7 +58,7 @@ class BroadcastNestedLoopJoinSuite extends SparkQueryCompareTestSuite {
       val plan = df3.queryExecution.executedPlan
 
       val nljCount =
-        PlanUtils.findOperators(plan, _.isInstanceOf[GpuBroadcastNestedLoopJoinExec])
+        OperatorsUtilShims.findOperators(plan, _.isInstanceOf[GpuBroadcastNestedLoopJoinExec])
 
       assert(nljCount.size === 1)
     }, conf)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,8 @@ class CsvScanSuite extends SparkQueryCompareTestSuite {
       "Test CSV count chunked by rows",
       intsFromCsv,
       conf = new SparkConf()
-          .set(RapidsConf.MAX_READER_BATCH_SIZE_ROWS.key, "1")) {
+          .set(RapidsConf.MAX_READER_BATCH_SIZE_ROWS.key, "1"),
+      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
     frameCount
   }
 
@@ -46,7 +47,8 @@ class CsvScanSuite extends SparkQueryCompareTestSuite {
       "Test CSV count chunked by bytes",
       intsFromCsv,
       conf = new SparkConf()
-          .set(RapidsConf.MAX_READER_BATCH_SIZE_BYTES.key, "0")) {
+          .set(RapidsConf.MAX_READER_BATCH_SIZE_BYTES.key, "0"),
+      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
     frameCount
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -106,11 +106,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
     incompat: Boolean = false,
     execsAllowedNonGpu: Seq[String] = Seq.empty,
     sortBeforeRepart: Boolean = false,
-<<<<<<< HEAD
-    assumeCondition: SparkSession => (Boolean, String) = null)
-=======
     assumeCondition: SparkSession => (Boolean, String))
->>>>>>> 703cd8512... hash aggregate fixes
     (fun: DataFrame => DataFrame)
     (validateCapturedPlans: (SparkPlan, SparkPlan) => Unit): Unit = {
     configMatrix.zipWithIndex.foreach { case (config, i) =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -567,7 +567,8 @@ trait SparkQueryCompareTestSuite extends AnyFunSuite with BeforeAndAfterAll {
       conf: SparkConf = new SparkConf(),
       sort: Boolean = false,
       repart: Integer = 1,
-      sortBeforeRepart: Boolean = false)
+      sortBeforeRepart: Boolean = false,
+      assumeCondition: SparkSession => (Boolean, String) = null)
     (fun: DataFrame => DataFrame): Unit = {
     testSparkResultsAreEqual(testName, df,
       conf=conf,
@@ -575,7 +576,8 @@ trait SparkQueryCompareTestSuite extends AnyFunSuite with BeforeAndAfterAll {
       sort=sort,
       maxFloatDiff=maxFloatDiff,
       incompat=true,
-      sortBeforeRepart = sortBeforeRepart)(fun)
+      sortBeforeRepart = sortBeforeRepart,
+      assumeCondition = assumeCondition)(fun)
   }
 
   def ALLOW_NON_GPU_testSparkResultsAreEqual(
@@ -627,7 +629,8 @@ trait SparkQueryCompareTestSuite extends AnyFunSuite with BeforeAndAfterAll {
       execsAllowedNonGpu: Seq[String],
       repart: Integer = 1,
       conf: SparkConf = new SparkConf(),
-      sortBeforeRepart: Boolean = false)
+      sortBeforeRepart: Boolean = false,
+      assumeCondition: SparkSession => (Boolean, String) = null)
       (fun: DataFrame => DataFrame)
       (validateCapturedPlans: (SparkPlan, SparkPlan) => Unit): Unit = {
     testSparkResultsAreEqualWithCapture(testName, df,
@@ -635,7 +638,8 @@ trait SparkQueryCompareTestSuite extends AnyFunSuite with BeforeAndAfterAll {
       execsAllowedNonGpu=execsAllowedNonGpu,
       repart=repart,
       sort=true,
-      sortBeforeRepart = sortBeforeRepart)(fun)(validateCapturedPlans)
+      sortBeforeRepart = sortBeforeRepart,
+      assumeCondition = assumeCondition)(fun)(validateCapturedPlans)
   }
 
   def IGNORE_ORDER_testSparkResultsAreEqual(
@@ -661,14 +665,16 @@ trait SparkQueryCompareTestSuite extends AnyFunSuite with BeforeAndAfterAll {
       df: SparkSession => DataFrame,
       repart: Integer = 1,
       conf: SparkConf = new SparkConf(),
-      sortBeforeRepart: Boolean = false)
+      sortBeforeRepart: Boolean = false,
+      assumeCondition: SparkSession => (Boolean, String) = null)
       (fun: DataFrame => DataFrame)
       (validateCapturedPlans: (SparkPlan, SparkPlan) => Unit): Unit = {
     testSparkResultsAreEqualWithCapture(testName, df,
       conf=conf,
       repart=repart,
       sort=true,
-      sortBeforeRepart = sortBeforeRepart)(fun)(validateCapturedPlans)
+      sortBeforeRepart = sortBeforeRepart,
+      assumeCondition = assumeCondition)(fun)(validateCapturedPlans)
   }
 
   def INCOMPAT_IGNORE_ORDER_testSparkResultsAreEqual(
@@ -676,13 +682,15 @@ trait SparkQueryCompareTestSuite extends AnyFunSuite with BeforeAndAfterAll {
       df: SparkSession => DataFrame,
       repart: Integer = 1,
       conf: SparkConf = new SparkConf(),
-      sortBeforeRepart: Boolean = false)(fun: DataFrame => DataFrame): Unit = {
+      sortBeforeRepart: Boolean = false,
+      assumeCondition: SparkSession => (Boolean, String) = null)(fun: DataFrame => DataFrame): Unit = {
     testSparkResultsAreEqual(testName, df,
       conf=conf,
       repart=repart,
       incompat=true,
       sort=true,
-      sortBeforeRepart = sortBeforeRepart)(fun)
+      sortBeforeRepart = sortBeforeRepart,
+      assumeCondition = assumeCondition)(fun)
   }
 
   /**


### PR DESCRIPTION
This PR is the last one to resolve unit test failures on Spark-4.0.
In this PR, we skip the tests when ansi mode is enabled. We need to fix the underlying issue to enable those.

We missed this in the earlier iteration. After we merge this, we can enabled Spark-4.0 unit tests in nightly CI/CD jobs.
This fixes https://github.com/NVIDIA/spark-rapids/issues/11235

Verified by running the complete test suite:

```
mvn package -f scala2.13/pom.xml -pl tests -am -Dbuildver=400

```
