### PR TITLE
Set overflow rows to nulls when casting timestamps to integrals for Spark 400[databricks]

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -580,10 +580,6 @@ def test_cast_timestamp_to_numeric_ansi_no_overflow():
         conf=ansi_enabled_conf)
 
 
-@pytest.mark.skipif(is_databricks_runtime() and is_databricks_version_or_later(14, 3),
-                    reason="https://github.com/NVIDIA/spark-rapids/issues/11555")
-@pytest.mark.skipif(not is_databricks_runtime() and is_spark_400_or_later(),
-                    reason="https://github.com/NVIDIA/spark-rapids/issues/11555")
 def test_cast_timestamp_to_numeric_non_ansi():
     """
     Test timestamp->numeric conversions with ANSI off.

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+object CastTimeToIntShim {
+  // Whether to set overflow rows to nulls when casting timestamps to integrals.
+  def ifNullifyOverflows: Boolean = false
+}

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "350db143"}
+{"spark": "400"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+object CastTimeToIntShim {
+  // From 400, rows overflow will be set to nulls when casting timestamps to integrals.
+  def ifNullifyOverflows: Boolean = true
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -576,16 +576,14 @@ class CastOpSuite extends GpuExpressionTestSuite {
   }
 
   testSparkResultsAreEqual(
-    "Test cast from timestamp", timestampDatesMsecParquet,
-      assumeCondition = _ => (!isSpark400OrLater,
-        "Spark version not before 4.0.0, " +
-        "non-ansi issue: https://github.com/NVIDIA/spark-rapids/issues/12019," +
-        "ansi issue: https://github.com/NVIDIA/spark-rapids/issues/12714"))(timestampCastFn)
+    "Test cast from timestamp",
+    timestampDatesMsecParquet,
+    assumeCondition = spark =>
+      ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12714")(spark)
+  )(timestampCastFn)
 
   test("Test cast from timestamp in UTC-equivalent timezone") {
     skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/12714")
-    // issue: https://github.com/NVIDIA/spark-rapids/issues/12019
-    assumePriorToSpark400
     val oldtz = TimeZone.getDefault
     try {
       TimeZone.setDefault(TimeZone.getTimeZone("Etc/UTC-0"))


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11555
close https://github.com/NVIDIA/spark-rapids/issues/12966

Spark 400 will return nulls for overflow rows when casting timestamps to integrals and the ansi mode is disabled. But GPU will always return the overflow values, the same as Spark before 400.

This PR adds shims to support both of the behaviors according to the Spark version.
