### PR TITLE
change a critical log's log level

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -679,7 +679,7 @@ object RmmRapidsRetryIterator extends Logging {
           clearInjectedOOMIfNeeded()
         } catch {
           case ex: Throwable =>
-            log.debug("got a throwable in RmmRapidsRetryIterator.next():", ex)
+            log.info("got a throwable in RmmRapidsRetryIterator.next():", ex)
             // handle a retry as the top-level exception
             val (topLevelIsRetry, topLevelIsSplit, isGpuOom) = isRetryOrSplitAndRetry(ex)
             if (topLevelIsSplit) {


### PR DESCRIPTION
This line of log is often helpful in trouble shooting. Chaning it to INFO level will save our life without having to run the same query again (to collect logs)