### PR TITLE
XFAIL'd Delta Lake 3.3.0 merge tests 

### DIFF
--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/MergeIntoCommandMeta.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/MergeIntoCommandMeta.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta33x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.delta.commands.MergeIntoCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class MergeIntoCommandMeta(
+    mergeCmd: MergeIntoCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends RunnableCommandMeta[MergeIntoCommand](mergeCmd, conf, parent, rule) with Logging {
+
+  override def tagSelfForGpu(): Unit = {
+    willNotWorkOnGpu("MergeIntoCommand is not supported for Delta Lake 3.3.0")
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    throw new UnsupportedOperationException("MergeIntoCommand not implemented")
+  }
+
+}

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -221,9 +221,12 @@ def pytest_runtest_setup(item):
     global _non_gpu_allowed
     global _per_test_ansi_mode_enabled
     _non_gpu_allowed_databricks = []
+    _non_gpu_allowed_conditional = []
     _allow_any_non_gpu_databricks = False
+    _allow_any_non_gpu_conditional = False
     non_gpu_databricks = item.get_closest_marker('allow_non_gpu_databricks')
     non_gpu = item.get_closest_marker('allow_non_gpu')
+    non_gpu_conditional = item.get_closest_marker('allow_non_gpu_conditional')
     _per_test_ansi_mode_enabled = None if item.get_closest_marker('disable_ansi_mode') is None \
       else not item.get_closest_marker('disable_ansi_mode')
 
@@ -250,11 +253,30 @@ def pytest_runtest_setup(item):
         _allow_any_non_gpu = False
         _non_gpu_allowed = []
 
-    _allow_any_non_gpu = _allow_any_non_gpu | _allow_any_non_gpu_databricks
+    if non_gpu_conditional:
+        condition = non_gpu_conditional.args[0]
+        _non_gpu_allowed_conditional = non_gpu_conditional.args[1]
+        if not isinstance(condition, bool):
+            raise ValueError("The first parameter of 'allow_non_gpu_conditional' must be a Boolean.")
+        if condition:
+            if non_gpu_conditional.kwargs and non_gpu_conditional.kwargs['any']:
+                _allow_any_non_gpu_conditional = True
+                _non_gpu_allowed_conditional = []
+            elif _non_gpu_allowed_conditional:
+                _allow_any_non_gpu_conditional = False
+            else:
+                warnings.warn('allow_non_gpu_conditional marker without anything allowed')
+                _allow_any_non_gpu_conditional = False
+                _non_gpu_allowed_conditional = []
+
+
+    _allow_any_non_gpu = _allow_any_non_gpu | _allow_any_non_gpu_databricks | _allow_any_non_gpu_conditional
     if _non_gpu_allowed and _non_gpu_allowed_databricks:
         _non_gpu_allowed = _non_gpu_allowed + _non_gpu_allowed_databricks
     elif _non_gpu_allowed_databricks:
         _non_gpu_allowed = _non_gpu_allowed_databricks
+    if _non_gpu_allowed_conditional:
+        _non_gpu_allowed = _non_gpu_allowed + tuple(_non_gpu_allowed_conditional.split(","))
 
     global _validate_execs_in_gpu_plan
     validate_execs = item.get_closest_marker('validate_execs_in_gpu_plan')

--- a/integration_tests/src/main/python/delta_lake_merge_common.py
+++ b/integration_tests/src/main/python/delta_lake_merge_common.py
@@ -54,9 +54,12 @@ def assert_collect(do_merge, read_delta_path, data_path, conf):
     gpu_result = with_gpu_session(lambda spark: do_merge(spark, gpu_path), conf=conf)
     assert_equal(cpu_result, gpu_result)
 
+# This method is used for making sure ExecutedCommand fallsback for Spark 3.5.3
+# It's defined as a global function because it's used by multiple tests.
 def assert_fallback(fallback_class):
     def do_assert(do_merge, read_delta_path, data_path, conf):
         assert_gpu_fallback_write(do_merge, read_delta_path, data_path, fallback_class, conf = conf)
+        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
     return do_assert
 
 def assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,

--- a/integration_tests/src/main/python/delta_lake_merge_common.py
+++ b/integration_tests/src/main/python/delta_lake_merge_common.py
@@ -47,10 +47,21 @@ def delta_sql_merge_test(spark_tmp_path, spark_tmp_table_factory, use_cdf, enabl
     with_cpu_session(setup_tables)
     check_func(data_path, do_merge)
 
+def assert_collect(do_merge, read_delta_path, data_path, conf):
+    cpu_path = data_path + "/CPU"
+    gpu_path = data_path + "/GPU"
+    cpu_result = with_cpu_session(lambda spark: do_merge(spark, cpu_path), conf=conf)
+    gpu_result = with_gpu_session(lambda spark: do_merge(spark, gpu_path), conf=conf)
+    assert_equal(cpu_result, gpu_result)
+
+def assert_fallback(fallback_class):
+    def do_assert(do_merge, read_delta_path, data_path, conf):
+        assert_gpu_fallback_write(do_merge, read_delta_path, data_path, fallback_class, conf = conf)
+    return do_assert
 
 def assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
                                    src_table_func, dest_table_func, merge_sql,
-                                   compare_logs, partition_columns=None, conf=None):
+                                   compare_logs, assert_func=assert_collect, partition_columns=None, conf=None):
     assert conf is not None, "conf must be set"
         
     def read_data(spark, path):
