### PR TITLE
Drop the new time based metric in commitInfo while comparing Delta Logs [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -66,7 +66,7 @@ def _fixup_operation_metrics(opm):
     # between CPU and GPU.
     metrics_to_remove = ["executionTimeMs", "numOutputBytes", "rewriteTimeMs", "scanTimeMs",
                          "numRemovedBytes", "numAddedBytes", "numTargetBytesAdded", "numTargetBytesInserted",
-                         "numTargetBytesUpdated", "numTargetBytesRemoved"]
+                         "numTargetBytesUpdated", "numTargetBytesRemoved", "materializeSourceTimeMs"]
     for k in metrics_to_remove:
         opm.pop(k, None)
 


### PR DESCRIPTION
Delta 3.3.0 has introduced a new metric `materializeSourceTimeMs` as part of the commitInfo. This should be dropped from comparison, similar to the other time based values like `executionTimeMs` and `scanTimeMs`

fixes #12772  