### PR TITLE
Fix lore GpuInsertIntoHiveTableunit test in spark332

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
@@ -351,7 +351,6 @@ object GpuLore {
     // These versions are extracted from GpuWriteFiles.scala spark-rapids-shim-json-lines
     Set(
       // Spark versions
-      SparkShimVersion(3, 3, 2),
       SparkShimVersion(3, 4, 0),
       SparkShimVersion(3, 4, 1),
       SparkShimVersion(3, 4, 2),
@@ -366,7 +365,7 @@ object GpuLore {
       SparkShimVersion(3, 5, 6),
       SparkShimVersion(4, 0, 0),
       // Databricks versions
-      DatabricksShimVersion(3, 3, 2), // 332db
+      DatabricksShimVersion(3, 3, 2, "12.2"), // 332db
       DatabricksShimVersion(3, 4, 1, "13.3"), // 341db143
       DatabricksShimVersion(3, 5, 0, "14.3") // 350db143
     )


### PR DESCRIPTION
Lore support for GpuInsertIntoHiveTable requires specific Spark versions due to limitation from current implementation.

actual unsupported versions can be found at https://github.com/NVIDIA/spark-rapids/blob/branch-25.08/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/execution/datasources/GpuWriteFiles.scala#L18-L33 

Previous PR has a wrong version number `332`, the correct one should be "332db". This PR fixes this issue that caused unit test failure.


Local unit test has passed after this fix:

```
mvn package -Dbuildver=332 -DwildcardSuites="com.nvidia.spark.rapids.lore.GpuLoreSuite"
...
Tests: succeeded 12, failed 0, canceled 1, ignored 0, pending 0
All tests passed.
```