### PR TITLE
Align the exception type with Spark for casting to numbers[databricks]

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -38,15 +38,13 @@ def test_cast_empty_string_to_int_ansi_off():
                 conf=ansi_disabled_conf)
 
 
-def test_cast_empty_string_to_int_ansi_on():
+@pytest.mark.parametrize('to_type', ['BYTE', 'SHORT', 'INTEGER', 'LONG'])
+def test_cast_empty_string_to_int_ansi_on(to_type):
     err_mess = "invalid input syntax for type numeric" if is_before_spark_330() \
         else "cannot be cast to "
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, StringGen(pattern="")).selectExpr(
-            'CAST(a as BYTE)',
-            'CAST(a as SHORT)',
-            'CAST(a as INTEGER)',
-            'CAST(a as LONG)').collect(),
+            'CAST(a as {})'.format(to_type)).collect(),
         conf=ansi_enabled_conf,
         error_message=err_mess)
 

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -38,8 +38,9 @@ def test_cast_empty_string_to_int_ansi_off():
                 conf=ansi_disabled_conf)
 
 
-@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/11552")
 def test_cast_empty_string_to_int_ansi_on():
+    err_mess = "invalid input syntax for type numeric" if is_before_spark_330() \
+        else "cannot be cast to "
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, StringGen(pattern="")).selectExpr(
             'CAST(a as BYTE)',
@@ -47,7 +48,7 @@ def test_cast_empty_string_to_int_ansi_on():
             'CAST(a as INTEGER)',
             'CAST(a as LONG)').collect(),
         conf=ansi_enabled_conf,
-        error_message="cannot be cast to ")
+        error_message=err_mess)
 
 # These tests are not intended to be exhaustive. The scala test CastOpSuite should cover
 # just about everything for non-nested values. This is intended to check that the

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -25,7 +25,7 @@ import ai.rapids.cudf.{BinaryOp, CaptureGroups, ColumnVector, ColumnView, DType,
 import ai.rapids.cudf
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.jni.{CastStrings, DecimalUtils, GpuTimeZoneDB}
+import com.nvidia.spark.rapids.jni.{CastException, CastStrings, DecimalUtils, GpuTimeZoneDB}
 import com.nvidia.spark.rapids.shims.{AnsiUtil, CastTimeToIntShim, GpuCastShims, GpuIntervalUtils, GpuTypeShims, NullIntolerantShim, SparkShimImpl}
 import org.apache.commons.text.StringEscapeUtils
 
@@ -36,8 +36,9 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_SECOND
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.RoundingErrorUtil
-import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
+import org.apache.spark.sql.rapids.shims.{GpuCastToNumberErrorShim, RapidsErrorUtils}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 /** Meta-data for cast and ansi_cast. */
 final class CastExprMeta[INPUT <: UnaryLike[Expression] with TimeZoneAwareExpression](
@@ -549,8 +550,10 @@ object GpuCast {
           inputWithNansToZero.castTo(GpuColumnVector.getNonNestedRapidsType(toDataType))
         }
       case (StringType, ByteType | ShortType | IntegerType | LongType) =>
-        CastStrings.toInteger(input, ansiMode,
-          GpuColumnVector.getNonNestedRapidsType(toDataType))
+        fixupToNumberException(input, toDataType)(
+          CastStrings.toInteger(input, ansiMode,
+            GpuColumnVector.getNonNestedRapidsType(toDataType))
+        )
       case (StringType, FloatType | DoubleType) =>
         CastStrings.toFloat(input, ansiMode,
           GpuColumnVector.getNonNestedRapidsType(toDataType))
@@ -635,6 +638,18 @@ object GpuCast {
         }
       case _ =>
         input.castTo(GpuColumnVector.getNonNestedRapidsType(toDataType))
+    }
+  }
+
+  private def fixupToNumberException[A](input: ColumnView, to: DataType)(f: => A): A = {
+    try {
+      f
+    } catch {
+      case c: CastException =>
+        val s = withResource(input.copyToHost()) { hcv =>
+          UTF8String.fromString(hcv.getJavaString(c.getRowWithError.toLong))
+        }
+        throw GpuCastToNumberErrorShim.invalidInputInCastToNumberError(to, s)
     }
   }
 

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.unsafe.types.UTF8String
+
+object GpuCastToNumberErrorShim {
+
+  def invalidInputInCastToNumberError(
+      to: DataType,
+      s: UTF8String,
+      errorContext: String = ""): NumberFormatException = {
+    new NumberFormatException("invalid input syntax for type numeric: " + s)
+  }
+}

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.unsafe.types.UTF8String
+
+object GpuCastToNumberErrorShim {
+
+  def invalidInputInCastToNumberError(
+      to: DataType,
+      s: UTF8String,
+      errorContext: String = ""): NumberFormatException = {
+    QueryExecutionErrors.invalidInputInCastToNumberError(to, s, "")
+  }
+}

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
@@ -21,7 +21,6 @@
 {"spark": "331"}
 {"spark": "332"}
 {"spark": "332cdh"}
