### PR TITLE
Fix Spark 4.0 IT failures: test_conv

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -913,7 +913,7 @@ def test_format_number_float_value():
                          [
                              pytest.param(10, r'-?[0-9]{1,18}',       id='from_10'),
                              pytest.param(16, r'-?[0-9a-fA-F]{1,15}', id='from_16'),
-                             pytest.param(36, r'-?[0-9a-zA-Z]{1,15}', id='from_36')
+                             pytest.param(36, r'-?[0-9a-zA-Z]{1,11}', id='from_36')
                          ])
 @pytest.mark.parametrize('to_base', [2, 10, 16, 21, 36, -2, -10, -16, -29, -33], ids=idfn)
 def test_conv_with_more_valid_values(from_base, to_base, pattern):
@@ -931,6 +931,7 @@ def test_conv_with_more_valid_values(from_base, to_base, pattern):
 
 # valid base range is [2, 36], to_base can be negative, out of range results nulls
 # When base is 36, the valid alphabets are: [0-9], [a-z] and [A-Z]
+@disable_ansi_mode
 def test_conv_with_more_invalid_values():
     gen = [
         ("str_col", mk_str_gen(r'-?[0-9a-zA-Z]{1,15}')),


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/11030


### Failed cases
- test_conv_with_more_valid_values
- test_conv_with_more_invalid_values

Refer to [link](https://github.com/NVIDIA/spark-rapids/issues/11030#issuecomment-2971850822)

### Fixes
- test_conv_with_more_valid_values
The regexp `r'-?[0-9a-zA-Z]{1,15}'` is wrong, 15 digits number of 36 radix exceeds max long value which is invalid:
36^15 > Long.MaxValue
Fix: Change the number 15 to 11, which generates values are less than max long.

- test_conv_with_more_invalid_values
This is testing invalid values will get null for non-ANSI mode.
So for Spark 4.0, should explicitly specify non-ANSI mode because default ANSI mode for Spark 4.0 is true.

Signed-off-by: Chong Gao <res_life@163.com>