### PR TITLE
Skip Ansi check for Count agg.

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2226,16 +2226,14 @@ def test_avg_fallback_when_ansi_enabled(data_gen, kudo_enabled):
 
 
 @ignore_order(local=True)
-@allow_non_gpu('HashAggregateExec', 'Alias', 'AggregateExpression',
-  'HashPartitioning', 'ShuffleExchangeExec', 'Count', 'Literal')
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_count_fallback_when_ansi_enabled(data_gen, kudo_enabled):
+def test_count_when_ansi_enabled(data_gen, kudo_enabled):
     def do_it(spark):
         df = gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100)
         return df.groupBy('a').agg(f.count("b"), f.count("*"))
 
-    assert_gpu_fallback_collect(do_it, 'Count',
+    assert_gpu_and_cpu_are_equal_collect(do_it,
         conf={'spark.sql.ansi.enabled': 'true', kudo_enabled_conf_key: kudo_enabled})
 
 @ignore_order(local=True)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -749,6 +749,12 @@ object GpuOverrides extends Logging {
    * @param meta agg expression meta
    */
   def checkAndTagAnsiAgg(checkType: Option[DataType], meta: AggExprMeta[_]): Unit = {
+    if (meta.expr.isInstanceOf[Count]) {
+      // Spark Count agg returns Long and does not check Ansi mode and overflow,
+      // so it's safe to ignore Ansi check for Count.
+      return
+    }
+
     val failOnError = SQLConf.get.ansiEnabled
     if (failOnError) {
       if (checkType.isDefined) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2217,7 +2217,7 @@ object GpuOverrides extends Logging {
       (count, conf, p, r) => new AggExprMeta[Count](count, conf, p, r) {
 
         // Spark Count agg returns Long and does not check Ansi mode and overflow
-        def needsAnsiCheck: Boolean = false
+        override def needsAnsiCheck: Boolean = false
 
         override def tagAggForGpu(): Unit = {
           if (count.children.size > 1) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1405,7 +1405,7 @@ abstract class AggExprMeta[INPUT <: AggregateFunction](
 
   // Set to false if the aggregate doesn't overflow and therefore
   // shouldn't error
-  val needsAnsiCheck: Boolean = true
+  def needsAnsiCheck: Boolean = true
 
   // The type to use to determine whether the aggregate could overflow.
   // Set to None, if we should fallback for all types


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/11013
contributes to https://github.com/NVIDIA/spark-rapids/issues/5114

### bug
The Ansi mode is enabled on Spark 400 by default.
The following count cases failed on Spark 400:

- FAILED ../../../../integration_tests/src/main/python/orc_test.py::test_missing_column_names_count
- FAILED ../../../../integration_tests/src/main/python/orc_test.py::test_partial_missing_column_names_count
- FAILED ../../../../integration_tests/src/main/python/orc_test.py::test_missing_column_names_count_with_schema
- FAILED ../../../../integration_tests/src/main/python/orc_test.py::test_orc_read_count

### fix
Spark Count agg returns Long and does not check Ansi mode and overflow,
rerfer to [Spark 400 Count link](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala), so it's safe to ignore Ansi check for Count.

Also checked Spark 320 Count, it also does not check Ansi mode and overflow

Signed-off-by: Chong Gao <res_life@163.com>