### PR TITLE
Support spark400 shim's integration tests

### DIFF
--- a/jenkins/hadoop-def.sh
+++ b/jenkins/hadoop-def.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Spark-4.x only has the scala2.13 binary with the classifier "bin-hadoop3"


