### PR TITLE
optimize shuffle read perf after getting a cpu wall time flame graph from customer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -553,9 +553,12 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
   // Don't install the callback if in a unit test
   Option(TaskContext.get()).foreach { tc =>
     onTaskCompletion(tc) {
-      dIn.close()
-      streamClosed = true
-      sharedBuffer.map(_.close())
+      Seq[AutoCloseable](
+        () => dIn.close(),
+        () => streamClosed = true,
+        () => sharedBuffer.map(_.close(),
+      ).safeClose()
+    )
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -582,7 +582,7 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
     }
   }
 
-  private def allocateWithRetry(size: Int): HostMemoryBuffer = {
+  private def allocateHostWithRetry(size: Int): HostMemoryBuffer = {
     withRetryNoSplit[HostMemoryBuffer] {
       // This buffer will later be concatenated into another host buffer before being
       // sent to the GPU, so no need to use pinned memory for these buffers.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -600,7 +600,7 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
         // The previous batches should be able to be spilled by itself.
         val buffer = {
           if (sharedBuffer.isEmpty) {
-            val allocated = allocateWithRetry(header.getTotalDataLen)
+            val allocated = allocateHostWithRetry(header.getTotalDataLen)
 
             if (firstTenBatchesSizes.length < 10) {
               firstTenBatchesSizes += header.getTotalDataLen
@@ -610,7 +610,7 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
                 if (maxSize < sharedBufferTriggerSize) {
                   // If the max size of the first 10 batches is less than the threshold,
                   // we can use a shared buffer.
-                  sharedBuffer = Some(allocateWithRetry(sharedBufferTotalSize))
+                  sharedBuffer = Some(allocateHostWithRetry(sharedBufferTotalSize))
                   sharedBufferCurrentUse = 0
                 }
               }
@@ -621,13 +621,13 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
             if (header.getTotalDataLen > sharedBufferTotalSize / 2) {
               // Too big to use shared buffer, this should rarely happen since
               // first ten batches all much smaller.
-              allocateWithRetry(header.getTotalDataLen)
+              allocateHostWithRetry(header.getTotalDataLen)
             } else {
               if (sharedBufferCurrentUse + header.getTotalDataLen > sharedBufferTotalSize) {
                 // If not enough room left, we need to allocate a new shared buffer.
                 sharedBuffer.get.close()
                 sharedBufferCurrentUse = 0
-                sharedBuffer = Some(allocateWithRetry(sharedBufferTotalSize))
+                sharedBuffer = Some(allocateHostWithRetry(sharedBufferTotalSize))
               }
               val ret = sharedBuffer.get.slice(sharedBufferCurrentUse,
                 header.getTotalDataLen)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -556,9 +556,8 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
       Seq[AutoCloseable](
         () => dIn.close(),
         () => streamClosed = true,
-        () => sharedBuffer.map(_.close(),
+        () => sharedBuffer.map(_.close())
       ).safeClose()
-    )
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -538,11 +538,24 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
   private[this] var nextHeader: Option[KudoTableHeader] = None
   private[this] var streamClosed: Boolean = false
 
+  // When KudoSerializedBatchIterator is often handling small kudo tables, it is more efficient
+  // to use a shared HostMemoryBuffer to avoid the overhead of allocating and deallocating, check
+  // SparkResourceAdaptor.cpuDeallocate to understand the overhead.
+
+  // Used to track the first 10 batch sizes
+  // and decide if to use a shared HostMemoryBuffer or not.
+  private[this] val firstTenBatchesSizes = new ArrayBuffer[Long](10)
+  private[this] var sharedBuffer: Option[HostMemoryBuffer] = None
+  private[this] val sharedBufferTriggerSize: Int = 1 << 20 // 1MB
+  private[this] val sharedBufferTotalSize: Int = 20 << 20 // 20MB
+  private[this] var sharedBufferCurrentUse: Int = 0
+
   // Don't install the callback if in a unit test
   Option(TaskContext.get()).foreach { tc =>
     onTaskCompletion(tc) {
       dIn.close()
       streamClosed = true
+      sharedBuffer.map(_.close())
     }
   }
 
@@ -566,6 +579,14 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
     }
   }
 
+  private def allocateWithRetry(size: Int): HostMemoryBuffer = {
+    withRetryNoSplit[HostMemoryBuffer] {
+      // This buffer will later be concatenated into another host buffer before being
+      // sent to the GPU, so no need to use pinned memory for these buffers.
+      HostMemoryBuffer.allocate(size, false)
+    }
+  }
+
   private def readNextBatch(): ColumnarBatch = deserTime.ns {
     withResource(new NvtxRange("Read Batch", NvtxColor.YELLOW)) { _ =>
       val header = nextHeader.get
@@ -575,11 +596,44 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
         // When allocation fails, will roll back to the beginning of this withRetryNoSplit,
         // with previous batches saved in HostCoalesceIteratorBase.serializedTables.
         // The previous batches should be able to be spilled by itself.
-        val buffer = withRetryNoSplit[HostMemoryBuffer] (
-          // This buffer will later be concatenated into another host buffer before being
-          // sent to the GPU, so no need to use pinned memory for these buffers.
-          HostMemoryBuffer.allocate(header.getTotalDataLen, false)
-        )
+        val buffer = {
+          if (sharedBuffer.isEmpty) {
+            val allocated = allocateWithRetry(header.getTotalDataLen)
+
+            if (firstTenBatchesSizes.length < 10) {
+              firstTenBatchesSizes += header.getTotalDataLen
+              if (firstTenBatchesSizes.length == 10) {
+                // If we have 10 batches, we can decide if to use a shared buffer or not.
+                val maxSize = firstTenBatchesSizes.max
+                if (maxSize < sharedBufferTriggerSize) {
+                  // If the max size of the first 10 batches is less than the threshold,
+                  // we can use a shared buffer.
+                  sharedBuffer = Some(allocateWithRetry(sharedBufferTotalSize))
+                  sharedBufferCurrentUse = 0
+                }
+              }
+            }
+
+            allocated
+          } else {
+            if (header.getTotalDataLen > sharedBufferTotalSize / 2) {
+              // Too big to use shared buffer, this should rarely happen since
+              // first ten batches all much smaller.
+              allocateWithRetry(header.getTotalDataLen)
+            } else {
+              if (sharedBufferCurrentUse + header.getTotalDataLen > sharedBufferTotalSize) {
+                // If not enough room left, we need to allocate a new shared buffer.
+                sharedBuffer.get.close()
+                sharedBufferCurrentUse = 0
+                sharedBuffer = Some(allocateWithRetry(sharedBufferTotalSize))
+              }
+              val ret = sharedBuffer.get.slice(sharedBufferCurrentUse,
+                header.getTotalDataLen)
+              sharedBufferCurrentUse += header.getTotalDataLen
+              ret
+            }
+          }
+        }
 
         closeOnExcept(buffer) { _ =>
           buffer.copyFromStream(0, dIn, header.getTotalDataLen)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -294,7 +294,7 @@ abstract class HostCoalesceIteratorBase[T <: AutoCloseable : ClassTag](
     onTaskCompletion(tc)(close())
   }
 
-  protected def tableOperator: SerializedTableOperator[T]
+  protected val tableOperator: SerializedTableOperator[T]
 
   override def close(): Unit = {
     serializedTables.forEach(_.close())
@@ -378,7 +378,7 @@ class HostShuffleCoalesceIterator(
     targetBatchSize: Long,
     metricsMap: Map[String, GpuMetric])
   extends HostCoalesceIteratorBase[SerializedTableColumn](iter, targetBatchSize, metricsMap) {
-  override protected def tableOperator = new JCudfTableOperator
+  override protected val tableOperator = new JCudfTableOperator
 }
 
 class KudoHostShuffleCoalesceIterator(
@@ -389,14 +389,14 @@ class KudoHostShuffleCoalesceIterator(
     readOption: CoalesceReadOption
     )
   extends HostCoalesceIteratorBase[KudoSerializedTableColumn](iter, targetBatchSize, metricsMap) {
-  
+
   // Capture TaskContext info during RDD execution when it's available
   private val taskIdentifier = Option(TaskContext.get()) match {
     case Some(tc) => s"stage_${tc.stageId()}_task_${tc.taskAttemptId()}"
     case None => java.util.UUID.randomUUID().toString
   }
-  
-  override protected def tableOperator = {
+
+  override protected val tableOperator = {
     val kudoSer = if (dataTypes.nonEmpty) {
       Some(new KudoSerializer(GpuColumnVector.from(dataTypes)))
     } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -591,7 +591,7 @@ object RmmRapidsRetryIterator extends Logging {
   // we can just use a cached value, in order to save the cost of creating new RapidsConf, which
   // is quite expensive when we're constantly invoking RmmRapidsRetryIterator in a long loop, e.g.
   // KudoSerializedBatchIterator.
-  private val injectMode = Option(SQLConf.get).map(new RapidsConf(_).testRetryOOMInjectionMode)
+  private lazy val injectMode = Option(SQLConf.get).map(new RapidsConf(_).testRetryOOMInjectionMode)
 
   /**
    * RmmRapidsRetryIterator exposes an iterator that can retry work,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -586,6 +586,13 @@ object RmmRapidsRetryIterator extends Logging {
     }
   }
 
+  // Used to figure out if we should inject an OOM (only for tests)
+  // We assume that runtime change of spark.rapids.sql.test.injectRetryOOM is not supported, so
+  // we can just use a cached value, in order to save the cost of creating new RapidsConf, which
+  // is quite expensive when we're constantly invoking RmmRapidsRetryIterator in a long loop, e.g.
+  // KudoSerializedBatchIterator.
+  private val injectMode = Option(SQLConf.get).map(new RapidsConf(_).testRetryOOMInjectionMode)
+
   /**
    * RmmRapidsRetryIterator exposes an iterator that can retry work,
    * specified by `fn`, abstracting away the retry specifics.
@@ -598,8 +605,6 @@ object RmmRapidsRetryIterator extends Logging {
       extends Iterator[K] {
     // We want to be sure that retry will work in all cases
     TaskRegistryTracker.registerThreadForRetry()
-    // used to figure out if we should inject an OOM (only for tests)
-    private val config = Option(SQLConf.get).map(new RapidsConf(_))
 
     // this is true if an OOM was injected (only for tests)
     private var injectedOOM = false
@@ -653,25 +658,24 @@ object RmmRapidsRetryIterator extends Logging {
         splitReason = SplitReason.NONE
         try {
           // call the user's function
-          config.foreach {
-            case rapidsConf if !injectedOOM && rapidsConf.testRetryOOMInjectionMode.numOoms > 0 =>
+          injectMode.foreach {
+            case mode if !injectedOOM && mode.numOoms > 0 =>
               injectedOOM = true
               // ensure we have associated our thread with the running task, as
               // `forceRetryOOM` requires a prior association.
               if (!RmmSpark.isThreadWorkingOnTaskAsPoolThread) {
                 RmmSpark.currentThreadIsDedicatedToTask(TaskContext.get().taskAttemptId())
               }
-              val injectConf = rapidsConf.testRetryOOMInjectionMode
-              if (injectConf.withSplit) {
+              if (mode.withSplit) {
                 RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId,
-                          injectConf.numOoms,
-                          injectConf.oomInjectionFilter.ordinal,
-                          injectConf.skipCount)
+                  mode.numOoms,
+                  mode.oomInjectionFilter.ordinal,
+                  mode.skipCount)
               } else {
                 RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId,
-                  injectConf.numOoms,
-                  injectConf.oomInjectionFilter.ordinal,
-                  injectConf.skipCount)
+                  mode.numOoms,
+                  mode.oomInjectionFilter.ordinal,
+                  mode.skipCount)
               }
             case _ => ()
           }


### PR DESCRIPTION
Recently we got a cpu wall time flame gragh for a shuffle read stage (with the help of https://github.com/NVIDIA/spark-rapids/pull/12960). The flame graph looks like below and gives us a chance to better understand some bottlenecks in blind spot, especially when there're >50000 mappers where for each reducer, all of the kudo tables it receive is very small (tens of rows)

![image](https://github.com/user-attachments/assets/a9433320-8029-4ad8-93a1-6e0a1fab5532)

From the flamegraph we can see at least there're 3 optimization points:

1. unncessary RapidsConf init cost
2. unnessary cost of  invoking KudoHostShuffleCoalesceIterator#tableOperator again and again
3. significant cost of HostMemoryBuffer allocation/deallocation when the request memory buffers are small in size but big in numbers

After optimization, we get a flamegraph which makes much more sense:

![image](https://github.com/user-attachments/assets/ae91c5a0-26f1-4547-bed2-bd782f3df7c7)

and the cpu core hour of this stage reduce from >80h to ~35h.
