### PR TITLE
Update exception message for spark400 integration tests

### DIFF
--- a/integration_tests/src/main/python/misc_expr_test.py
+++ b/integration_tests/src/main/python/misc_expr_test.py
@@ -63,7 +63,7 @@ def raise_error_test_impl(test_conf):
         lambda spark: spark.range(0).select(f.raise_error(f.col("id"))),
         conf=test_conf)
 
-    error_fragment = "org.apache.spark.SparkRuntimeException" if use_new_error_semantics \
+    error_fragment = "SparkRuntimeException" if use_new_error_semantics \
       else "java.lang.RuntimeException"
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, null_gen, length=2, num_slices=1).select(


### PR DESCRIPTION
This contributes to https://github.com/NVIDIA/spark-rapids/issues/11004

In this PR, we update the expected error message for tests in Spark-4.0.

1. In  `misc_expr_test.py`, updated the error message to look for only Excpetion name and not the fully qualified name.
It will resolve below error.
```
test_raise_error_new_semantics[DATAGEN_SEED=1750693220, TZ=UTC] - AssertionError: Expected error 'org.apache.spark.SparkRuntimeException' did not appear in 'pyspark.errors.exceptions.captured.SparkRuntimeException: [USER_RAISED_EXCEPTION] null SQLSTATE: P0001'
```

2.  In `regexp_test.py`, updated the test to run the cpu and gpu tests separately and checking for the appropriate error message.


All the integration tests pass now with this fix:

```
=============================== 39075 passed, 2037 skipped, 494 xfailed, 786 xpassed, 16793 warnings
```