### PR TITLE
Fix spark-test for delta 3.3.0 [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -184,7 +184,7 @@ run_delta_lake_tests() {
   SPARK_32X_PATTERN="(3\.2\.[0-9])"
   SPARK_33X_PATTERN="(3\.3\.[0-9])"
   SPARK_34X_PATTERN="(3\.4\.[0-9])"
-  SPARK_35X_PATTERN="(3\.5\.[0-9])"
+  SPARK_35X_PATTERN="(3\.5\.[3-9])"
 
   if [[ $SPARK_VER =~ $SPARK_32X_PATTERN ]]; then
     # There are multiple versions of deltalake that support SPARK 3.2.X


### PR DESCRIPTION
Close #12999 

Delta 3.3.0 only supports 3.5.3+, fix the version in `spark-test.sh`
