### PR TITLE
Spark-4.0 - Resolve/skip integration test failures

### DIFF
--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -18,7 +18,8 @@ from pyspark.sql.types import *
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_cpu_and_gpu_are_equal_collect_with_capture
 from conftest import is_databricks_runtime, is_not_utc
 from data_gen import *
-from marks import ignore_order, allow_non_gpu
+from spark_session import is_spark_400_or_later
+from marks import ignore_order, allow_non_gpu, disable_ansi_mode
 from spark_session import with_cpu_session, is_databricks113_or_later, is_before_spark_330, is_databricks_version_or_later
 
 # allow non gpu when time zone is non-UTC because of https://github.com/NVIDIA/spark-rapids/issues/9653'
@@ -31,12 +32,12 @@ def create_skew_df(spark, length):
     mid = length / 2
     left = root.select(
         when(col('id') < mid / 2, mid).
-            otherwise('id').alias("key1"),
+            otherwise(col('id')).alias("key1"),
         col('id').alias("value1")
     )
     right = root.select(
         when(col('id') < mid, mid).
-            otherwise('id').alias("key2"),
+            otherwise(col('id')).alias("key2"),
         col('id').alias("value2")
     )
     return left, right
@@ -57,6 +58,8 @@ def test_aqe_skew_join():
 # Test the computeStats(...) implementation in GpuDataSourceScanExec
 @ignore_order(local=True)
 @pytest.mark.parametrize("data_gen", integral_gens, ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_aqe_join_parquet(spark_tmp_path, data_gen):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     with_cpu_session(
@@ -74,6 +77,8 @@ def test_aqe_join_parquet(spark_tmp_path, data_gen):
 # Test the computeStats(...) implementation in GpuBatchScanExec
 @ignore_order(local=True)
 @pytest.mark.parametrize("data_gen", integral_gens, ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_aqe_join_parquet_batch(spark_tmp_path, data_gen):
     # force v2 source for parquet to use BatchScanExec
     conf = copy_and_update(_adaptive_conf, {
@@ -198,6 +203,7 @@ db_113_cpu_bnlj_join_allow=["ShuffleExchangeExec"] if is_databricks113_or_later(
 # theoretically show up in other Spark distributions
 @ignore_order(local=True)
 @allow_non_gpu('BroadcastNestedLoopJoinExec', 'Cast', 'DateSub', *db_113_cpu_bnlj_join_allow, *not_utc_aqe_allow)
+@pytest.mark.skipif(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/11100")
 @pytest.mark.parametrize('join', joins, ids=idfn)
 def test_aqe_join_reused_exchange_inequality_condition(spark_tmp_path, join):
     data_path = spark_tmp_path + '/PARQUET_DATA'

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -18,7 +18,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are
 from data_gen import *
 from spark_session import is_before_spark_320, is_jvm_charset_utf8
 from pyspark.sql.types import *
-from marks import datagen_overrides, allow_non_gpu
+from marks import datagen_overrides, allow_non_gpu, disable_ansi_mode
 import pyspark.sql.functions as f
 
 # mark this test as ci_1 for mvn verify sanity check in pre-merge CI
@@ -47,6 +47,8 @@ if_struct_gens_sample = [if_struct_gen,
 if_nested_gens = if_array_gens_sample + if_struct_gens_sample
 
 @pytest.mark.parametrize('data_gen', all_gens + if_nested_gens, ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/12019
+@disable_ansi_mode
 def test_if_else(data_gen):
     (s1, s2) = with_cpu_session(
         lambda spark: gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
@@ -117,6 +119,8 @@ def test_nanvl(data_gen):
                 f.nanvl(f.lit(float('nan')).cast(data_type), f.col('b'))))
 
 @pytest.mark.parametrize('data_gen', all_basic_gens + decimal_gens, ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/12019
+@disable_ansi_mode
 def test_nvl(data_gen):
     (s1, s2) = with_cpu_session(
         lambda spark: gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
@@ -156,6 +160,8 @@ def test_coalesce_constant_output():
             lambda spark : spark.range(1, 100).selectExpr("4 + coalesce(5, id) as nine"))
 
 @pytest.mark.parametrize('data_gen', all_basic_gens + decimal_gens, ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/12019
+@disable_ansi_mode
 def test_nvl2(data_gen):
     (s1, s2) = with_cpu_session(
         lambda spark: gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
@@ -169,6 +175,8 @@ def test_nvl2(data_gen):
                 'nvl2(a, {}, c)'.format(null_lit)))
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/12019
+@disable_ansi_mode
 def test_nullif(data_gen):
     (s1, s2) = with_cpu_session(
         lambda spark: gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))
@@ -182,6 +190,8 @@ def test_nullif(data_gen):
                 'nullif(a, {})'.format(null_lit)))
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/12019
+@disable_ansi_mode
 def test_ifnull(data_gen):
     (s1, s2) = with_cpu_session(
         lambda spark: gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen)))


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/11005, https://github.com/NVIDIA/spark-rapids/issues/11010 and https://github.com/NVIDIA/spark-rapids/issues/11012

Changes made in each file:

1. aqe_test.py - 
 - Added `disable_ansi_mode` to tests affected by ANSI mode issues (#5114)
-  Fixed column handling in `create_skew_df` by properly wrapping 'id' in `col()`
- Added skip condition for `test_aqe_join_reused_exchange_inequality_condition` in Spark 4.0 (#11100)

2. conditional_test.py and cache_test.py
 - Added `disable_ansi_mode` decorator to multiple tests affected by ANSI mode issues (#5114) and overflow issues(#12019)

Testing:

All tests pass for the below files.
```
Cache test:
./integration_tests/run_pyspark_from_build.sh -k 'cache_test.py'

Conditionals test:
./integration_tests/run_pyspark_from_build.sh -k 'conditionals_test.py

AQE test:
./integration_tests/run_pyspark_from_build.sh -k 'aqe_test.py

```