@@ -62,9 +73,7 @@ def assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_
         cpu_path = data_path + "/CPU"
         gpu_path = data_path + "/GPU"
         # compare resulting dataframe from the merge operation (some older Spark versions return empty here)
-        cpu_result = with_cpu_session(lambda spark: do_merge(spark, cpu_path), conf=conf)
-        gpu_result = with_gpu_session(lambda spark: do_merge(spark, gpu_path), conf=conf)
-        assert_equal(cpu_result, gpu_result)
+        assert_func(do_merge, read_delta_path, data_path, conf)
         # compare merged table data results, read both via CPU to make sure GPU write can be read by CPU
         cpu_result = with_cpu_session(lambda spark: read_data(spark, cpu_path).collect(), conf=conf)
         gpu_result = with_cpu_session(lambda spark: read_data(spark, gpu_path).collect(), conf=conf)
@@ -79,67 +88,67 @@ def assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_
 
 def do_test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_factory, table_ranges,
                                               use_cdf, enable_deletion_vectors, partition_columns, num_slices, compare_logs,
-                                              conf):
+                                              conf, assert_func):
     src_range, dest_range = table_ranges
     src_table_func = lambda spark: make_df(spark, SetValuesGen(IntegerType(), src_range), num_slices)
     dest_table_func = lambda spark: make_df(spark, SetValuesGen(IntegerType(), dest_range), num_slices)
     merge_sql = "MERGE INTO {dest_table} USING {src_table} ON {dest_table}.a == {src_table}.a" \
                 " WHEN NOT MATCHED THEN INSERT *"
     assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                   src_table_func, dest_table_func, merge_sql, compare_logs,
+                                   src_table_func, dest_table_func, merge_sql, compare_logs, assert_func,
                                    partition_columns, conf=conf)
 
 
 def do_test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, table_ranges,
                                           use_cdf, enable_deletion_vectors, partition_columns, num_slices, compare_logs,
-                                          conf):
+                                          conf, assert_func):
     src_range, dest_range = table_ranges
     src_table_func = lambda spark: make_df(spark, SetValuesGen(IntegerType(), src_range), num_slices)
     dest_table_func = lambda spark: make_df(spark, SetValuesGen(IntegerType(), dest_range), num_slices)
     merge_sql = "MERGE INTO {dest_table} USING {src_table} ON {dest_table}.a == {src_table}.a" \
                 " WHEN MATCHED THEN DELETE"
     assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                   src_table_func, dest_table_func, merge_sql, compare_logs,
+                                   src_table_func, dest_table_func, merge_sql, compare_logs, assert_func,
                                    partition_columns, conf=conf)
 
 
 def do_test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                        num_slices, compare_logs, conf):
