### PR TITLE
Align the exception message with that of Spark for casting to Decimals

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -210,7 +210,6 @@ def test_with_ansi_disabled_cast_decimal_to_decimal(data_gen, to_type):
             lambda spark : unary_op_df(spark, data_gen).select(f.col('a').cast(to_type), f.col('a')))
 
 
-@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/11550")
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/10050')
 @pytest.mark.parametrize('data_gen', [
     DecimalGen(3, 0)], ids=meta_idfn('from:'))
@@ -220,7 +219,7 @@ def test_ansi_cast_failures_decimal_to_decimal(data_gen, to_type):
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, data_gen).select(f.col('a').cast(to_type), f.col('a')).collect(),
         conf=ansi_enabled_conf,
-        error_message="overflow occurred")
+        error_message="cannot be represented as Decimal")
 
 
 @pytest.mark.parametrize('data_gen', [byte_gen, short_gen, int_gen, long_gen], ids=idfn)
@@ -240,14 +239,14 @@ def test_cast_integral_to_decimal_ansi_off(data_gen, to_type):
         conf=ansi_disabled_conf)
 
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/11550")
-@pytest.mark.parametrize('data_gen', [long_gen], ids=idfn)
+@pytest.mark.parametrize('data_gen', [LongGen(min_val=100)], ids=idfn)
 @pytest.mark.parametrize('to_type', [DecimalType(2, 0)], ids=idfn)
 def test_cast_integral_to_decimal_ansi_on(data_gen, to_type):
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen).select(
-                f.col('a').cast(to_type)),
-        conf=ansi_enabled_conf)
+    assert_gpu_and_cpu_error(
+        lambda spark: unary_op_df(spark, data_gen).select(f.col('a').cast(to_type)).collect(),
+        conf=ansi_enabled_conf,
+        error_message="cannot be represented as Decimal")
+
 
 def test_cast_byte_to_decimal_overflow():
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
@@ -47,6 +47,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 object CastTimeToIntShim {
-  // Whether to set overflow rows to nulls when casting timestamps to integrals.
+  // Whether to set overflow rows to nulls when casting timestamps to integrals,
+  // when ANSI is disabled.
   def ifNullifyOverflows: Boolean = false
 }

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/CastTimeToIntShim.scala
@@ -20,6 +20,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 object CastTimeToIntShim {
-  // From 400, rows overflow will be set to nulls when casting timestamps to integrals.
+  // From 400, rows overflow will be set to nulls when casting timestamps to integrals,
+  // when ANSI is disabled.
   def ifNullifyOverflows: Boolean = true
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -877,6 +877,10 @@ class CastOpSuite extends GpuExpressionTestSuite {
       precision: Int,
       scale: Int): Unit = {
       // Catch out of range exception when AnsiMode is on
+      val errMsg = dataType match {
+        case DataTypes.DoubleType | DataTypes.FloatType => GpuCast.OVERFLOW_MESSAGE
+        case _ => "cannot be represented as Decimal"
+      }
       assert(
         exceptionContains(
           if (isSpark400OrLater) {
@@ -894,7 +898,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
               nonOverflowCase(dataType, generator, precision, scale)
             }
           },
-        GpuCast.OVERFLOW_MESSAGE)
+          errMsg)
       )
       // Compare gpu results with cpu ones when AnsiMode is off (most of them should be null)
       testCastToDecimal(dataType,


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/11550

This PR changes the exception message to align with that of Spark for casting intergals or decimals to decimals when the ansi mode is on.

This issue also exists when casting floats to decimals, but this is likely to request the support from JNI. So it is not covered in this PR.