### PR TITLE
Fix test_orc_fallback for Spark400

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -182,7 +182,7 @@ def test_orc_fallback(spark_tmp_path, read_func, disable_conf):
     with_cpu_session(
             lambda spark : gen_df(spark, gen).write.orc(data_path))
     assert_gpu_fallback_collect(
-            lambda spark : reader(spark).select(f.col('*'), f.col('_c2') + f.col('_c3')),
+            lambda spark : reader(spark).select(f.col('*'), f.col('_c2'), f.col('_c3')),
             'FileSourceScanExec',
             conf={disable_conf: 'false',
                 "spark.sql.sources.useV1SourceList": "orc"})

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -182,7 +182,8 @@ def test_orc_fallback(spark_tmp_path, read_func, disable_conf):
     with_cpu_session(
             lambda spark : gen_df(spark, gen).write.orc(data_path))
     assert_gpu_fallback_collect(
-            lambda spark : reader(spark).select(f.col('*'), f.col('_c2'), f.col('_c3')),
+            # Default Ansi mode is on for Spark 400, here cast c2 to long then add c3 to avoid overflow
+            lambda spark : reader(spark).select(f.col('*'), f.col('_c2').cast(long_gen.data_type) + f.col('_c3')),
             'FileSourceScanExec',
             conf={disable_conf: 'false',
                 "spark.sql.sources.useV1SourceList": "orc"})


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/11013

### bug description
This case `test_orc_fallback` is testing the fallback to CPU behavior for configs:
- `spark.rapids.sql.format.orc.enabled'
- 'spark.rapids.sql.format.orc.read.enabled

On Spark400, fallback works, but the addition operator throws exception because Spark400's default Ansi mode is true.

### fix
Change the `select a + b`  to  `select a, b` to avoid overflow which causes exception for Ansi mode.

Signed-off-by: Chong Gao <res_life@163.com>
