### PR TITLE
Fix the failures in array_test.py for Spark 400[databricks]

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -264,7 +264,7 @@ def test_array_position(data_gen):
         'array_position(array(null), b)',
         'array_position(array(), b)',
         'array_position(a, b)',
-        'array_position(a, a[5])',
+        'array_position(a, get(a, 5))',
         'array_position(a, null)'))
 
 
@@ -319,8 +319,9 @@ def test_array_slice_with_zero_start(data_gen, zero_start, valid_length):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: three_col_df(spark, array_all_null_gen, zero_start_gen, valid_length_gen, length=5).selectExpr(
             f"slice(a, {zero_start}, {valid_length})"))
-    error = "The value of parameter(s) `start` in `slice` is invalid: Expects a positive or a negative value for `start`, but got" if is_databricks143_or_later() \
-            else "Unexpected value for start in function slice: SQL array indices start at 1."
+    error = "The value of parameter(s) `start` in `slice` is invalid: Expects a positive or a negative value for `start`, but got"\
+        if is_databricks143_or_later() or is_spark_400_or_later() \
+        else "Unexpected value for start in function slice: SQL array indices start at 1."
     # start can not be zero
     assert_gpu_and_cpu_error(
         lambda spark: three_col_df(spark, data_gen, zero_start_gen, valid_length_gen, length=5).selectExpr(
@@ -338,8 +339,9 @@ def test_array_slice_with_negative_length(data_gen, valid_start, negative_length
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: three_col_df(spark, array_all_null_gen, array_no_zero_index_gen, negative_length_gen, length=5).selectExpr(
             f"slice(a, {valid_start}, {negative_length})"))
-    error = "The value of parameter(s) `length` in `slice` is invalid: Expects `length` greater than or equal to 0" if is_databricks143_or_later() \
-            else 'Unexpected value for length in function slice: length must be greater than or equal to 0.'
+    error = "The value of parameter(s) `length` in `slice` is invalid: Expects `length` greater than or equal to 0"\
+        if is_databricks143_or_later() or is_spark_400_or_later()\
+        else 'Unexpected value for length in function slice: length must be greater than or equal to 0.'
     # length can not be negative
     assert_gpu_and_cpu_error(
         lambda spark: three_col_df(spark, data_gen, array_no_zero_index_gen, negative_length_gen, length=5).selectExpr(

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -264,7 +264,7 @@ def test_array_position(data_gen):
         'array_position(array(null), b)',
         'array_position(array(), b)',
         'array_position(a, b)',
-        'array_position(a, a[5]))',
+        'array_position(a, a[5])',
         'array_position(a, null)'))
 
 

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -259,12 +259,12 @@ orderable_gens_sample_no_null = [g for g in orderable_gens_sample if g != null_g
 @pytest.mark.parametrize('data_gen',
     orderable_gens_sample_no_null if is_spark_340_or_later() or is_databricks_runtime() else orderable_gens_sample, ids=idfn)
 def test_array_position(data_gen):
-    arr_gen = ArrayGen(data_gen)
+    arr_gen = ArrayGen(data_gen, min_length=6)
     assert_gpu_and_cpu_are_equal_collect(lambda spark: two_col_df(spark, arr_gen, data_gen).selectExpr(
         'array_position(array(null), b)',
         'array_position(array(), b)',
         'array_position(a, b)',
-        'array_position(a, get(a, 5))',
+        'array_position(a, a[5]))',
         'array_position(a, null)'))
 
 

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -259,6 +259,7 @@ orderable_gens_sample_no_null = [g for g in orderable_gens_sample if g != null_g
 @pytest.mark.parametrize('data_gen',
     orderable_gens_sample_no_null if is_spark_340_or_later() or is_databricks_runtime() else orderable_gens_sample, ids=idfn)
 def test_array_position(data_gen):
+    # min_length=6 to make sure 'a[5]' always works.
     arr_gen = ArrayGen(data_gen, min_length=6)
     assert_gpu_and_cpu_are_equal_collect(lambda spark: two_col_df(spark, arr_gen, data_gen).selectExpr(
         'array_position(array(null), b)',


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11007

There are two kinds of failures here
1) `a[5]` sometimes throws out an exception because the index 5 is out of bounds when the generated array has less than 5 elements. So we make sure the array is either a null or has 6 elements at least.
```
pyspark.errors.exceptions.captured.ArrayIndexOutOfBoundsException: [INVALID_ARRAY_INDEX] The index 5 is out of bounds. The array has 3 elements. Use the SQL function `get()` to tolerate accessing element at invalid index and return NULL instead. SQLSTATE: 22003
```

2) The error message changes for invalid cases, so update it accordingly.