-{"spark": "332db"}
 {"spark": "333"}
 {"spark": "334"}
 spark-rapids-shim-json-lines ***/

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
@@ -15,6 +15,7 @@
  */
 
 /*** spark-rapids-shim-json-lines
+{"spark": "332db"}
 {"spark": "340"}
 {"spark": "341"}
 {"spark": "341db"}

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/shims/GpuCastToNumberErrorShim.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "400"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.unsafe.types.UTF8String
+
+object GpuCastToNumberErrorShim {
+
+  def invalidInputInCastToNumberError(
+      to: DataType,
+      s: UTF8String,
+      errorContext: String = ""): NumberFormatException = {
+    QueryExecutionErrors.invalidInputInCastToNumberError(to, s, null)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -363,29 +363,35 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
     frame => testCastTo(DataTypes.LongType)(frame)
   }
 
+  private lazy val toNumErrMsg = if (isSpark330OrLater) {
+    "cannot be cast to"
+  } else {
+    "invalid input syntax for type numeric"
+  }
+
   testCastFailsForBadInputs("ansi_cast string to byte (invalid values)", shortsAsStrings,
-    sparkConf, msg = INVALID_ROW_VALUE_MSG) {
+    sparkConf, msg = toNumErrMsg) {
     frame => testCastTo(DataTypes.ByteType)(frame)
   }
 
   testCastFailsForBadInputs("ansi_cast string to short (invalid values)", intsAsStrings,
-    sparkConf, msg = INVALID_ROW_VALUE_MSG) {
+    sparkConf, msg = toNumErrMsg) {
     frame => testCastTo(DataTypes.ShortType)(frame)
   }
 
   testCastFailsForBadInputs("ansi_cast string to long (invalid decimal values)",
     longsAsDecimalStrings,
-    sparkConf, msg = INVALID_ROW_VALUE_MSG) {
+    sparkConf, msg = toNumErrMsg) {
     frame => testCastTo(DataTypes.LongType)(frame)
   }
 
   testCastFailsForBadInputs("ansi_cast string to int (invalid values)", longsAsStrings,
-    sparkConf, msg = INVALID_ROW_VALUE_MSG) {
+    sparkConf, msg = toNumErrMsg) {
     frame => testCastTo(DataTypes.IntegerType)(frame)
   }
 
   testCastFailsForBadInputs("ansi_cast string to int (non-numeric values)", testStrings,
-    sparkConf, msg = INVALID_ROW_VALUE_MSG) {
+    sparkConf, msg = toNumErrMsg) {
     frame => testCastTo(DataTypes.IntegerType)(frame)
   }
 


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11552

This PR catches the raw cudf exception and instead throws an exception the same as the Spark one for casting strings to numbers.