+                                        num_slices, compare_logs, conf, assert_func):
     # Need to eliminate duplicate keys in the source table otherwise update semantics are ambiguous
     src_table_func = lambda spark: two_col_df(spark, int_gen, string_gen, num_slices=num_slices).groupBy("a").agg(f.max("b").alias("b"))
     dest_table_func = lambda spark: two_col_df(spark, int_gen, string_gen, seed=1, num_slices=num_slices)
     merge_sql = "MERGE INTO {dest_table} USING {src_table} ON {dest_table}.a == {src_table}.a" \
                 " WHEN MATCHED THEN UPDATE SET * WHEN NOT MATCHED THEN INSERT *"
     assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                   src_table_func, dest_table_func, merge_sql, compare_logs,
+                                   src_table_func, dest_table_func, merge_sql, compare_logs, assert_func,
                                    conf=conf)
 
 
 def do_test_delta_merge_upsert_with_condition(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                              merge_sql, num_slices, compare_logs, conf):
+                                              merge_sql, num_slices, compare_logs, conf, assert_func):
     # Need to eliminate duplicate keys in the source table otherwise update semantics are ambiguous
     src_table_func = lambda spark: two_col_df(spark, int_gen, string_gen, num_slices=num_slices).groupBy("a").agg(f.max("b").alias("b"))
     dest_table_func = lambda spark: two_col_df(spark, int_gen, string_gen, seed=1, num_slices=num_slices)
     assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                   src_table_func, dest_table_func, merge_sql, compare_logs, 
+                                   src_table_func, dest_table_func, merge_sql, compare_logs, assert_func,
                                    conf=conf)
 
 
 def do_test_delta_merge_upsert_with_unmatchable_match_condition(spark_tmp_path,
                                                                 spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                                                num_slices, compare_logs, conf):
+                                                                num_slices, compare_logs, conf, assert_func):
     # Need to eliminate duplicate keys in the source table otherwise update semantics are ambiguous
     src_table_func = lambda spark: two_col_df(spark, int_gen, string_gen, num_slices=num_slices).groupBy("a").agg(f.max("b").alias("b"))
     dest_table_func = lambda spark: two_col_df(spark, SetValuesGen(IntegerType(), range(100)), string_gen, seed=1, num_slices=num_slices)
     merge_sql = "MERGE INTO {dest_table} USING {src_table} ON {dest_table}.a == {src_table}.a" \
                 " WHEN MATCHED AND {dest_table}.a > 100 THEN UPDATE SET *"
     assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                   src_table_func, dest_table_func, merge_sql, compare_logs,
+                                   src_table_func, dest_table_func, merge_sql, compare_logs, assert_func,
                                    conf=conf)
 
 
 def do_test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
-                                                conf):
+                                                conf, assert_func):
     # Need to eliminate duplicate keys in the source table otherwise update semantics are ambiguous
     src_table_func = lambda spark: spark.range(10).withColumn("x", f.col("id") + 1) \
         .select(f.col("id"), (f.col("x") + 1).alias("x")) \
@@ -152,4 +161,4 @@ def do_test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_
 
     assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
                                    src_table_func, dest_table_func, merge_sql,
-                                   compare_logs=False, conf=conf)
+                                   compare_logs=False, assert_func=assert_func, conf=conf)

--- a/integration_tests/src/main/python/delta_lake_merge_test.py
+++ b/integration_tests/src/main/python/delta_lake_merge_test.py
@@ -18,7 +18,7 @@ import pytest
 from delta_lake_merge_common import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import is_before_spark_320, is_databricks_runtime, spark_version, supports_delta_lake_deletion_vectors
