### PR TITLE
Fix IT: cast_test.py

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -886,7 +886,7 @@ def test_cast_string_to_timestamp_valid():
 
 # Disable ANSI for Spark 4.0
 @disable_ansi_mode
-def test_cast_string_to_timestamp_valid_just_time_with_default_timezone():
+def test_cast_string_to_timestamp_just_time_ANSI_OFF():
     # For the just time strings, will get current date to fill the missing date.
     # E.g.: "T00:00:00" will be "2025-05-23T00:00:00"
     # This test case is sensitive to the current date, and may cause diff between CPU and GPU
@@ -905,7 +905,11 @@ def test_cast_string_to_timestamp_valid_just_time_with_default_timezone():
                 ("T23:17:50",),
                 ("T23:17:50",),
                 ("T23:17:50",),
-                (" \r\n\tT23:17:50",), # This is testing issue: https://github.com/NVIDIA/spark-rapids-jni/issues/3401
+
+                # This is invalid value for Spark 4.0
+                # For details, refer to https://github.com/NVIDIA/spark-rapids-jni/issues/3401
+                (" \r\n\tT23:17:50",),
+
                 ("T23:17:50 \r\n\t",),
                 ("T00",),
                 ("T1:2",),
@@ -1085,7 +1089,7 @@ _cast_string_to_timestamp_invalid = [
 
 # Disable ANSI for Spark 4.0
 @disable_ansi_mode
-def test_cast_string_to_timestamp_invalid():
+def test_cast_string_to_timestamp_invalid_ANSI_OFF():
     def _gen_df(spark):
         return spark.createDataFrame(
             _cast_string_to_timestamp_invalid,
@@ -1146,7 +1150,7 @@ def test_cast_string_to_timestamp_invalid_ansi_enabled(invalid_item):
             r'3[0-9]{3,3}-[0-9]{1,2}-[0-9]{1,2}[ T][0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} PST',
             id='yyyy-mm-dd[ T]hh:mm:ss PST, ts > 2200')
     ])
-def test_cast_string_to_timestamp_const_format(pattern):
+def test_cast_string_to_timestamp_const_format_ANSI_OFF(pattern):
     gen = [("str_col", StringGen(pattern))]
     def _query(spark):
         # depends on the timezone info in `GpuTimeZoneDB`, load first


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/11009

### bugs
Failed cases in cast_test.py:
- test_cast_string_to_timestamp_valid_just_time_with_default_timezone
- test_cast_string_to_timestamp_invalid
- test_cast_string_to_timestamp_const_format

### Fix
The above failed cases are expected running with non-ANSI mode, but for Spark4.0, the default mode is ANSI mode, so explicitly specify using non-ANSI mode.

Signed-off-by: Chong Gao <res_life@163.com>