### PR TITLE
suipport RuntimeReplaceable expr for Spark 400

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1127,7 +1127,6 @@ structs_read_allowed_non_gpu = non_utc_project_allow if is_before_spark_400() el
     'UTC',
     'Etc/UTC'
 ])
-@allow_non_gpu(*structs_read_allowed_non_gpu)
 def test_structs_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
     struct_gen = StructGen([
         ('a', data_gen),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -70,7 +70,7 @@ import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
 import org.apache.spark.sql.rapids.execution._
 import org.apache.spark.sql.rapids.execution.python._
 import org.apache.spark.sql.rapids.execution.python.GpuFlatMapGroupsInPandasExecMeta
-import org.apache.spark.sql.rapids.shims.{GpuAscii, GpuMapInPandasExecMeta, GpuTimeAdd}
+import org.apache.spark.sql.rapids.shims.{GpuAscii, GpuMapInPandasExecMeta, GpuTimeAdd, PreRuleShims}
 import org.apache.spark.sql.rapids.zorder.ZOrderRules
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -4894,7 +4894,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         var updatedPlan = updateForAdaptivePlan(plan, conf)
         updatedPlan = HybridExecutionUtils.tryToApplyHybridScanRules(updatedPlan, conf)
         updatedPlan = SparkShimImpl.applyShimPlanRules(updatedPlan, conf)
-        updatedPlan = applyOverrides(updatedPlan, conf)
+        updatedPlan = applyOverridesWithPreRules(updatedPlan, conf)
         if (conf.logQueryTransformations) {
           val logPrefix = context.map(str => s"[$str]").getOrElse("")
           logWarning(s"${logPrefix}Transformed query:" +
@@ -5013,6 +5013,11 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         false
     })
     deltaLogScans.nonEmpty
+  }
+
+  private def applyOverridesWithPreRules(plan: SparkPlan, conf: RapidsConf): SparkPlan = {
+    val p = PreRuleShims.getPreRules.foldLeft(plan) { (tmpPlan, rule) => rule.apply(tmpPlan) }
+    applyOverrides(p, conf)
   }
 
   private def applyOverrides(plan: SparkPlan, conf: RapidsConf): SparkPlan = {

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/PreRuleShims.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/PreRuleShims.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+
+object PreRuleShims {
+  def getPreRules: Seq[Rule[SparkPlan]] = Nil
+}

--- a/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/rapids/shims/PreRuleShims.scala
+++ b/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/rapids/shims/PreRuleShims.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "400"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, StructsToJson}
+import org.apache.spark.sql.catalyst.expressions.json.StructsToJsonEvaluator
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.INVOKE
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types.{AbstractDataType, ObjectType, StringType}
+
+/**
+ *
+ * From Spark 400, it transforms the following expr to `Invoke` with `Literal` and `XxEvaluator`
+ *   StructsToJson => Invoke(Literal(StructsToJsonEvaluator), "evaluate", type, arguments)
+ *   ...
+ * This rule is used to do the revert of the above transforms.
+ * After the revert, it's easy to use the existing code.
+ */
+object RevertInvokeRule extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan =
+    plan.transformExpressionsWithPruning(_.containsPattern(INVOKE)) {
+        case Invoke(
+          Literal(evaluator: StructsToJsonEvaluator, _: ObjectType),
+          functionName: String,
+          _: StringType,
+          arguments: Seq[Expression],
+          methodInputTypes: Seq[AbstractDataType],
+          propagateNull: Boolean,
+          returnNullable : Boolean,
+          isDeterministic: Boolean) if (functionName == "evaluate"
+            && arguments.size == 1
+            && methodInputTypes.size == 1
+            && propagateNull == true
+            && returnNullable == true
+            && isDeterministic == true) =>
+          val child = arguments.head
+          StructsToJson(evaluator.options, child, evaluator.timeZoneId)
+    }
+}
+
+object PreRuleShims {
+  def getPreRules: Seq[Rule[SparkPlan]] = Seq(RevertInvokeRule)
+}


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/12941

## Analysis
From Spark 400, it transforms some expressions to `Invoke` with `Literal` and `XxEvaluator`, e.g.:
  StructsToJson => Invoke(Literal(StructsToJsonEvaluator), "evaluate", type, arguments)

Please search with `override def replacement: Expression = Invoke`, and gets:
```scala

  override def replacement: Expression = Invoke(
    Literal.create(evaluator, ObjectType(classOf[StructsToJsonEvaluator])),
    "evaluate",
    dataType,
    Seq(child),
    Seq(child.dataType)
  )

  override def replacement: Expression = Invoke(
    Literal.create(evaluator, ObjectType(classOf[ParseUrlEvaluator])),
    "evaluate",
    dataType,
    children,
    children.map(_.dataType))

  override def replacement: Expression = Invoke(
    Literal.create(evaluator, ObjectType(classOf[SchemaOfCsvEvaluator])),
    "evaluate",
    dataType,
    Seq(child),
    Seq(child.dataType),
    returnNullable = false)

  override def replacement: Expression = Invoke(
    Literal.create(evaluator, ObjectType(classOf[SchemaOfJsonEvaluator])),
    "evaluate",
    dataType,
    Seq(child),
    Seq(child.dataType),
    returnNullable = false)

  override def replacement: Expression = Invoke(
    Literal.create(evaluator, ObjectType(classOf[XPathEvaluator])),
    "evaluate",
    dataType,
    Seq(xml),
    Seq(xml.dataType))
```

The `XXEvaluator` e.g. `StructsToJsonEvaluator` is not a sub-class of Expression.
The `Literal` can not be convert to `GpuLiteral`, becasue the `Literal` in `Invoke` is just a Java class referance to `XXEvaluator`.
It's hard to add a `GpuInvoke`.

### Solution
Add a rule to do the revert of the above transforms before `GpuOverrides`.`applyOverrides`
After the revert, it's easy to reuse the existing code.

### changes
-  Add RevertInvokeRule
- Fix test case `test_structs_to_json`, it can now run on GPU on Spark 400.

### TODO
Add more case paths in `RevertInvokeRule` to revert all kind of `Invoke` expressions.

Signed-off-by: Chong Gao <res_life@163.com>