### PR TITLE
Enable delta lake tests when TEST_MODE is DEFAULT 

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -201,11 +201,6 @@ run_delta_lake_tests() {
   fi
 
   if [[ $SPARK_VER =~ $SPARK_35X_PATTERN ]]; then
-    # We don't want the Delta Lake tests to run in DEFAULT mode for Spark 3.5.3 as 
-    # there are expected failures that may cause other pipelines to be blocked
-    if [[ $TEST_MODE == "DEFAULT" ]]; then
-      return 
-    fi
     DELTA_LAKE_VERSIONS="3.3.0"
   fi
 


### PR DESCRIPTION
Our nightly pipeline runs the delta lake tests with `TEST_MODE=DEFAULT` so we should remove this extra check to be able to run the pipeline. 

With all the Delta Lake 3.3.x tests xfailing we can turn on the CI/CD pipeline. 

fixes #12834 