### PR TITLE
Ignore .mvn [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .generated-mima*
 .idea_modules/
 .idea/
+.mvn/
 .metals/
 .project
 .pydevproject


### PR DESCRIPTION
.mvn is typicall used to store project's maven settings, which is highly customizable in different developer's environment.