### PR TITLE
[Spark-4.0] Resolve integration test failures in join_test.py

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -19,7 +19,7 @@ from pyspark.sql.types import *
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal, assert_gpu_fallback_collect, assert_cpu_and_gpu_are_equal_collect_with_capture
 from conftest import is_emr_runtime
 from data_gen import *
-from marks import ignore_order, allow_non_gpu, incompat, validate_execs_in_gpu_plan
+from marks import ignore_order, allow_non_gpu, incompat, validate_execs_in_gpu_plan, disable_ansi_mode
 from spark_session import with_cpu_session, is_before_spark_330, is_databricks_runtime
 from src.main.python.spark_session import with_gpu_session
 
@@ -131,6 +131,8 @@ def join_batch_size_test_params(*args):
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/11100
+@allow_non_gpu('EmptyRelationExec')
 def test_right_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
@@ -144,6 +146,8 @@ def test_right_broadcast_nested_loop_join_without_condition_empty(join_type, aqe
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/11100
+@allow_non_gpu('EmptyRelationExec')
 def test_left_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 0, 50)
@@ -157,6 +161,8 @@ def test_left_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/11100
+@allow_non_gpu('EmptyRelationExec')
 def test_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 0, 0)
@@ -169,6 +175,8 @@ def test_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabl
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/11100
+@allow_non_gpu('EmptyRelationExec')
 def test_right_broadcast_nested_loop_join_without_condition_empty_small_batch(join_type, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
@@ -181,6 +189,8 @@ def test_right_broadcast_nested_loop_join_without_condition_empty_small_batch(jo
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/11100
+@allow_non_gpu('EmptyRelationExec')
 def test_empty_broadcast_hash_join(join_type, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
@@ -192,6 +202,8 @@ def test_empty_broadcast_hash_join(join_type, kudo_enabled):
 
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_broadcast_hash_join_constant_keys(join_type, kudo_enabled):
     def do_join(spark):
         left = spark.range(10).withColumn("s", lit(1))
@@ -444,6 +456,8 @@ def test_cartesian_join(data_gen, batch_size, kudo_enabled):
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_cartesian_join_special_case_count(batch_size, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
@@ -461,6 +475,8 @@ def test_cartesian_join_special_case_count(batch_size, kudo_enabled):
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_cartesian_join_special_case_group_by_count(batch_size, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
@@ -515,6 +531,8 @@ def test_broadcast_nested_loop_join(data_gen, batch_size, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_broadcast_nested_loop_join_special_case_count(batch_size, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
@@ -531,6 +549,8 @@ def test_broadcast_nested_loop_join_special_case_count(batch_size, kudo_enabled)
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_broadcast_nested_loop_join_special_case_group_by_count(batch_size, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
@@ -599,6 +619,8 @@ def test_broadcast_nested_loop_join_with_condition_post_filter(data_gen, join_ty
 @pytest.mark.parametrize('data_gen', [IntegerGen(), LongGen(), pytest.param(FloatGen(), marks=[incompat]), pytest.param(DoubleGen(), marks=[incompat])], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Cross', 'Left', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/12700
+@disable_ansi_mode
 def test_broadcast_nested_loop_join_with_condition(data_gen, join_type, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
@@ -682,6 +704,8 @@ def test_left_broadcast_nested_loop_join_condition_missing(data_gen, join_type, 
 @pytest.mark.parametrize('join_type', ['Left', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_right_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
@@ -692,6 +716,8 @@ def test_right_broadcast_nested_loop_join_condition_missing_count(data_gen, join
 @pytest.mark.parametrize('join_type', ['Right'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_left_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type, kudo_enabled):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
@@ -936,6 +962,7 @@ def test_bucket_join_io_precache(spark_tmp_table_factory, join_type, aqe_enabled
 @pytest.mark.parametrize('cache_side', ['cache_left', 'cache_right'], ids=idfn)
 @pytest.mark.parametrize('cpu_side', ['cache', 'not_cache'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+@disable_ansi_mode
 def test_half_cache_join(join_type, cache_side, cpu_side, kudo_enabled):
     left_gen = [('a', SetValuesGen(LongType(), range(500))), ('b', IntegerGen())]
     right_gen = [('r_a', SetValuesGen(LongType(), range(500))), ('c', LongGen())]
@@ -952,7 +979,7 @@ def test_half_cache_join(join_type, cache_side, cpu_side, kudo_enabled):
             # by default if the operation after the shuffle is not on the GPU then
             # don't do a GPU shuffle, so do something simple after the repartition
             # to make sure that the GPU shuffle is used.
-            left = left.repartition('a').selectExpr('b + 1 as b', 'a').cache()
+            left = left.repartition('a').selectExpr('b as b', 'a').cache()
             left.count() # populate the cache
         else:
             #cache_right
@@ -960,7 +987,7 @@ def test_half_cache_join(join_type, cache_side, cpu_side, kudo_enabled):
             # by default if the operation after the shuffle is not on the GPU then
             # don't do a GPU shuffle, so do something simple after the repartition
             # to make sure that the GPU shuffle is used.
-            right = right.repartition('r_a').selectExpr('c + 1 as c', 'r_a').cache()
+            right = right.repartition('r_a').selectExpr('c as c', 'r_a').cache()
             right.count() # populate the cache
         # Now turn it back so the other half of the shuffle will be on the oposite side
         spark.conf.set('spark.rapids.sql.exec.ShuffleExchangeExec', cpu_side == 'cache')
@@ -1495,7 +1522,7 @@ def test_distinct_join(join_type, batch_size, kudo_enabled):
     }
     def do_join(spark):
         left_df = spark.range(1024).withColumn("x", f.col("id") + 1)
-        right_df = spark.range(768).withColumn("x", f.col("id") * 2)
+        right_df = spark.range(768).withColumn("x", f.col("id") + f.col("id"))
         return left_df.join(right_df, ["x"], join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=join_conf)
 
@@ -1580,6 +1607,8 @@ def test_sized_join_conditional(join_type, is_ast_supported, is_left_smaller, ba
 @pytest.mark.parametrize("is_conditional", [False, True], ids=idfn)
 @pytest.mark.parametrize("is_outer_side_small", [False, True], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode
 def test_sized_join_high_key_replication(join_type, is_left_replicated, is_conditional,
                                          is_outer_side_small, kudo_enabled):
     join_conf = {


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/11022

In this PR:

1. We allow EmptyRelationExec to fallback to CPU 
2. Disable ansi mode for tests containing aggregates.
3. Modify the test to use addition instead of multiplication since the latter is not accelerated on GPU when ansi is enabled and we fallback to CPU in that case. The functionality still remains the same.

```
./integration_tests/run_pyspark_from_build.sh -k 'join_test.py'

======================================== 4408 passed, 24 skipped, 12 xpassed, 3342 warnings in 846.99s (0:14:06) =========================================

```