### PR TITLE
Fix double column mapping in delta 3.3 parquet reader

### DIFF
--- a/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
+++ b/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
@@ -36,6 +36,11 @@ trait GpuDeltaParquetFileFormat extends GpuReadParquetFileFormat {
   val columnMappingMode: DeltaColumnMappingMode
   val referenceSchema: StructType
 
+  /**
+   * prepareSchema must only be used for parquet read.
+   * It removes "PARQUET_FIELD_ID_METADATA_KEY" for name mapping mode which address columns by
+   * physical name instead of id.
+   */
   def prepareSchema(inputSchema: StructType): StructType = {
     val schema = DeltaColumnMapping.createPhysicalSchema(
       inputSchema, referenceSchema, columnMappingMode)

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
@@ -72,11 +72,10 @@ case class GpuDelta33xParquetFileFormat(
   }
 
   /**
-   * prepareSchemaForRead must only be used for parquet read.
-   * It removes "PARQUET_FIELD_ID_METADATA_KEY" for name mapping mode which address columns by
-   * physical name instead of id.
+   * This function is overridden as Delta 3.3 has an extra `PARQUET_FIELD_NESTED_IDS_METADATA_KEY`
+   * key to remove from the metadata, which does not exist in earlier versions.
    */
-  def prepareSchemaForRead(inputSchema: StructType): StructType = {
+  override def prepareSchema(inputSchema: StructType): StructType = {
     val schema = DeltaColumnMapping.createPhysicalSchema(
       inputSchema, referenceSchema, columnMappingMode)
     if (columnMappingMode == NameMapping) {
@@ -150,9 +149,9 @@ case class GpuDelta33xParquetFileFormat(
 
     val dataReader = super.buildReaderWithPartitionValuesAndMetrics(
       sparkSession,
-      prepareSchemaForRead(dataSchema),
-      prepareSchemaForRead(partitionSchema),
-      prepareSchemaForRead(requiredSchema),
+      dataSchema,
+      partitionSchema,
+      requiredSchema,
       prepareFiltersForRead(filters),
       options,
       hadoopConf,


### PR DESCRIPTION
Fixes #12855.

The delta 3.3 parquet reader has extra calls to `DeltaColumnMapping.createPhysicalSchema()` (in `GpuDelta33xParquetFileFormat.prepareSchemaForRead()`), which performs the column name mapping. All column mapping should be done only in `GpuDeltaParquetFileFormat.prepareSchema()` instead. The `prepareSchemaForRead()` is adopted from the Delta codebase, which are a bit different between 2.4 and 3.3. As such, `GpuDelta33xParquetFileFormat.prepareSchema()` overrides `GpuDeltaParquetFileFormat.prepareSchema()` to handle the difference. We may remove the default implementation in `GpuDeltaParquetFileFormat.prepareSchema()` in the future if this function changes drastically between versions.

This change is covered by the existing `delta_lake_test.py::test_delta_read_column_mapping` test.