### PR TITLE
Fix failures in hash aggregate tests

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -405,6 +405,7 @@ def test_hash_grpby_sum_full_decimal(data_gen, conf, kudo_enabled):
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b')),
         conf = new_conf)
 
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @approximate_float
 @datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/9822")
 @ignore_order
@@ -2437,6 +2438,7 @@ def test_hash_agg_force_pre_sort(cast_key_to, kudo_enabled):
             'spark.rapids.sql.agg.singlePassPartialSortEnabled': True,
             kudo_enabled_conf_key: kudo_enabled})
 
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @ignore_order(local=True)
 @pytest.mark.parametrize("gen", [
     binary_gen,
@@ -2487,6 +2489,8 @@ hash_agg_conf = {"spark.rapids.sql.foldLocalAggregate.enabled": 'true',
 sort_agg_conf = {"spark.rapids.sql.foldLocalAggregate.enabled": 'true',
                  "spark.sql.test.forceApplySortAggregate": 'true'}
 
+
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @ignore_order(local=True)
 @pytest.mark.skipif(is_databricks_runtime(), reason="This rule is not applied onto Databricks shims")
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
@@ -2539,6 +2543,7 @@ def test_fold_local_aggregate(spark_tmp_table_factory, aqe_enabled, agg_conf, ag
     assert_gpu_and_cpu_are_equal_collect(run_spark_fn, conf=run_conf)
 
 
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
 def test_hash_reduction_bitwise(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
@@ -2548,6 +2553,7 @@ def test_hash_reduction_bitwise(data_gen):
             "bit_xor(a)"))
 
 
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @ignore_order(local=True)
 @pytest.mark.parametrize('int_gen', integral_gens, ids=idfn)
 def test_hash_groupby_bitwise(int_gen):

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
@@ -42,7 +42,6 @@
 {"spark": "354"}
 {"spark": "355"}
 {"spark": "356"}
-{"spark": "400"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350db143"}
+{"spark": "400"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11018

There are two types of failures.

- GPU aggregates do not support ANSI mode. So disable the ansi mode for the these tests. (This feature requirement is tracked by https://github.com/NVIDIA/spark-rapids/issues/5114)
- Fail to find the `ApproximatePercentile` in a fallback check. The error log shows the root node is a `ResultQueryStageExec`, so map the 400 shim to the correct implementation of `extractExecutedPlan` which can extract the real plan from a `ResultQueryStageExec`. 


