### PR TITLE
Disable ansi mode for the kudo dump tests.

### DIFF
--- a/integration_tests/src/main/python/kudo_dump_test.py
+++ b/integration_tests/src/main/python/kudo_dump_test.py
@@ -21,6 +21,7 @@ from data_gen import *
 from marks import *
 import pyspark.sql.functions as f
 
+@disable_ansi_mode
 @ignore_order(local=True)
 @pytest.mark.skipif(not is_apache_runtime() and not is_databricks_runtime(), reason="only test on local file system")
 def test_kudo_serializer_debug_dump(spark_tmp_path):


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/12937

The failure in kudo_dump_test.py is because the `SUM` aggregate does not support ansi mode. And this is not the goal of this test, so disable the ansi mode here.
