### PR TITLE
Fix Column to Expression conversion for Spark 4.0

### DIFF
--- a/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/nvidia/DFUDFShims.scala
+++ b/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/nvidia/DFUDFShims.scala
@@ -21,15 +21,9 @@ package org.apache.spark.sql.nvidia
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.classic.ColumnNodeToExpressionConverter
-import org.apache.spark.sql.classic.ExpressionUtils.column
+import org.apache.spark.sql.classic.{ColumnNodeToExpressionConverter, ExpressionUtils}
 
 object DFUDFShims {
-  def columnToExpr(c: Column): Expression = {
-    // Use ColumnNodeToExpressionConverter to convert the Column's node to an Expression
-    val expr = ColumnNodeToExpressionConverter(c.node)
-    expr
-  }
-
-  def exprToColumn(e: Expression): Column = column(e)
+  def columnToExpr(c: Column): Expression = ColumnNodeToExpressionConverter(c.node)
+  def exprToColumn(e: Expression): Column = ExpressionUtils.column(e)
 }

--- a/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/nvidia/DFUDFShims.scala
+++ b/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/nvidia/DFUDFShims.scala
@@ -21,9 +21,15 @@ package org.apache.spark.sql.nvidia
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.classic.ExpressionUtils.{column, expression}
+import org.apache.spark.sql.classic.ColumnNodeToExpressionConverter
+import org.apache.spark.sql.classic.ExpressionUtils.column
 
 object DFUDFShims {
-  def columnToExpr(c: Column): Expression = expression(c)
+  def columnToExpr(c: Column): Expression = {
+    // Use ColumnNodeToExpressionConverter to convert the Column's node to an Expression
+    val expr = ColumnNodeToExpressionConverter(c.node)
+    expr
+  }
+
   def exprToColumn(e: Expression): Column = column(e)
 }


### PR DESCRIPTION
This PR fixes https://github.com/NVIDIA/spark-rapids/issues/12884

This PR fixes the Column to Expression conversion to properly handle ColumnNodeExpression in Spark 4.0. The change replaces the old conversion path with Spark 4.0's ColumnNodeToExpressionConverter. 
This commit in Apache Spark simplified  Column handling - https://github.com/apache/spark/pull/49038

Verified by building and running all tests for spark400 shim:
```
URM_URL=<URM_REPO_URL>  mvn package -f scala2.13/pom.xml  -Dbuildver=400   -s jenkins/settings.xml
``` 
