### PR TITLE
Align the exception message for casting floats to decimals

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -24,8 +24,7 @@ from delta_lake_utils import *
 from marks import *
 from parquet_write_test import parquet_write_gens_list, writer_confs
 from pyspark.sql.types import *
-from spark_session import is_before_spark_320, is_before_spark_330, is_spark_340_or_later, \
-    with_cpu_session, supports_delta_lake_deletion_vectors, is_spark_356
+from spark_session import *
 
 delta_write_gens = [x for sublist in parquet_write_gens_list for x in sublist]
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -704,11 +704,9 @@ class CastOpSuite extends GpuExpressionTestSuite {
     List(-10, -1, 0, 1, 10).foreach { scale =>
       testCastToDecimal(DataTypes.FloatType, scale,
         customDataGenerator = Some(floatsIncludeNaNs))
-      assertThrows[Throwable] {
-        testCastToDecimal(DataTypes.FloatType, scale,
-          customDataGenerator = Some(floatsIncludeNaNs),
-          ansiEnabled = true)
-      }
+      testCastToDecimal(DataTypes.FloatType, scale,
+        customDataGenerator = Some(floatsIncludeNaNs),
+        ansiEnabled = true)
     }
   }
 
@@ -726,11 +724,9 @@ class CastOpSuite extends GpuExpressionTestSuite {
     List(-10, -1, 0, 1, 10).foreach { scale =>
       testCastToDecimal(DataTypes.DoubleType, scale,
         customDataGenerator = Some(doublesIncludeNaNs))
-      assertThrows[Throwable] {
-        testCastToDecimal(DataTypes.DoubleType, scale,
-          customDataGenerator = Some(doublesIncludeNaNs),
-          ansiEnabled = true)
-      }
+      testCastToDecimal(DataTypes.DoubleType, scale,
+        customDataGenerator = Some(doublesIncludeNaNs),
+        ansiEnabled = true)
     }
   }
 
@@ -877,10 +873,6 @@ class CastOpSuite extends GpuExpressionTestSuite {
       precision: Int,
       scale: Int): Unit = {
       // Catch out of range exception when AnsiMode is on
-      val errMsg = dataType match {
-        case DataTypes.DoubleType | DataTypes.FloatType => GpuCast.OVERFLOW_MESSAGE
-        case _ => "cannot be represented as Decimal"
-      }
       assert(
         exceptionContains(
           if (isSpark400OrLater) {
@@ -898,7 +890,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
               nonOverflowCase(dataType, generator, precision, scale)
             }
           },
-          errMsg)
+          "cannot be represented as Decimal")
       )
       // Compare gpu results with cpu ones when AnsiMode is off (most of them should be null)
       testCastToDecimal(dataType,


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11550

This PR changes the exception message to align with that of Spark for casting floats to decimals when the ansi mode is on.

PR https://github.com/NVIDIA/spark-rapids/pull/12985 has already fixed the other two cases.

Depends on https://github.com/NVIDIA/spark-rapids-jni/pull/3479