### PR TITLE
Some missing changes for CTAS and RTAS for Delta Lake 3.3.x

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -209,11 +209,11 @@ def _atomic_write_table_as_select(gens, spark_tmp_table_factory, spark_tmp_path,
         if overwrite:
             writer = writer.mode("overwrite")
         writer.saveAsTable(table)
-    assert_gpu_and_cpu_writes_are_equal_collect(
-        do_write,
-        lambda spark, path: spark.read.format("delta").table(path_to_table[path]),
-        data_path,
-        conf=confs)
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            do_write,
+            lambda spark, path: spark.read.format("delta").table(path_to_table[path]),
+            data_path,
+            conf=confs)
 
 @allow_non_gpu('DataWritingCommandExec', 'WriteFilesExec', *delta_meta_allow)
 @delta_lake


### PR DESCRIPTION
Some changes were missed in #12990

There were some execs that were being allowed to fallback to the CPU even though the code to check the fallback was removed. 

contributes to #12931 