### PR TITLE
Fix Spark 400 IT failures in date_time_test.py

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -677,6 +677,7 @@ def test_to_timestamp_tz_rules(parser_policy):
         { "spark.sql.legacy.timeParserPolicy": parser_policy})
 
 # mm: minute; MM: month
+@disable_ansi_mode
 @pytest.mark.parametrize("format", ['yyyyMMdd', 'yyyymmdd', 'yyyy-mm-dd'], ids=idfn)
 # Test years after 1900, refer to issues: https://github.com/NVIDIA/spark-rapids/issues/11543, https://github.com/NVIDIA/spark-rapids/issues/11539
 @pytest.mark.skipif(get_test_tz() != "Asia/Shanghai" and get_test_tz() != "UTC", reason="https://github.com/NVIDIA/spark-rapids/issues/11562")
@@ -694,6 +695,7 @@ def test_formats_for_legacy_mode(format):
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
 # mm: minute; MM: month
+@disable_ansi_mode
 @pytest.mark.skipif(get_test_tz() != "Asia/Shanghai" and get_test_tz() != "UTC", reason="https://github.com/NVIDIA/spark-rapids/issues/11562")
 def test_formats_for_legacy_mode_other_formats_runtime_fallback():
     # We will do a CPU fallback during runtime for timezones with transitions during 
@@ -713,6 +715,7 @@ def test_formats_for_legacy_mode_other_formats_runtime_fallback():
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
 # mm: minute; MM: month
+@disable_ansi_mode
 @pytest.mark.skipif(get_test_tz() != "Asia/Shanghai" and get_test_tz() != "UTC", reason="https://github.com/NVIDIA/spark-rapids/issues/11562")
 def test_formats_for_legacy_mode_other_formats_tz_rules():
     format = "yyyyMMdd HH:mm:ss"

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -517,6 +517,7 @@ def test_unsupported_fallback_from_unixtime(data_gen):
     ('2021-01', 'yyyy/MM'),
     ('01/02/201', 'dd/MM/yyyy'),
     ('2021-01-01 00:00', 'yyyy-MM-dd HH:mm:ss'),
+    ('19224303 22:82:35', 'yyyy-MM-dd HH:mm:ss'),
     ('01#01', 'MM-dd'),
     ('01T01', 'MM/dd'),
     ('29-02', 'dd-MM'),  # 1970-02-29 is invalid


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/12934


### Fix cases in date_time_test.py
- test_formats_for_legacy_mode
- test_formats_for_legacy_mode_other_formats_runtime_fallback
- test_formats_for_legacy_mode_other_formats_tz_rules

### Analysis
All the above cases reports error when meet invalid input:
```
pyspark.errors.exceptions.captured.DateTimeException: [CANNOT_PARSE_TIMESTAMP] Unparseable date: "19224303 22:82:35". 
Use `try_to_timestamp` to tolerate invalid input string and return NULL instead. SQLSTATE: 22007
```
The goal of these cases are to test for non-ANSI mode, so for Spark 4.0 explicitly set non-ANISI mode(The default mode is ANSI for Spark 4.0).


Signed-off-by: Chong Gao <res_life@163.com>