### PR TITLE
[Spark-4.0]: Resolve integration tests in parquet_test

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -1540,12 +1540,11 @@ def test_parquet_decimal_precision_scale_change(spark_tmp_path, from_decimal_gen
     ])
 
     spark_conf = {}
-    if is_before_spark_400():
-        # In Spark versions earlier than 4.0, the vectorized Parquet reader throws an exception
-        # if the read scale differs from the write scale. We disable the vectorized reader,
-        # forcing Spark to use the non-vectorized path for CPU case. This configuration
-        # is ignored by the plugin.
-        spark_conf['spark.sql.parquet.enableVectorizedReader'] = 'false'
+    # The vectorized Parquet reader throws an exception in some cases where the
+    # read scale differs from the write scale. We disable the vectorized reader,
+    # forcing Spark to use the non-vectorized path for CPU case. This configuration
+    # is ignored by the plugin.
+    spark_conf['spark.sql.parquet.enableVectorizedReader'] = 'false'
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.read.schema(read_schema).parquet(data_path), conf=spark_conf)


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/11015

Some of the tests in `test_parquet_decimal_precision_scale_change` were failing on Spark-4.0. Even though vectorized reader added widening/narrowing of read schema, it doesn't apply to all the combinations. 
Since spark-rapids has it's own vectorized reader path, we should continue using the non-vectorized path(parquet-mr) for CPU code. 
We want to ensure that the GPU results are correct and as expected. 

Verified:
```
./integration_tests/run_pyspark_from_build.sh -k parquet_test.py
``` 