+from spark_session import is_before_spark_320, is_databricks_runtime, spark_version, supports_delta_lake_deletion_vectors, is_spark_353_or_later
 
 
 delta_merge_enabled_conf = copy_and_update(delta_writes_enabled_conf,
@@ -97,6 +97,7 @@ def test_delta_merge_not_matched_by_source_fallback(spark_tmp_path, spark_tmp_ta
                          merge_sql=merge_sql,
                          check_func=checker)
 
+@allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -123,8 +124,9 @@ def test_delta_merge_partial_fallback_via_conf(spark_tmp_path, spark_tmp_table_f
     conf = copy_and_update(delta_merge_enabled_conf, { disable_conf: "false" })
     assert_delta_sql_merge_collect(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vectors,
                                    src_table_func, dest_table_func, merge_sql, compare_logs,
-                                   partition_columns, conf)
+                                   partition_columns=partition_columns, conf=conf)
 
+@allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -140,10 +142,14 @@ def test_delta_merge_partial_fallback_via_conf(spark_tmp_path, spark_tmp_table_f
                             enabled_xfail_reason='https://github.com/NVIDIA/spark-rapids/issues/12042'), ids=idfn)
 def test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_factory, table_ranges,
                                            use_cdf, partition_columns, num_slices, enable_deletion_vector):
+    assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_factory,
                                               table_ranges, use_cdf, enable_deletion_vector, partition_columns,
-                                              num_slices, num_slices == 1, delta_merge_enabled_conf)
+                                              num_slices, num_slices == 1, delta_merge_enabled_conf, assert_func)
+    if is_spark_353_or_later():
+        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
+@allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -159,9 +165,15 @@ def test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_facto
                             enabled_xfail_reason='https://github.com/NVIDIA/spark-rapids/issues/12042'), ids=idfn)
 def test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, table_ranges,
                                        use_cdf, partition_columns, num_slices, enable_deletion_vector):
+    assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, table_ranges,
-                                          use_cdf, enable_deletion_vector, partition_columns, num_slices, num_slices == 1, delta_merge_enabled_conf)
+                                          use_cdf, enable_deletion_vector, partition_columns, num_slices,
+                                          num_slices == 1, delta_merge_enabled_conf, assert_func)
+    if is_spark_353_or_later():
+        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
+
+@allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -171,10 +183,14 @@ def test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, 
 @pytest.mark.parametrize("enable_deletion_vector", deletion_vector_values_with_350DB143_xfail_reasons(
                             enabled_xfail_reason='https://github.com/NVIDIA/spark-rapids/issues/12042'), ids=idfn)
 def test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, use_cdf, num_slices, enable_deletion_vector):
+    assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector,
-                                        num_slices, num_slices == 1, delta_merge_enabled_conf)
+                                        num_slices, num_slices == 1, delta_merge_enabled_conf, assert_func)
+    if is_spark_353_or_later():
+        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 
+@allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -196,10 +212,14 @@ def test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, us
                             enabled_xfail_reason='https://github.com/NVIDIA/spark-rapids/issues/12042'), ids=idfn)
 def test_delta_merge_upsert_with_condition(spark_tmp_path, spark_tmp_table_factory, use_cdf, merge_sql, num_slices,
                                            enable_deletion_vector):
+    assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_upsert_with_condition(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector,
-                                              merge_sql, num_slices, num_slices == 1, delta_merge_enabled_conf)
+                                              merge_sql, num_slices, num_slices == 1, delta_merge_enabled_conf, assert_func)
+    if is_spark_353_or_later():
+        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 
+@allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -210,11 +230,15 @@ def test_delta_merge_upsert_with_condition(spark_tmp_path, spark_tmp_table_facto
                             enabled_xfail_reason='https://github.com/NVIDIA/spark-rapids/issues/12042'), ids=idfn)
 def test_delta_merge_upsert_with_unmatchable_match_condition(spark_tmp_path, spark_tmp_table_factory, use_cdf,
                                                              num_slices, enable_deletion_vector):
+    assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_upsert_with_unmatchable_match_condition(spark_tmp_path,
                                                                 spark_tmp_table_factory, use_cdf, enable_deletion_vector,
                                                                 num_slices, num_slices == 1,
-                                                                delta_merge_enabled_conf)
+                                                                delta_merge_enabled_conf, assert_func)
+    if is_spark_353_or_later():
+        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
+@allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
@@ -223,7 +247,11 @@ def test_delta_merge_upsert_with_unmatchable_match_condition(spark_tmp_path, spa
 @pytest.mark.parametrize("enable_deletion_vector", deletion_vector_values_with_350DB143_xfail_reasons(
                             enabled_xfail_reason='https://github.com/NVIDIA/spark-rapids/issues/12042'), ids=idfn)
 def test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector):
