### PR TITLE
enable rmm state log for troubleshooting 12883

### DIFF
--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -341,7 +341,7 @@ class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
     }
     // some tests need an event handler
     RmmSpark.setEventHandler(
-      new DeviceMemoryEventHandler(SpillFramework.stores.deviceStore, None, 0))
+      new DeviceMemoryEventHandler(SpillFramework.stores.deviceStore, None, 0), "STDERR")
     PinnedMemoryPool.shutdown()
     HostAlloc.initialize(-1)
   }


### PR DESCRIPTION
For now, we don't have many clues why the test case in #12883 fails intermitently in daily CI. I'm by default enabling RMM state transition log for the whole HostAllocSuite to provide more contexts.

I have already tried at local dev machine, this change will not increase log size too much, and it should only impact HostAllocSuite alone:

```
/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -javaagent:/home/hongbin/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/lib/idea_rt.jar=46573:/home/hongbin/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/bin -Dfile.encoding=UTF-8 -classpath /home/hongbin/.local/share/JetBrains/IntelliJIdea2024.3/Scala/lib/runners.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/charsets.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/cldrdata.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/dnsns.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/icedtea-sound.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/jaccess.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/java-atk-wrapper.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/localedata.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/nashorn.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/sunec.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/sunjce_provider.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/sunpkcs11.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/zipfs.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/jce.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/jfr.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/jsse.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/management-agent.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/resources.jar:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/rt.jar:/home/hongbin/code/spark-rapids2/sql-plugin/target/spark321/test-classes:/home/hongbin/code/spark-rapids2/sql-plugin/target/spark321/classes:/home/hongbin/.m2/repository/tools/profiler/async-profiler/4.0/async-profiler-4.0.jar:/home/hongbin/.m2/repository/com/nvidia/spark-rapids-jni/25.08.0-SNAPSHOT/spark-rapids-jni-25.08.0-20250621.040302-29-cuda12.jar:/home/hongbin/.m2/repository/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar:/home/hongbin/.m2/repository/com/nvidia/rapids-4-spark-private_2.12/25.08.0-SNAPSHOT/rapids-4-spark-private_2.12-25.08.0-20250622.030647-29-spark321.jar:/home/hongbin/code/spark-rapids2/sql-plugin-api/target/spark321/classes:/home/hongbin/.m2/repository/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest_2.12/3.2.16/scalatest_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-core_2.12/3.2.16/scalatest-core_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-compatible/3.2.16/scalatest-compatible-3.2.16.jar:/home/hongbin/.m2/repository/org/scalactic/scalactic_2.12/3.2.16/scalactic_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scala-lang/modules/scala-xml_2.12/2.1.0/scala-xml_2.12-2.1.0.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-featurespec_2.12/3.2.16/scalatest-featurespec_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-flatspec_2.12/3.2.16/scalatest-flatspec_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-freespec_2.12/3.2.16/scalatest-freespec_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-funsuite_2.12/3.2.16/scalatest-funsuite_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-funspec_2.12/3.2.16/scalatest-funspec_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-propspec_2.12/3.2.16/scalatest-propspec_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-refspec_2.12/3.2.16/scalatest-refspec_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-wordspec_2.12/3.2.16/scalatest-wordspec_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-diagrams_2.12/3.2.16/scalatest-diagrams_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-matchers-core_2.12/3.2.16/scalatest-matchers-core_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-shouldmatchers_2.12/3.2.16/scalatest-shouldmatchers_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scalatest/scalatest-mustmatchers_2.12/3.2.16/scalatest-mustmatchers_2.12-3.2.16.jar:/home/hongbin/.m2/repository/org/scala-lang/scala-reflect/2.12.17/scala-reflect-2.12.17.jar:/home/hongbin/.m2/repository/org/scalatestplus/mockito-4-11_2.12/3.2.16.0/mockito-4-11_2.12-3.2.16.0.jar:/home/hongbin/.m2/repository/com/google/flatbuffers/flatbuffers-java/1.11.0/flatbuffers-java-1.11.0.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-avro_2.12/3.2.1/spark-avro_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-tags_2.12/3.2.1/spark-tags_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/tukaani/xz/1.8/xz-1.8.jar:/home/hongbin/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar:/home/hongbin/.m2/repository/org/roaringbitmap/RoaringBitmap/1.0.6/RoaringBitmap-1.0.6.jar:/home/hongbin/.m2/repository/org/mockito/mockito-core/3.12.4/mockito-core-3.12.4.jar:/home/hongbin/.m2/repository/net/bytebuddy/byte-buddy/1.11.13/byte-buddy-1.11.13.jar:/home/hongbin/.m2/repository/net/bytebuddy/byte-buddy-agent/1.11.13/byte-buddy-agent-1.11.13.jar:/home/hongbin/.m2/repository/org/objenesis/objenesis/3.2/objenesis-3.2.jar:/home/hongbin/.m2/repository/com/nvidia/rapids-4-spark-hybrid_2.12/25.08.0-SNAPSHOT/rapids-4-spark-hybrid_2.12-25.08.0-20250622.024014-29.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-hive_2.12/3.2.1/spark-hive_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-core_2.12/3.2.1/spark-core_2.12-3.2.1.jar:/home/hongbin/.m2/repository/com/twitter/chill_2.12/0.10.0/chill_2.12-0.10.0.jar:/home/hongbin/.m2/repository/com/esotericsoftware/kryo-shaded/4.0.2/kryo-shaded-4.0.2.jar:/home/hongbin/.m2/repository/com/esotericsoftware/minlog/1.3.0/minlog-1.3.0.jar:/home/hongbin/.m2/repository/com/twitter/chill-java/0.10.0/chill-java-0.10.0.jar:/home/hongbin/.m2/repository/org/apache/hadoop/hadoop-client-api/3.3.1/hadoop-client-api-3.3.1.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-launcher_2.12/3.2.1/spark-launcher_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-kvstore_2.12/3.2.1/spark-kvstore_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-network-common_2.12/3.2.1/spark-network-common_2.12-3.2.1.jar:/home/hongbin/.m2/repository/com/google/crypto/tink/tink/1.6.0/tink-1.6.0.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-network-shuffle_2.12/3.2.1/spark-network-shuffle_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-unsafe_2.12/3.2.1/spark-unsafe_2.12-3.2.1.jar:/home/hongbin/.m2/repository/javax/activation/activation/1.1.1/activation-1.1.1.jar:/home/hongbin/.m2/repository/org/apache/curator/curator-recipes/2.13.0/curator-recipes-2.13.0.jar:/home/hongbin/.m2/repository/org/apache/curator/curator-framework/2.13.0/curator-framework-2.13.0.jar:/home/hongbin/.m2/repository/org/apache/curator/curator-client/2.13.0/curator-client-2.13.0.jar:/home/hongbin/.m2/repository/org/apache/zookeeper/zookeeper/3.6.2/zookeeper-3.6.2.jar:/home/hongbin/.m2/repository/org/apache/zookeeper/zookeeper-jute/3.6.2/zookeeper-jute-3.6.2.jar:/home/hongbin/.m2/repository/org/apache/yetus/audience-annotations/0.5.0/audience-annotations-0.5.0.jar:/home/hongbin/.m2/repository/jakarta/servlet/jakarta.servlet-api/4.0.3/jakarta.servlet-api-4.0.3.jar:/home/hongbin/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar:/home/hongbin/.m2/repository/org/apache/commons/commons-math3/3.4.1/commons-math3-3.4.1.jar:/home/hongbin/.m2/repository/org/apache/commons/commons-text/1.6/commons-text-1.6.jar:/home/hongbin/.m2/repository/commons-io/commons-io/2.8.0/commons-io-2.8.0.jar:/home/hongbin/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/home/hongbin/.m2/repository/org/slf4j/jul-to-slf4j/1.7.30/jul-to-slf4j-1.7.30.jar:/home/hongbin/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30.jar:/home/hongbin/.m2/repository/log4j/log4j/1.2.17/log4j-1.2.17.jar:/home/hongbin/.m2/repository/org/slf4j/slf4j-log4j12/1.7.30/slf4j-log4j12-1.7.30.jar:/home/hongbin/.m2/repository/com/ning/compress-lzf/1.0.3/compress-lzf-1.0.3.jar:/home/hongbin/.m2/repository/org/xerial/snappy/snappy-java/1.1.8.4/snappy-java-1.1.8.4.jar:/home/hongbin/.m2/repository/org/lz4/lz4-java/1.7.1/lz4-java-1.7.1.jar:/home/hongbin/.m2/repository/com/github/luben/zstd-jni/1.5.0-4/zstd-jni-1.5.0-4.jar:/home/hongbin/.m2/repository/commons-net/commons-net/3.1/commons-net-3.1.jar:/home/hongbin/.m2/repository/org/json4s/json4s-jackson_2.12/3.7.0-M11/json4s-jackson_2.12-3.7.0-M11.jar:/home/hongbin/.m2/repository/org/json4s/json4s-core_2.12/3.7.0-M11/json4s-core_2.12-3.7.0-M11.jar:/home/hongbin/.m2/repository/org/json4s/json4s-ast_2.12/3.7.0-M11/json4s-ast_2.12-3.7.0-M11.jar:/home/hongbin/.m2/repository/org/json4s/json4s-scalap_2.12/3.7.0-M11/json4s-scalap_2.12-3.7.0-M11.jar:/home/hongbin/.m2/repository/org/glassfish/jersey/core/jersey-client/2.34/jersey-client-2.34.jar:/home/hongbin/.m2/repository/jakarta/ws/rs/jakarta.ws.rs-api/2.1.6/jakarta.ws.rs-api-2.1.6.jar:/home/hongbin/.m2/repository/org/glassfish/hk2/external/jakarta.inject/2.6.1/jakarta.inject-2.6.1.jar:/home/hongbin/.m2/repository/org/glassfish/jersey/core/jersey-common/2.34/jersey-common-2.34.jar:/home/hongbin/.m2/repository/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar:/home/hongbin/.m2/repository/org/glassfish/hk2/osgi-resource-locator/1.0.3/osgi-resource-locator-1.0.3.jar:/home/hongbin/.m2/repository/org/glassfish/jersey/core/jersey-server/2.34/jersey-server-2.34.jar:/home/hongbin/.m2/repository/jakarta/validation/jakarta.validation-api/2.0.2/jakarta.validation-api-2.0.2.jar:/home/hongbin/.m2/repository/org/glassfish/jersey/containers/jersey-container-servlet/2.34/jersey-container-servlet-2.34.jar:/home/hongbin/.m2/repository/org/glassfish/jersey/containers/jersey-container-servlet-core/2.34/jersey-container-servlet-core-2.34.jar:/home/hongbin/.m2/repository/org/glassfish/jersey/inject/jersey-hk2/2.34/jersey-hk2-2.34.jar:/home/hongbin/.m2/repository/org/glassfish/hk2/hk2-locator/2.6.1/hk2-locator-2.6.1.jar:/home/hongbin/.m2/repository/org/glassfish/hk2/external/aopalliance-repackaged/2.6.1/aopalliance-repackaged-2.6.1.jar:/home/hongbin/.m2/repository/org/glassfish/hk2/hk2-api/2.6.1/hk2-api-2.6.1.jar:/home/hongbin/.m2/repository/org/glassfish/hk2/hk2-utils/2.6.1/hk2-utils-2.6.1.jar:/home/hongbin/.m2/repository/org/javassist/javassist/3.25.0-GA/javassist-3.25.0-GA.jar:/home/hongbin/.m2/repository/io/netty/netty-all/4.1.68.Final/netty-all-4.1.68.Final.jar:/home/hongbin/.m2/repository/com/clearspring/analytics/stream/2.9.6/stream-2.9.6.jar:/home/hongbin/.m2/repository/io/dropwizard/metrics/metrics-core/4.2.0/metrics-core-4.2.0.jar:/home/hongbin/.m2/repository/io/dropwizard/metrics/metrics-jvm/4.2.0/metrics-jvm-4.2.0.jar:/home/hongbin/.m2/repository/io/dropwizard/metrics/metrics-json/4.2.0/metrics-json-4.2.0.jar:/home/hongbin/.m2/repository/io/dropwizard/metrics/metrics-graphite/4.2.0/metrics-graphite-4.2.0.jar:/home/hongbin/.m2/repository/io/dropwizard/metrics/metrics-jmx/4.2.0/metrics-jmx-4.2.0.jar:/home/hongbin/.m2/repository/com/fasterxml/jackson/module/jackson-module-scala_2.12/2.12.3/jackson-module-scala_2.12-2.12.3.jar:/home/hongbin/.m2/repository/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8.jar:/home/hongbin/.m2/repository/org/apache/ivy/ivy/2.5.0/ivy-2.5.0.jar:/home/hongbin/.m2/repository/oro/oro/2.0.8/oro-2.0.8.jar:/home/hongbin/.m2/repository/net/razorvine/pyrolite/4.30/pyrolite-4.30.jar:/home/hongbin/.m2/repository/net/sf/py4j/py4j/0.10.9.3/py4j-0.10.9.3.jar:/home/hongbin/.m2/repository/org/apache/commons/commons-crypto/1.1.0/commons-crypto-1.1.0.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-common/2.3.9/hive-common-2.3.9.jar:/home/hongbin/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/home/hongbin/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/home/hongbin/.m2/repository/jline/jline/2.12/jline-2.12.jar:/home/hongbin/.m2/repository/org/apache/commons/commons-compress/1.9/commons-compress-1.9.jar:/home/hongbin/.m2/repository/com/tdunning/json/1.8/json-1.8.jar:/home/hongbin/.m2/repository/com/github/joshelser/dropwizard-metrics-hadoop-metrics2-reporter/0.1.2/dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9-core.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-vector-code-gen/2.3.9/hive-vector-code-gen-2.3.9.jar:/home/hongbin/.m2/repository/com/google/guava/guava/14.0.1/guava-14.0.1.jar:/home/hongbin/.m2/repository/org/apache/velocity/velocity/1.5/velocity-1.5.jar:/home/hongbin/.m2/repository/org/antlr/antlr-runtime/3.5.2/antlr-runtime-3.5.2.jar:/home/hongbin/.m2/repository/org/antlr/ST4/4.0.4/ST4-4.0.4.jar:/home/hongbin/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/home/hongbin/.m2/repository/stax/stax-api/1.0.1/stax-api-1.0.1.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-metastore/2.3.9/hive-metastore-2.3.9.jar:/home/hongbin/.m2/repository/javolution/javolution/5.5.1/javolution-5.5.1.jar:/home/hongbin/.m2/repository/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar:/home/hongbin/.m2/repository/com/jolbox/bonecp/0.8.0.RELEASE/bonecp-0.8.0.RELEASE.jar:/home/hongbin/.m2/repository/com/zaxxer/HikariCP/2.5.1/HikariCP-2.5.1.jar:/home/hongbin/.m2/repository/org/datanucleus/datanucleus-api-jdo/4.2.4/datanucleus-api-jdo-4.2.4.jar:/home/hongbin/.m2/repository/org/datanucleus/datanucleus-rdbms/4.1.19/datanucleus-rdbms-4.1.19.jar:/home/hongbin/.m2/repository/commons-pool/commons-pool/1.5.4/commons-pool-1.5.4.jar:/home/hongbin/.m2/repository/commons-dbcp/commons-dbcp/1.4/commons-dbcp-1.4.jar:/home/hongbin/.m2/repository/javax/jdo/jdo-api/3.0.1/jdo-api-3.0.1.jar:/home/hongbin/.m2/repository/javax/transaction/jta/1.1/jta-1.1.jar:/home/hongbin/.m2/repository/org/datanucleus/javax.jdo/3.2.0-m3/javax.jdo-3.2.0-m3.jar:/home/hongbin/.m2/repository/javax/transaction/transaction-api/1.1/transaction-api-1.1.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-serde/2.3.9/hive-serde-2.3.9.jar:/home/hongbin/.m2/repository/net/sf/opencsv/opencsv/2.3/opencsv-2.3.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-shims/2.3.9/hive-shims-2.3.9.jar:/home/hongbin/.m2/repository/org/apache/hive/shims/hive-shims-common/2.3.9/hive-shims-common-2.3.9.jar:/home/hongbin/.m2/repository/org/apache/hive/shims/hive-shims-0.23/2.3.9/hive-shims-0.23-2.3.9.jar:/home/hongbin/.m2/repository/org/apache/hive/shims/hive-shims-scheduler/2.3.9/hive-shims-scheduler-2.3.9.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-llap-common/2.3.9/hive-llap-common-2.3.9.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-llap-client/2.3.9/hive-llap-client-2.3.9.jar:/home/hongbin/.m2/repository/org/apache/avro/avro/1.10.2/avro-1.10.2.jar:/home/hongbin/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.2/jackson-core-2.12.2.jar:/home/hongbin/.m2/repository/org/apache/avro/avro-mapred/1.10.2/avro-mapred-1.10.2.jar:/home/hongbin/.m2/repository/org/apache/avro/avro-ipc/1.10.2/avro-ipc-1.10.2.jar:/home/hongbin/.m2/repository/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar:/home/hongbin/.m2/repository/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar:/home/hongbin/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar:/home/hongbin/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/home/hongbin/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/home/hongbin/.m2/repository/commons-codec/commons-codec/1.15/commons-codec-1.15.jar:/home/hongbin/.m2/repository/joda-time/joda-time/2.10.10/joda-time-2.10.10.jar:/home/hongbin/.m2/repository/org/jodd/jodd-core/3.5.2/jodd-core-3.5.2.jar:/home/hongbin/.m2/repository/com/google/code/findbugs/jsr305/3.0.0/jsr305-3.0.0.jar:/home/hongbin/.m2/repository/org/datanucleus/datanucleus-core/4.1.17/datanucleus-core-4.1.17.jar:/home/hongbin/.m2/repository/org/apache/hadoop/hadoop-client-runtime/3.3.1/hadoop-client-runtime-3.3.1.jar:/home/hongbin/.m2/repository/org/apache/htrace/htrace-core4/4.1.0-incubating/htrace-core4-4.1.0-incubating.jar:/home/hongbin/.m2/repository/org/apache/thrift/libthrift/0.12.0/libthrift-0.12.0.jar:/home/hongbin/.m2/repository/org/apache/thrift/libfb303/0.9.3/libfb303-0.9.3.jar:/home/hongbin/.m2/repository/org/apache/derby/derby/10.14.2.0/derby-10.14.2.0.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-sql_2.12/3.2.1/spark-sql_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/rocksdb/rocksdbjni/6.20.3/rocksdbjni-6.20.3.jar:/home/hongbin/.m2/repository/com/univocity/univocity-parsers/2.9.1/univocity-parsers-2.9.1.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-sketch_2.12/3.2.1/spark-sketch_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/apache/spark/spark-catalyst_2.12/3.2.1/spark-catalyst_2.12-3.2.1.jar:/home/hongbin/.m2/repository/org/scala-lang/modules/scala-parser-combinators_2.12/1.1.2/scala-parser-combinators_2.12-1.1.2.jar:/home/hongbin/.m2/repository/org/codehaus/janino/janino/3.0.16/janino-3.0.16.jar:/home/hongbin/.m2/repository/org/codehaus/janino/commons-compiler/3.0.16/commons-compiler-3.0.16.jar:/home/hongbin/.m2/repository/org/antlr/antlr4-runtime/4.8/antlr4-runtime-4.8.jar:/home/hongbin/.m2/repository/javax/xml/bind/jaxb-api/2.2.11/jaxb-api-2.2.11.jar:/home/hongbin/.m2/repository/org/apache/arrow/arrow-vector/2.0.0/arrow-vector-2.0.0.jar:/home/hongbin/.m2/repository/org/apache/arrow/arrow-format/2.0.0/arrow-format-2.0.0.jar:/home/hongbin/.m2/repository/org/apache/arrow/arrow-memory-core/2.0.0/arrow-memory-core-2.0.0.jar:/home/hongbin/.m2/repository/org/apache/arrow/arrow-memory-netty/2.0.0/arrow-memory-netty-2.0.0.jar:/home/hongbin/.m2/repository/org/apache/orc/orc-core/1.6.12/orc-core-1.6.12.jar:/home/hongbin/.m2/repository/org/apache/orc/orc-shims/1.6.12/orc-shims-1.6.12.jar:/home/hongbin/.m2/repository/io/airlift/aircompressor/0.21/aircompressor-0.21.jar:/home/hongbin/.m2/repository/org/jetbrains/annotations/17.0.0/annotations-17.0.0.jar:/home/hongbin/.m2/repository/org/threeten/threeten-extra/1.5.0/threeten-extra-1.5.0.jar:/home/hongbin/.m2/repository/org/apache/orc/orc-mapreduce/1.6.12/orc-mapreduce-1.6.12.jar:/home/hongbin/.m2/repository/org/apache/hive/hive-storage-api/2.7.2/hive-storage-api-2.7.2.jar:/home/hongbin/.m2/repository/org/apache/parquet/parquet-column/1.12.2/parquet-column-1.12.2.jar:/home/hongbin/.m2/repository/org/apache/parquet/parquet-common/1.12.2/parquet-common-1.12.2.jar:/home/hongbin/.m2/repository/org/apache/parquet/parquet-encoding/1.12.2/parquet-encoding-1.12.2.jar:/home/hongbin/.m2/repository/org/apache/parquet/parquet-hadoop/1.12.2/parquet-hadoop-1.12.2.jar:/home/hongbin/.m2/repository/org/apache/parquet/parquet-format-structures/1.12.2/parquet-format-structures-1.12.2.jar:/home/hongbin/.m2/repository/org/apache/parquet/parquet-jackson/1.12.2/parquet-jackson-1.12.2.jar:/home/hongbin/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.3/jackson-databind-2.12.3.jar:/home/hongbin/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.3/jackson-annotations-2.12.3.jar:/home/hongbin/.m2/repository/org/apache/xbean/xbean-asm9-shaded/4.20/xbean-asm9-shaded-4.20.jar org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner -s com.nvidia.spark.rapids.HostAllocSuite -showProgressMessages true
Testing started at 2:24 pm ...


time,op,current thread,op thread,op task,from state,to state,notes

14:24:52.600268,DEALLOC,128636161197632,128636161197632,-2,UNKNOWN,,
[3482078][14:24:52:600848][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 4.000000 KiB, 4.000000 KiB, 256.000000 B]
14:24:52.604806,DEALLOC,128636161197632,128636161197632,-2,UNKNOWN,,

time,op,current thread,op thread,op task,from state,to state,notes
14:24:53.617559,DEALLOC,128636161197632,128636161197632,-2,UNKNOWN,,
[3482078][14:24:53:617614][error ] [A][Stream 0x1][Upstream 4096B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 4.000000 KiB]

[3482078][14:24:53:618095][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 256.000000 B]
14:24:53.618701,DEALLOC,128636161197632,128636161197632,-2,UNKNOWN,,

time,op,current thread,op thread,op task,from state,to state,notes

14:24:54.628169,DEALLOC,128636161197632,128636161197632,-2,UNKNOWN,,
[3482078][14:24:54:628665][error ] [A][Stream 0x1][Upstream 4096B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 4.000000 KiB, 4.000000 KiB, 4.000000 KiB]
[3482078][14:24:54:629030][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 4.000000 KiB, 4.000000 KiB, 256.000000 B]
14:24:54.629593,DEALLOC,128636161197632,128636161197632,-2,UNKNOWN,,
14:24:54.629698,DEALLOC,128636161197632,128636161197632,-2,UNKNOWN,,

time,op,current thread,op thread,op task,from state,to state,notes

14:24:55.879717,TRANSITION,128634317698624,128634317698624,1,UNKNOWN,THREAD_RUNNING,
14:24:55.937766,TRANSITION,128634315601472,128634315601472,2,UNKNOWN,THREAD_RUNNING,
14:24:55.972553,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,THREAD_ALLOC,
14:24:55.972841,TRANSITION,128634317698624,128634317698624,1,THREAD_ALLOC,THREAD_RUNNING,
14:24:55.974377,DEALLOC,128634317698624,128634317698624,1,THREAD_RUNNING,,
14:24:55.975164,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,THREAD_ALLOC,
14:24:55.975279,TRANSITION,128634317698624,128634317698624,1,THREAD_ALLOC,THREAD_RUNNING,
14:24:55.977183,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
[3482371][14:24:55:977267][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 4.000000 KiB, 4.000000 KiB, 256.000000 B]
14:24:55.977515,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_BLOCKED,
14:24:55.977531,WAITING,128634315601472,128634315601472,2,THREAD_BLOCKED,,
14:24:55.987434,DEALLOC,128634317698624,128634317698624,1,THREAD_RUNNING,,
14:24:55.987440,TRANSITION,128634317698624,128634315601472,2,THREAD_BLOCKED,THREAD_RUNNING,
14:24:55.987455,DONE WAITING,128634315601472,128634315601472,2,THREAD_RUNNING,,
14:24:55.987457,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
14:24:55.987670,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_RUNNING,
14:24:55.988095,DEALLOC,128634315601472,128634315601472,2,THREAD_RUNNING,,
14:24:55.988306,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,UNKNOWN,
14:24:55.988358,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,UNKNOWN,

time,op,current thread,op thread,op task,from state,to state,notes

14:24:56.997235,TRANSITION,128634315601472,128634315601472,1,UNKNOWN,THREAD_RUNNING,
14:24:56.998660,TRANSITION,128634317698624,128634317698624,2,UNKNOWN,THREAD_RUNNING,
14:24:56.998832,TRANSITION,128634315601472,128634315601472,1,THREAD_RUNNING,THREAD_ALLOC,
14:24:56.999038,TRANSITION,128634315601472,128634315601472,1,THREAD_ALLOC,THREAD_RUNNING,
14:24:56.999427,DEALLOC,128634315601472,128634315601472,1,THREAD_RUNNING,,
14:24:56.999601,TRANSITION,128634315601472,128634315601472,1,THREAD_RUNNING,THREAD_ALLOC,
[3482387][14:24:56:999623][error ] [A][Stream 0x1][Upstream 4096B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 4.000000 KiB]
14:24:56.999753,TRANSITION,128634315601472,128634315601472,1,THREAD_ALLOC,THREAD_RUNNING,
14:24:57.000235,TRANSITION,128634317698624,128634317698624,2,THREAD_RUNNING,THREAD_ALLOC,
[3482388][14:24:57:000374][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 256.000000 B]
14:24:57.000509,TRANSITION,128634317698624,128634317698624,2,THREAD_ALLOC,THREAD_BLOCKED,
14:24:57.000521,WAITING,128634317698624,128634317698624,2,THREAD_BLOCKED,,
14:24:57.010612,DEALLOC,128634315601472,128634315601472,1,THREAD_RUNNING,,
14:24:57.010617,TRANSITION,128634315601472,128634317698624,2,THREAD_BLOCKED,THREAD_RUNNING,
14:24:57.010631,DONE WAITING,128634317698624,128634317698624,2,THREAD_RUNNING,,
14:24:57.010637,TRANSITION,128634317698624,128634317698624,2,THREAD_RUNNING,THREAD_ALLOC,
[3482388][14:24:57:010654][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 256.000000 B]
14:24:57.010904,TRANSITION,128634317698624,128634317698624,2,THREAD_ALLOC,THREAD_RUNNING,
14:24:57.011334,DEALLOC,128634317698624,128634317698624,2,THREAD_RUNNING,,
14:24:57.011398,TRANSITION,128634315601472,128634315601472,1,THREAD_RUNNING,UNKNOWN,
14:24:57.011437,TRANSITION,128634317698624,128634317698624,2,THREAD_RUNNING,UNKNOWN,

time,op,current thread,op thread,op task,from state,to state,notes

14:24:58.019242,TRANSITION,128634317698624,128634317698624,1,UNKNOWN,THREAD_RUNNING,
14:24:58.020276,TRANSITION,128634315601472,128634315601472,2,UNKNOWN,THREAD_RUNNING,
14:24:58.021927,TRANSITION,128634313504320,128634313504320,3,UNKNOWN,THREAD_RUNNING,
14:24:58.022095,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,THREAD_ALLOC,
14:24:58.022294,TRANSITION,128634317698624,128634317698624,1,THREAD_ALLOC,THREAD_RUNNING,
14:24:58.023120,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
14:24:58.023282,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_RUNNING,
14:24:58.023902,TRANSITION,128634313504320,128634313504320,3,THREAD_RUNNING,THREAD_ALLOC,
[3482414][14:24:58:024095][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 4.000000 KiB, 4.000000 KiB, 256.000000 B]
14:24:58.024234,TRANSITION,128634313504320,128634313504320,3,THREAD_ALLOC,THREAD_BLOCKED,
14:24:58.024249,WAITING,128634313504320,128634313504320,3,THREAD_BLOCKED,,
14:24:58.024414,DEALLOC,128634317698624,128634317698624,1,THREAD_RUNNING,,
14:24:58.024419,TRANSITION,128634317698624,128634313504320,3,THREAD_BLOCKED,THREAD_RUNNING,
14:24:58.024427,DONE WAITING,128634313504320,128634313504320,3,THREAD_RUNNING,,
14:24:58.024429,TRANSITION,128634313504320,128634313504320,3,THREAD_RUNNING,THREAD_ALLOC,
14:24:58.024579,TRANSITION,128634313504320,128634313504320,3,THREAD_ALLOC,THREAD_RUNNING,
14:24:58.024919,DEALLOC,128634313504320,128634313504320,3,THREAD_RUNNING,,
14:24:58.025060,DEALLOC,128634315601472,128634315601472,2,THREAD_RUNNING,,
14:24:58.025120,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,UNKNOWN,
14:24:58.025230,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,UNKNOWN,
14:24:58.025331,TRANSITION,128634313504320,128634313504320,3,THREAD_RUNNING,UNKNOWN,

time,op,current thread,op thread,op task,from state,to state,notes

14:24:59.034269,TRANSITION,128634313504320,128634313504320,1,UNKNOWN,THREAD_RUNNING,
14:24:59.035246,TRANSITION,128634315601472,128634315601472,2,UNKNOWN,THREAD_RUNNING,
14:24:59.035412,TRANSITION,128634313504320,128634313504320,1,THREAD_RUNNING,THREAD_ALLOC,
14:24:59.035617,TRANSITION,128634313504320,128634313504320,1,THREAD_ALLOC,THREAD_RUNNING,
14:24:59.040454,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
[3482433][14:24:59:040554][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 4.000000 KiB, 4.000000 KiB, 256.000000 B]

14:24:59.069554,DEALLOC,128634315601472,128634315601472,2,THREAD_ALLOC,,
14:24:59.070031,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_RUNNING,
14:24:59.070432,DEALLOC,128634315601472,128634315601472,2,THREAD_RUNNING,,
14:24:59.071158,TRANSITION,128634313504320,128634313504320,1,THREAD_RUNNING,UNKNOWN,
14:24:59.071199,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,UNKNOWN,
time,op,current thread,op thread,op task,from state,to state,notes
14:25:00.077956,TRANSITION,128634315601472,128634315601472,1,UNKNOWN,THREAD_RUNNING,

14:25:00.079052,TRANSITION,128634313504320,128634313504320,2,UNKNOWN,THREAD_RUNNING,
14:25:00.079198,TRANSITION,128634315601472,128634315601472,1,THREAD_RUNNING,THREAD_ALLOC,
[3482557][14:25:00:079227][error ] [A][Stream 0x1][Upstream 4096B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 4.000000 KiB]
14:25:00.079457,TRANSITION,128634315601472,128634315601472,1,THREAD_ALLOC,THREAD_RUNNING,
14:25:00.080834,TRANSITION,128634313504320,128634313504320,2,THREAD_RUNNING,THREAD_ALLOC,
[3482558][14:25:00:080985][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 256.000000 B]

14:25:00.082646,DEALLOC,128634313504320,128634313504320,2,THREAD_ALLOC,,
[3482558][14:25:00:082741][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 256.000000 B]
14:25:00.082844,TRANSITION,128634313504320,128634313504320,2,THREAD_ALLOC,THREAD_RUNNING,
14:25:00.083538,DEALLOC,128634313504320,128634313504320,2,THREAD_RUNNING,,
14:25:00.083779,TRANSITION,128634315601472,128634315601472,1,THREAD_RUNNING,UNKNOWN,
14:25:00.083945,TRANSITION,128634313504320,128634313504320,2,THREAD_RUNNING,UNKNOWN,

time,op,current thread,op thread,op task,from state,to state,notes
14:25:01.092054,TRANSITION,128634313504320,128634313504320,1,UNKNOWN,THREAD_RUNNING,
14:25:01.093654,TRANSITION,128634315601472,128634315601472,2,UNKNOWN,THREAD_RUNNING,
14:25:01.094616,TRANSITION,128634317698624,128634317698624,3,UNKNOWN,THREAD_RUNNING,
14:25:01.094756,TRANSITION,128634313504320,128634313504320,1,THREAD_RUNNING,THREAD_ALLOC,
14:25:01.094943,TRANSITION,128634313504320,128634313504320,1,THREAD_ALLOC,THREAD_RUNNING,
14:25:01.095481,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
14:25:01.095647,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_RUNNING,
14:25:01.095984,TRANSITION,128634317698624,128634317698624,3,THREAD_RUNNING,THREAD_ALLOC,
[3482577][14:25:01:096099][error ] [A][Stream 0x1][Upstream 256B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 4.000000 KiB, 4.000000 KiB, 256.000000 B]
14:25:01.097632,DEALLOC,128634317698624,128634317698624,3,THREAD_ALLOC,,
14:25:01.097802,TRANSITION,128634317698624,128634317698624,3,THREAD_ALLOC,THREAD_RUNNING,
14:25:01.098042,DEALLOC,128634317698624,128634317698624,3,THREAD_RUNNING,,
14:25:01.098185,DEALLOC,128634315601472,128634315601472,2,THREAD_RUNNING,,
14:25:01.098598,TRANSITION,128634313504320,128634313504320,1,THREAD_RUNNING,UNKNOWN,
14:25:01.098706,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,UNKNOWN,
14:25:01.098865,TRANSITION,128634317698624,128634317698624,3,THREAD_RUNNING,UNKNOWN,

time,op,current thread,op thread,op task,from state,to state,notes

14:25:02.105815,TRANSITION,128634317698624,128634317698624,1,UNKNOWN,THREAD_RUNNING,
14:25:02.107369,TRANSITION,128634315601472,128634315601472,2,UNKNOWN,THREAD_RUNNING,
14:25:02.108504,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
[3482598][14:25:02:108533][error ] [A][Stream 0x1][Upstream 1024B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 1024.000000 B]
14:25:02.108815,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,THREAD_ALLOC,
[3482597][14:25:02:109067][error ] [A][Stream 0x1][Upstream 1024B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 1024.000000 B]
14:25:02.109089,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_RUNNING,
14:25:02.109257,TRANSITION,128634317698624,128634317698624,1,THREAD_ALLOC,THREAD_RUNNING,
14:25:02.201736,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.201747,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:02.301881,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.301893,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:02.402009,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.402021,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:02.502146,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.502161,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:02.602279,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.602293,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:02.702400,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.702413,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:02.802525,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.802537,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:02.902650,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:02.902660,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:03.002770,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:03.002787,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:03.102893,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {1,2} (2), threads: {128634315601472,128634317698624} (2)
14:25:03.102902,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 2
14:25:03.110118,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,THREAD_ALLOC,
[3482597][14:25:03:110143][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
14:25:03.110192,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
[3482598][14:25:03:110238][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:110803][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:110898][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:110949][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:110996][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:111046][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:111075][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:111128][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:111156][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:111215][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:111253][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:111298][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:111340][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:111383][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:111418][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:111461][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:111499][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482598][14:25:03:111552][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
[3482597][14:25:03:111595][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
14:25:03.111643,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_BLOCKED,
14:25:03.111663,WAITING,128634315601472,128634315601472,2,THREAD_BLOCKED,,
14:25:03.111693,TRANSITION,128634317698624,128634317698624,1,THREAD_ALLOC,THREAD_BLOCKED,
14:25:03.111702,DETAIL,128634317698624,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {} (0), threads: {128634315601472,128634317698624} (2)
14:25:03.111714,DETAIL,128634317698624,-1,-1,UNKNOWN,,States of all threads: thread_id: 128634315601472, task_id: 2, state: THREAD_BLOCKED, is_for_shuffle: 0, pool_blocked: 0, is_cpu_alloc: 1, is_retry_alloc_before_bufn: 0;thread_id: 128634317698624, task_id: 1, state: THREAD_BLOCKED, is_for_shuffle: 0, pool_blocked: 0, is_cpu_alloc: 1, is_retry_alloc_before_bufn: 0
14:25:03.111718,TRANSITION,128634317698624,128634315601472,2,THREAD_BLOCKED,THREAD_BUFN_THROW,
14:25:03.111727,WAITING,128634317698624,128634317698624,1,THREAD_BLOCKED,,
14:25:03.111730,TRANSITION,128634315601472,128634315601472,2,THREAD_BUFN_THROW,THREAD_BUFN_WAIT,
14:25:03.114519,TRANSITION,128634315601472,128634315601472,2,THREAD_BUFN_WAIT,THREAD_BUFN,
14:25:03.114532,DETAIL,128634315601472,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {1,2} (2), blocked_task_ids: {1,2} (2), bufn_task_ids: {2} (1), threads: {128634315601472,128634317698624} (2)
14:25:03.114536,DETAIL,128634315601472,128634317698624,1,THREAD_BLOCKED,,thread (id: 128634317698624) is_retry_alloc_before_bufn set to true
14:25:03.114537,TRANSITION,128634315601472,128634317698624,1,THREAD_BLOCKED,THREAD_RUNNING,
14:25:03.114541,WAITING,128634315601472,128634315601472,2,THREAD_BUFN,,
14:25:03.114548,DONE WAITING,128634317698624,128634317698624,1,THREAD_RUNNING,,
14:25:03.114550,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,THREAD_ALLOC,
[3482597][14:25:03:114561][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
14:25:03.116111,DEALLOC,128634317698624,128634317698624,1,THREAD_ALLOC,,
[3482597][14:25:03:116221][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
14:25:03.116340,DETAIL,128634317698624,128634317698624,1,THREAD_ALLOC,,thread (id: 128634317698624) is_retry_alloc_before_bufn set to false in post_alloc_success_core
14:25:03.116344,TRANSITION,128634317698624,128634317698624,1,THREAD_ALLOC,THREAD_RUNNING,
14:25:03.116835,DEALLOC,128634317698624,128634317698624,1,THREAD_RUNNING,,
14:25:03.117260,DEALLOC,128634317698624,128634317698624,1,THREAD_RUNNING,,
14:25:03.117312,TRANSITION,128634317698624,128634317698624,1,THREAD_RUNNING,UNKNOWN,
14:25:03.117314,TRANSITION,128634317698624,128634315601472,2,THREAD_BUFN,THREAD_RUNNING,
14:25:03.117327,DONE WAITING,128634315601472,128634315601472,2,THREAD_RUNNING,,
14:25:03.117470,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
[3482598][14:25:03:117485][error ] [A][Stream 0x1][Upstream 1024B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 1024.000000 B]
14:25:03.117771,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_RUNNING,
14:25:03.203001,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.203012,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:03.303124,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.303151,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:03.403262,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.403273,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:03.503400,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.503415,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:03.603547,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.603565,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:03.703670,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.703684,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:03.803779,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.803790,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:03.903896,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:03.903911,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:04.004034,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:04.004051,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1
14:25:04.104152,DETAIL,128634316650048,-1,-1,UNKNOWN,,deadlock state is reached with all_task_ids: {2} (1), blocked_task_ids: {2} (1), bufn_task_ids: {2} (1), threads: {128634315601472} (1)
14:25:04.104163,DETAIL,128634316650048,-1,-1,UNKNOWN,,all_bufn state is reached with all_task_ids size: 1

14:25:04.117988,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,THREAD_ALLOC,
[3482598][14:25:04:118033][error ] [A][Stream 0x1][Upstream 9216B][FAILURE maximum pool size exceeded: Not enough room to grow, current/max/try size = 0.000000 B, 0.000000 B, 9.000000 KiB]
14:25:04.118469,TRANSITION,128634315601472,128634315601472,2,THREAD_ALLOC,THREAD_RUNNING,
14:25:04.118955,DEALLOC,128634315601472,128634315601472,2,THREAD_RUNNING,,
14:25:04.119013,TRANSITION,128634315601472,128634315601472,2,THREAD_RUNNING,UNKNOWN,


Process finished with exit code 0

```