### PR TITLE
[BUG] Auto compact tests should use the confs with auto compact enabled

### DIFF
--- a/integration_tests/src/main/python/delta_lake_auto_compact_test.py
+++ b/integration_tests/src/main/python/delta_lake_auto_compact_test.py
@@ -42,6 +42,23 @@ def write_to_delta(enable_deletion_vectors, num_rows=30, is_partitioned=False, n
     return write
 
 
+def assert_optimized(spark, table_path):
+    """
+    Asserts that the table at `table_path` has been optimized.
+    """
+    from delta.tables import DeltaTable
+    input_table = DeltaTable.forPath(spark, table_path)
+    table_history = input_table.history()
+    assert table_history.select("version", "operation").count() > 0, \
+        "Expected at least one version in the table history."
+    optimize_op_cnt = table_history.select("version") \
+        .where("operation = 'OPTIMIZE'") \
+        .count()
+    # Check that at least one OPTIMIZE operation exists.
+    assert optimize_op_cnt > 0, \
+        "Expected at least one OPTIMIZE operation in the table history."
+
+
 @delta_lake
 @allow_non_gpu(*delta_meta_allow)
 @pytest.mark.skipif(not is_databricks104_or_later(),
@@ -64,13 +81,16 @@ def test_auto_compact_basic(spark_tmp_path, auto_compact_conf, enable_deletion_v
     def read_data(spark, table_path):
         return spark.read.format("delta").load(table_path)
 
+    conf_enable_auto_compact = copy_and_update(_conf, {auto_compact_conf: "true"})
+
     assert_gpu_and_cpu_writes_are_equal_collect(
         write_func=write_to_delta(enable_deletion_vectors, is_partitioned=False),
         read_func=read_data,
         base_path=data_path,
-        conf=_conf)
+        conf=conf_enable_auto_compact)
 
     def read_metadata(spark, table_path):
+        assert_optimized(spark, table_path)
         input_table = DeltaTable.forPath(spark, table_path)
         table_history = input_table.history()
         return table_history.select(
@@ -80,8 +100,6 @@ def test_auto_compact_basic(spark_tmp_path, auto_compact_conf, enable_deletion_v
             expr("operationMetrics[\"numRemovedFiles\"]").alias("numRemoved"),
             expr("operationMetrics[\"numAddedFiles\"]").alias("numAdded")
         )
-
-    conf_enable_auto_compact = copy_and_update(_conf, {auto_compact_conf: "true"})
 
     assert_gpu_and_cpu_writes_are_equal_collect(
         write_func=lambda spark, table_path: None,  # Already written.
@@ -113,13 +131,16 @@ def test_auto_compact_partitioned(spark_tmp_path, auto_compact_conf, enable_dele
     def read_data(spark, table_path):
         return spark.read.format("delta").load(table_path).orderBy("id", "part")
 
+    conf_enable_auto_compact = copy_and_update(_conf, {auto_compact_conf: "true"})
+
     assert_gpu_and_cpu_writes_are_equal_collect(
         write_func=write_to_delta(enable_deletion_vectors, is_partitioned=True),
         read_func=read_data,
         base_path=data_path,
-        conf=_conf)
+        conf=conf_enable_auto_compact)
 
     def read_metadata(spark, table_path):
+        assert_optimized(spark, table_path)
         """
         The snapshots might not look alike, in the partitioned case.
         Ensure that auto compaction has occurred, even if it's not identical.
@@ -133,8 +154,6 @@ def test_auto_compact_partitioned(spark_tmp_path, auto_compact_conf, enable_dele
             expr("operationMetrics[\"numRemovedFiles\"] > 0").alias("numRemoved_gt_0"),
             expr("operationMetrics[\"numAddedFiles\"] > 0").alias("numAdded_gt_0")
         )
-
-    conf_enable_auto_compact = copy_and_update(_conf, {auto_compact_conf: "true"})
 
     assert_gpu_and_cpu_writes_are_equal_collect(
         write_func=lambda spark, table_path: None,  # Already written.


### PR DESCRIPTION
`test_auto_compact_basic` and `test_auto_compact_partitioned` in `test_auto_compact_min_num_files` are using the `_conf` object for the writing which does not have the auto compact enabled. As such, none of them actually performs the auto compact. These tests are passing because they do not validate whether the table written is optimized or not. This PR fixes this problem.