### PR TITLE
Fix a potential issue that could cause a NPE when dumping kudo tables

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -84,7 +84,7 @@ case class GpuShuffleCoalesceExec(child: SparkPlan, targetBatchByteSize: Long)
   }
 }
 
-/** A case class to pack some options. Now it has only one, but may have more in the future */
+/** A case class to pack some options. */
 case class CoalesceReadOption private(
   kudoEnabled: Boolean, 
   kudoDebugMode: DumpOption, 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -89,7 +89,6 @@ case class CoalesceReadOption private(
   kudoEnabled: Boolean, kudoDebugMode: DumpOption, kudoDebugDumpPrefix: Option[String])
 
 object CoalesceReadOption {
-  
   def apply(conf: SQLConf): CoalesceReadOption = {
     val dumpOption = RapidsConf.SHUFFLE_KUDO_SERIALIZER_DEBUG_MODE.get(conf) match {
       case "NEVER" => DumpOption.Never

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -89,7 +89,6 @@ case class CoalesceReadOption private(
   kudoEnabled: Boolean, 
   kudoDebugMode: DumpOption, 
   kudoDebugDumpPrefix: Option[String],
-  // Only captured when debug mode is enabled
   debugStageId: Option[Int],
   debugTaskId: Option[Long])
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -394,7 +394,10 @@ class KudoHostShuffleCoalesceIterator(
   // Capture TaskContext info during RDD execution when it's available
   private val (stageId, taskId) = Option(TaskContext.get()) match {
     case Some(tc) => (tc.stageId(), tc.taskAttemptId())
-    case None => (0, 0L) // Fallback for tests or when TaskContext unavailable
+    case None => 
+      // Generate UUID-based values for unique naming when TaskContext unavailable
+      val uuid = java.util.UUID.randomUUID()
+      (uuid.hashCode(), uuid.getLeastSignificantBits())
   }
   
   override protected def tableOperator = {


### PR DESCRIPTION
When enabling kudo debug mode https://github.com/NVIDIA/spark-rapids/pull/12325, there is a potential bug that we should not assume that the kudo `mergeOnHost()` method is always executed in the main task thread. Otherwise, `TaskContext.get()` will return null. So when we test async shuffle, this bug occurs and an NPE is reported.

This pr moves the `TaskContext.get()` out of `KudoTableOperator` and lets it happen when we build `CoalesceReadOption`, which will be on the main thread.

