### PR TITLE
fix shebang in prioritize-commits.sh

### DIFF
--- a/scripts/prioritize-commits.sh
+++ b/scripts/prioritize-commits.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The shebang in this script was not previously working when I tried running it, because it was not placed on the top line. This led to lots of downstream syntax errors from sh.

This is a util script for analyzing spark commits for audit.