### PR TITLE
Fix Spark400 failed cases in CastOpSuite [databricks]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -162,8 +162,6 @@ class CastOpSuite extends GpuExpressionTestSuite {
   }
 
   test("Cast from string to timestamp") {
-    // issue: https://github.com/NVIDIA/spark-rapids/issues/12019
-    assumePriorToSpark400
     testCastStringTo(DataTypes.TimestampType,
       timestampsAsStringsSeq(castStringToTimestamp = true, validOnly = false))
   }
@@ -263,8 +261,6 @@ class CastOpSuite extends GpuExpressionTestSuite {
   }
 
   test("Test all supported casts with in-range values") {
-    // issue: https://github.com/NVIDIA/spark-rapids/issues/12019
-    assumePriorToSpark400
     // test cast() and ansi_cast()
     Seq(false, true).foreach { ansiEnabled =>
 
@@ -1400,7 +1396,6 @@ object CastOpSuite {
     } else {
       Seq(
         "23:59:59.333666Z",
-        "T21:34:56.333666Z"
       )
     }
 


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/12019

Fix the following test cases:
- Cast from string to timestamp
This is fixed by https://github.com/NVIDIA/spark-rapids/pull/12824
- Test all supported casts with in-range values
The `T21:34:56.333666Z` will generate another case by prepend and postpend empty chars,  the related code:
```
val valuesWithWhitespace = values.map(s => s"\t\n\t$s\r\n")
```
And the `\t\n\tT21:34:56.333666Z\r\n` will trigger a different behavior described in [#12824](https://github.com/NVIDIA/spark-rapids/pull/12824):

Spark400 and 400+:
cast(`\t\n\tT21:34:56.333666Z\r\n` as timestamp) is invalid, throws exception on ANSI mode.
Other Spark:
cast(`\t\n\tT21:34:56.333666Z\r\n` as timestamp) is valid, case passes on ANSI mode.

So this test case can not fit all the Spark versions when ANSI is on, so remove this value `T21:34:56.333666Z`.
The Pytest already covers this kind of case, so do not need to add new cases in UT.


Signed-off-by: Chong Gao <res_life@163.com>