### PR TITLE
xfail the url tests for Spark 400+

### DIFF
--- a/integration_tests/src/main/python/url_test.py
+++ b/integration_tests/src/main/python/url_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ from data_gen import *
 from marks import *
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
-from spark_session import is_before_spark_340
+from spark_session import is_before_spark_340, is_spark_400_or_later
 
 # regex to generate limit length urls with HOST, PATH, QUERY, REF, PROTOCOL, FILE, AUTHORITY, USERINFO
 url_pattern = r'((http|https|ftp)://)(([a-zA-Z][a-zA-Z0-9]{0,2}\.){0,3}([a-zA-Z][a-zA-Z0-9]{0,2})\.([a-zA-Z][a-zA-Z0-9]{0,2}))' \
@@ -150,7 +150,8 @@ url_gen = StringGen(url_pattern)
 
 supported_parts = ['PROTOCOL', 'HOST', 'QUERY', 'PATH', 'invalid', 'path']
 unsupported_parts = ['REF', 'FILE', 'AUTHORITY', 'USERINFO']
-    
+
+@pytest.mark.xfail(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12941")
 @pytest.mark.parametrize('data_gen', [url_gen, edge_cases_gen], ids=idfn)
 @pytest.mark.parametrize('part', supported_parts, ids=idfn)
 def test_parse_url_supported(data_gen, part):
@@ -159,6 +160,7 @@ def test_parse_url_supported(data_gen, part):
         ansi_disabled_conf  # ANSI mode failures are tested in test_parse_url_query_ansi_mode.
     )
 
+@pytest.mark.xfail(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12941")
 @allow_non_gpu('ProjectExec', 'ParseUrl')
 @pytest.mark.parametrize('part', unsupported_parts, ids=idfn)
 def test_parse_url_unsupported_fallback(part):
@@ -166,6 +168,7 @@ def test_parse_url_unsupported_fallback(part):
         lambda spark: unary_op_df(spark, url_gen).selectExpr("a", "parse_url(a, '" + part + "')"),
         'ParseUrl')
 
+@pytest.mark.xfail(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12941")
 def test_parse_url_query_with_key():
     url_gen = StringGen(url_pattern_with_key)
     assert_gpu_and_cpu_are_equal_collect(
@@ -192,6 +195,7 @@ def test_parse_url_query_ansi_mode():
     )
 
 
+@pytest.mark.xfail(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12941")
 def test_parse_url_query_with_key_column():
     url_gen = StringGen(url_pattern_with_key)
     key_gen = StringGen('[a-d]{1,3}')
@@ -201,6 +205,8 @@ def test_parse_url_query_with_key_column():
         ansi_disabled_conf  # ANSI mode failures are tested in test_parse_url_query_ansi_mode.
     )
 
+
+@pytest.mark.xfail(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12941")
 @pytest.mark.parametrize('key', ['a?c', '*'], ids=idfn)
 @allow_non_gpu('ProjectExec', 'ParseUrl')
 def test_parse_url_query_with_key_regex_fallback(key):
@@ -210,6 +216,7 @@ def test_parse_url_query_with_key_regex_fallback(key):
             .selectExpr("a", "parse_url(a, 'QUERY', '" + key + "')"),
             'ParseUrl')
 
+@pytest.mark.xfail(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12941")
 @pytest.mark.parametrize('part', supported_parts, ids=idfn)
 def test_parse_url_with_key(part):
     assert_gpu_and_cpu_are_equal_collect(
@@ -217,6 +224,7 @@ def test_parse_url_with_key(part):
         ansi_disabled_conf  # ANSI mode failures are tested in test_parse_url_query_ansi_mode.
     )
 
+@pytest.mark.xfail(is_spark_400_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12941")
 @allow_non_gpu('ProjectExec', 'ParseUrl')
 @pytest.mark.parametrize('part', unsupported_parts, ids=idfn)
 def test_parse_url_with_key_fallback(part):


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11017

This PR is a quick fix for url tests to unblock the 400 CI. And eventually we should support overriding the runtime replaced version of the `ParseUrl` expression, which changes the SQL plan and fails the GPU overriding. See https://github.com/NVIDIA/spark-rapids/issues/12941
