### PR TITLE
Add in code to halt on shutdown timeouts

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -598,7 +598,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
         logGpuDebugInfoAndExit(systemExitCode = 1)
       case e: Throwable =>
         logError("Exception in the executor plugin, shutting down!", e)
-        System.exit(1)
+        RapidsExecutorPlugin.exitWithHaltOnTimeout(1)
     }
   }
 
@@ -678,7 +678,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       case e: Throwable =>
         logWarning("nvidia-smi process failed", e)
     }
-    System.exit(systemExitCode)
+    RapidsExecutorPlugin.exitWithHaltOnTimeout(systemExitCode)
   }
 
   override def shutdown(): Unit = {
@@ -758,7 +758,32 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   }
 }
 
-object RapidsExecutorPlugin {
+object RapidsExecutorPlugin extends Logging {
+  /**
+   * Calling System.exit will trigger shutdown hooks to run.
+   * This code is intended to let them run, but then force
+   * kill the process if it takes too long to actually exit.
+   * @param exitCode the exit code to use.
+   */
+  def exitWithHaltOnTimeout(exitCode: Int): Unit = synchronized {
+    val sleepTime = 40
+    val sleepKill = new java.lang.Thread(() => {
+      try {
+        logInfo(s"Halting after $sleepTime seconds")
+        Thread.sleep(sleepTime * 1000)
+        logWarning("Forcing Halt...")
+        Runtime.getRuntime.halt(exitCode)
+      } catch {
+        case _: InterruptedException => //Ignored/expected...
+        case e: Exception =>
+          logWarning("Exception in the ShutDownHook", e)
+      }
+    }, "ShutdownHook-sleepKill-" + sleepTime + "s")
+    sleepKill.setDaemon(true)
+    sleepKill.start()
+    System.exit(exitCode)
+  }
+
   /**
    * Return true if the expected cudf version is satisfied by the actual version found.
    * The version is satisfied if the major and minor versions match exactly. If there is a requested


### PR DESCRIPTION
We have run into cases where an executor gets stuck on shutdown. We do not know the root cause of it yet, but this should mitigate the issue where we can try and ask the process to shut down nicely, but if it still has things up and running after a set timeout (currently 40 seconds), then we will call Runtime.halt, which is similar to a kill -9 for the process.

I think we may want to add some debugging before we call halt, but I want to be careful with it because I don't want it to get in the way of us shutting down so suggestions are welcome.