-    do_test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector, delta_merge_enabled_conf)
+    assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
+    do_test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector,
+                                                delta_merge_enabled_conf, assert_func)
+    if is_spark_353_or_later():
+        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake

--- a/integration_tests/src/main/python/delta_lake_merge_test.py
+++ b/integration_tests/src/main/python/delta_lake_merge_test.py
@@ -146,8 +146,6 @@ def test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_facto
     do_test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_factory,
                                               table_ranges, use_cdf, enable_deletion_vector, partition_columns,
                                               num_slices, num_slices == 1, delta_merge_enabled_conf, assert_func)
-    if is_spark_353_or_later():
-        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 @allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
@@ -169,9 +167,6 @@ def test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, 
     do_test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, table_ranges,
                                           use_cdf, enable_deletion_vector, partition_columns, num_slices,
                                           num_slices == 1, delta_merge_enabled_conf, assert_func)
-    if is_spark_353_or_later():
-        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
-
 
 @allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
@@ -186,8 +181,6 @@ def test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, us
     assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector,
                                         num_slices, num_slices == 1, delta_merge_enabled_conf, assert_func)
-    if is_spark_353_or_later():
-        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 
 @allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
@@ -215,8 +208,6 @@ def test_delta_merge_upsert_with_condition(spark_tmp_path, spark_tmp_table_facto
     assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_upsert_with_condition(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector,
                                               merge_sql, num_slices, num_slices == 1, delta_merge_enabled_conf, assert_func)
-    if is_spark_353_or_later():
-        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 
 @allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
@@ -235,8 +226,6 @@ def test_delta_merge_upsert_with_unmatchable_match_condition(spark_tmp_path, spa
                                                                 spark_tmp_table_factory, use_cdf, enable_deletion_vector,
                                                                 num_slices, num_slices == 1,
                                                                 delta_merge_enabled_conf, assert_func)
-    if is_spark_353_or_later():
-        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 @allow_non_gpu_conditional(is_spark_353_or_later(), "ExecutedCommandExec")
 @allow_non_gpu(*delta_meta_allow)
@@ -250,8 +239,6 @@ def test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_fac
     assert_func = assert_fallback("ExecutedCommandExec") if is_spark_353_or_later() else assert_collect
     do_test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_factory, use_cdf, enable_deletion_vector,
                                                 delta_merge_enabled_conf, assert_func)
-    if is_spark_353_or_later():
-        pytest.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/12879")
 
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake

--- a/integration_tests/src/main/python/marks.py
+++ b/integration_tests/src/main/python/marks.py
@@ -15,6 +15,7 @@
 import pytest
 
 allow_non_gpu_databricks = pytest.mark.allow_non_gpu_databricks
+allow_non_gpu_conditional = pytest.mark.allow_non_gpu_conditional
 allow_non_gpu = pytest.mark.allow_non_gpu
 disable_ansi_mode = pytest.mark.disable_ansi_mode
 validate_execs_in_gpu_plan = pytest.mark.validate_execs_in_gpu_plan

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -228,6 +228,9 @@ def is_spark_341():
 def is_spark_350_or_later():
     return spark_version() >= "3.5.0"
 
+def is_spark_353_or_later():
+    return spark_version() >= "3.5.3"
+
 def is_spark_351_or_later():
     return spark_version() >= "3.5.1"
 


### PR DESCRIPTION
This PR achieves fallback assertions for merge tests on Delta Lake 3.3.0. 

Key Changes

* Added logic to let MergeIntoCommand fallback. 

* New File: MergeIntoCommandMeta.scala

* Integration Test Improvements to allow for tests to set their assertion method. This allows tests to conditionally let the tests verify fallback instead of just verifying the output.

* Pytest marker was added to be able to add conditionally allowing execs to fallback
