### PR TITLE
Update tests/aggregations for ANSI mode, when they don't care

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -523,7 +523,6 @@ def test_hash_avg_nulls_partial_only(data_gen, kudo_enabled):
 @approximate_float
 @ignore_order
 @incompat
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', _init_list_with_decimalbig, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_intersect_all(data_gen, kudo_enabled):
@@ -535,7 +534,6 @@ def test_intersect_all(data_gen, kudo_enabled):
 @approximate_float
 @ignore_order
 @incompat
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', _init_list_with_decimalbig, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_exceptAll(data_gen, kudo_enabled):
@@ -543,7 +541,9 @@ def test_exceptAll(data_gen, kudo_enabled):
         lambda spark : (gen_df(spark, data_gen, length=100)
                         .exceptAll(gen_df(spark, data_gen, length=100)
                         .filter('a != b'))),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        conf = {kudo_enabled_conf_key: kudo_enabled,
+            # disable ansi because a != b can insert a cast that can fail in ANSI mode
+            'spark.sql.ansi.enabled': False})
 
 # Spark fails to sort some decimal values due to overflow when calculating the sorting prefix.
 # See https://issues.apache.org/jira/browse/SPARK-40129
@@ -583,7 +583,6 @@ def test_hash_grpby_pivot(data_gen, conf, kudo_enabled):
 @approximate_float
 @ignore_order(local=True)
 @incompat
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -592,7 +591,7 @@ def test_hash_multiple_grpby_pivot(data_gen, conf, kudo_enabled):
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby('a','b')
             .pivot('b')
-            .agg(f.sum('c'), f.max('c')),
+            .agg(f.min('c'), f.max('c')),
         conf=copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled}))
 
 @approximate_float
@@ -602,21 +601,18 @@ def test_hash_multiple_grpby_pivot(data_gen, conf, kudo_enabled):
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_reduction_pivot(data_gen, conf, kudo_enabled):
-    # disable ANSI mode to avoid overflow in some cases of SUM
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby()
             .pivot('b')
-            .agg(f.sum('c')),
-        conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-            'spark.sql.ansi.enabled': False}))
+            .agg(f.max('c')),
+        conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled}))
 
 @approximate_float
 @ignore_order(local=True)
 @allow_non_gpu('HashAggregateExec', 'PivotFirst', 'AggregateExpression', 'Alias', 'GetArrayItem',
         'Literal', 'ShuffleExchangeExec', 'HashPartitioning', 'NormalizeNaNAndZero')
 @incompat
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', [_grpkey_floats_with_nulls_and_nans], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_pivot_groupby_duplicates_fallback(data_gen, kudo_enabled):
@@ -625,9 +621,11 @@ def test_hash_pivot_groupby_duplicates_fallback(data_gen, kudo_enabled):
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby('a')
             .pivot('b', ['10.0', '10.0'])
-            .agg(f.sum('c')),
+            .agg(f.min('c')),
         "PivotFirst",
-        conf=copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}) )
+        conf=copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled,
+            # The CPU fails in ANSI mode for this test with an array index access
+            'spark.sql.ansi.enabled': False}) )
 
 _repeat_agg_column_for_collect_op = [
     RepeatSeqGen(BooleanGen(), length=15),
@@ -692,27 +690,31 @@ _gen_data_for_collect_set_op_nested = [[
 
 _all_basic_gens_with_all_nans_cases = all_basic_gens + [SetValuesGen(t, [math.nan, None]) for t in [FloatType(), DoubleType()]]
 
-# very simple test for just a count on decimals 128 values until we can support more with them
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
+# COUNT does not care about ANSI more or not, but include a few tests
+# to future proof them
+@pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_decimal128_count_reduction(data_gen, kudo_enabled):
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
+def test_decimal128_count_reduction(data_gen, kudo_enabled, ansi):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('count(a)'),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        conf = {kudo_enabled_conf_key: kudo_enabled,
+            'spark.sql.ansi.enabled': ansi})
 
-# very simple test for just a count on decimals 128 values until we can support more with them
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
+# COUNT does not care about ANSI more or not, but include a few tests
+# to future proof them
+@pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_decimal128_count_group_by(data_gen, kudo_enabled):
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
+def test_decimal128_count_group_by(data_gen, kudo_enabled, ansi):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: two_col_df(spark, byte_gen, data_gen)
             .groupby('a')
             .agg(f.count('b')),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        conf = {kudo_enabled_conf_key: kudo_enabled,
+            'spark.sql.ansi.enabled': ansi})
 
 # very simple test for just a min/max on decimals 128 values until we can support more with them
 @ignore_order(local=True)
@@ -784,7 +786,6 @@ def test_hash_groupby_collect_list_of_maps(use_obj_hash_agg, kudo_enabled):
 
 
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
@@ -830,7 +831,6 @@ def test_hash_groupby_collect_set_on_nested_array_type(data_gen, kudo_enabled):
 
 
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
@@ -873,7 +873,6 @@ def test_hash_reduction_collect_set_on_nested_array_type(data_gen, kudo_enabled)
 
 
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
@@ -909,7 +908,8 @@ def hash_groupby_single_distinct_collect_impl(data_gen, conf):
         df_fun=lambda spark: gen_df(spark, data_gen, length=100),
         table_name="tbl", sql=sql, conf=conf)
 
-
+# TODO LOOK AT collect_list and collect_set for ANSI, because these tests should not
+# work if they do need ANSI
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_op, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -940,7 +940,6 @@ def test_hash_groupby_single_distinct_collect_ansi_enabled(data_gen, kudo_enable
 
 
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_op, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
@@ -1014,7 +1013,6 @@ _replace_modes_single_distinct = [
 
 
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @allow_non_gpu('ObjectHashAggregateExec', 'SortAggregateExec',
                'ShuffleExchangeExec', 'HashPartitioning', 'SortExec',
                'SortArray', 'Alias', 'Literal', 'Count', 'CollectList', 'CollectSet',
@@ -1248,7 +1246,7 @@ def test_hash_groupby_typed_imperative_agg_without_gpu_implementation_fallback(k
 @approximate_float
 @ignore_order
 @incompat
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (But SUM is okay)
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (All but AVG are okay)
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -1289,7 +1287,7 @@ def test_hash_multiple_mode_query_avg_distincts(data_gen, conf, kudo_enabled):
 @ignore_order
 @incompat
 @datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10388")
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (But SUM is okay)
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (All but AVG are okay)
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -1316,13 +1314,15 @@ def test_hash_query_multiple_distincts_with_non_distinct(data_gen, conf, kudo_en
 @approximate_float
 @ignore_order
 @incompat
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (But SUM is okay)
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_query_max_with_multiple_distincts(data_gen, conf, kudo_enabled):
     local_conf = copy_and_update(conf, {'spark.sql.legacy.allowParameterlessCount': 'true',
-                                        kudo_enabled_conf_key: kudo_enabled})
+                                        kudo_enabled_conf_key: kudo_enabled,
+                                        'spark.sql.ansi.enabled': False})
+    # Disable ANSI mode to avoid overflow on SUM. We test SUM elsewhere and none of the
+    # others care about ANSI or not.
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=100),
         "hash_agg_table",
@@ -1333,21 +1333,22 @@ def test_hash_query_max_with_multiple_distincts(data_gen, conf, kudo_enabled):
         conf=local_conf)
 
 @ignore_order
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
+@pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_count_with_filter(data_gen, conf, kudo_enabled):
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
+def test_hash_count_with_filter(data_gen, conf, kudo_enabled, ansi):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .selectExpr('count(a) filter (where c > 50)'),
-        conf=copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled}))
+        conf=copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
+            'spark.sql.ansi.enabled': ansi}))
 
 
 @approximate_float
 @ignore_order
 @incompat
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (All but AVG are okay)
 @pytest.mark.parametrize('data_gen', _init_list + [_grpkey_short_mid_decimals, _grpkey_short_big_decimals], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -1363,7 +1364,7 @@ def test_hash_multiple_filters(data_gen, conf, kudo_enabled):
 
 @approximate_float
 @ignore_order
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (But SUM is okay)
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (All but AVG are okay)
 @pytest.mark.parametrize('data_gen', [_grpkey_floats_with_nan_zero_grouping_keys,
                                       _grpkey_doubles_with_nan_zero_grouping_keys], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -1386,7 +1387,7 @@ def test_hash_agg_with_nan_keys(data_gen, kudo_enabled):
         local_conf)
 
 @ignore_order
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (But SUM is okay)
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114 (All but AVG are okay)
 @pytest.mark.parametrize('data_gen',  [_grpkey_structs_with_non_nested_children,
                                        _grpkey_nested_structs], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -1436,9 +1437,8 @@ def test_hash_agg_with_struct_of_array_fallback(data_gen, kudo_enabled):
 
 @approximate_float
 @ignore_order
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', [ _grpkey_floats_with_nulls_and_nans ], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 def test_count_distinct_with_nan_floats(data_gen, kudo_enabled):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1024),
@@ -1475,7 +1475,6 @@ def test_first_last_reductions_nested_types(data_gen, kudo_enabled):
 
 @pytest.mark.parametrize('data_gen', _all_basic_gens_with_all_nans_cases, ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @allow_non_gpu(*non_utc_allow)
 def test_generic_reductions(data_gen, kudo_enabled):
     local_conf = copy_and_update(_float_conf, {'spark.sql.legacy.allowParameterlessCount': 'true',
@@ -1538,8 +1537,7 @@ def test_reduction_with_max_by_same(data_gen, kudo_enabled):
         conf = {kudo_enabled_conf_key: kudo_enabled})
 
 @pytest.mark.parametrize('data_gen', all_gen + _nested_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 @allow_non_gpu(*non_utc_allow)
 def test_count(data_gen, kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(
@@ -1552,9 +1550,8 @@ def test_count(data_gen, kudo_enabled):
         conf = {'spark.sql.legacy.allowParameterlessCount': 'true',
                 kudo_enabled_conf_key: kudo_enabled})
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 @allow_non_gpu(*non_utc_allow)
 def test_distinct_count_reductions(data_gen, kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(
@@ -1562,9 +1559,8 @@ def test_distinct_count_reductions(data_gen, kudo_enabled):
                 'count(DISTINCT a)'),
         conf= {kudo_enabled_conf_key: kudo_enabled})
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', [float_gen, double_gen], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 def test_distinct_float_count_reductions(data_gen, kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).selectExpr(
@@ -1654,10 +1650,9 @@ def test_sorted_groupby_first_last(data_gen, kudo_enabled):
 # Spark has a sorting bug with decimals, see https://issues.apache.org/jira/browse/SPARK-40129.
 # Have pytest do the sorting rather than Spark as a workaround.
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('count_func', [f.count, f.countDistinct], ids=["COUNT", "COUNT_DISTINCT"])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 @allow_non_gpu(*non_utc_allow)
 def test_agg_count(data_gen, count_func, kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(
@@ -1748,7 +1743,6 @@ def test_struct_groupby_count(key_data_gen, kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(group_by_count, conf = {kudo_enabled_conf_key: kudo_enabled})
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('cast_struct_tostring', ['LEGACY', 'SPARK311+'])
 @pytest.mark.parametrize('key_data_gen', [
     StructGen([
@@ -1760,7 +1754,7 @@ def test_struct_groupby_count(key_data_gen, kudo_enabled):
     ], nullable=False)
 ], ids=idfn)
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 def test_struct_cast_groupby_count(cast_struct_tostring, key_data_gen, kudo_enabled):
     def _group_by_struct_or_cast(spark):
         df = two_col_df(spark, key_data_gen, IntegerGen())
@@ -1794,7 +1788,6 @@ def test_struct_count_distinct(key_data_gen, kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(_count_distinct_by_struct, conf = {kudo_enabled_conf_key: kudo_enabled})
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('cast_struct_tostring', ['LEGACY', 'SPARK311+'])
 @pytest.mark.parametrize('key_data_gen', [
     StructGen([
@@ -1846,14 +1839,15 @@ def test_reduction_nested_array(kudo_enabled, ansi):
                 'spark.sql.ansi.enabled': ansi})
 
 # The map here is a child not a top level, because we only support GetMapValue on String to String maps.
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @ignore_order(local=True)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_reduction_nested_map(kudo_enabled):
     def do_it(spark):
         df = unary_op_df(spark, ArrayGen(MapGen(StringGen('a{1,5}', nullable=False), StringGen('[ab]{1,5}'))))
         return df.agg(f.min(df.a[1]["a"]))
-    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled,
+        # Disable ANSI to avoid array index out of bounds errors
+        'spark.sql.ansi.enabled': False})
 
 @ignore_order(local=True)
 @pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
@@ -1868,23 +1862,25 @@ def test_agg_nested_struct(kudo_enabled, ansi):
                 'spark.sql.ansi.enabled': ansi})
 
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_agg_nested_array(kudo_enabled):
+    # Ths SUM in ANSI mode is okay because we cannot overflow with values 0 to 4 with a small number of rows
     def do_it(spark):
-        df = two_col_df(spark, StringGen('k{1,5}'), ArrayGen(StructGen([('aa', IntegerGen(min_val=0, max_val=4))])))
+        # have a min length of 2 to avoid ANSI issues when getting a value from an array
+        df = two_col_df(spark, StringGen('k{1,5}'), ArrayGen(StructGen([('aa', IntegerGen(min_val=0, max_val=4))]), min_length=2))
         return df.groupBy('a').agg(f.sum(df.b[1].aa))
     assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled})
 
 # The map here is a child not a top level, because we only support GetMapValue on String to String maps.
 @ignore_order(local=True)
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_agg_nested_map(kudo_enabled):
     def do_it(spark):
         df = two_col_df(spark, StringGen('k{1,5}'), ArrayGen(MapGen(StringGen('a{1,5}', nullable=False), StringGen('[ab]{1,5}'))))
         return df.groupBy('a').agg(f.min(df.b[1]["a"]))
-    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled,
+        # Disable ANSI mode to avoid issues with array indexes and map keys not being present
+        'spark.sql.ansi.enabled': False})
 
 @incompat
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
@@ -2552,8 +2548,8 @@ sort_agg_conf = {"spark.rapids.sql.foldLocalAggregate.enabled": 'true',
                  "spark.sql.test.forceApplySortAggregate": 'true'}
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @ignore_order(local=True)
+@disable_ansi_mode #https://github.com/NVIDIA/spark-rapids/issues/5120 Multiply does not work in ANSI mode yet, but the rest should be fine
 @pytest.mark.skipif(is_databricks_runtime(), reason="This rule is not applied onto Databricks shims")
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.parametrize("agg_conf", [hash_agg_conf, sort_agg_conf], ids=idfn)
@@ -2563,6 +2559,8 @@ sort_agg_conf = {"spark.rapids.sql.foldLocalAggregate.enabled": 'true',
                           local_object_hash_aggregate_gen],
                          ids=['local_agg_gen', 'local_agg_gen_filter', 'local_object_hash_agg_gen'])
 def test_fold_local_aggregate(spark_tmp_table_factory, aqe_enabled, agg_conf, agg_transform_fn):
+    # The SUM aggregations should not overflow in ANSI mode because they are all integer values
+    # and the number of rows is relatively small
     # --- Create bucketed table ---
     bucketed_table = spark_tmp_table_factory.get()
 
@@ -2605,7 +2603,6 @@ def test_fold_local_aggregate(spark_tmp_table_factory, aqe_enabled, agg_conf, ag
     assert_gpu_and_cpu_are_equal_collect(run_spark_fn, conf=run_conf)
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
 def test_hash_reduction_bitwise(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
@@ -2615,7 +2612,6 @@ def test_hash_reduction_bitwise(data_gen):
             "bit_xor(a)"))
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @ignore_order(local=True)
 @pytest.mark.parametrize('int_gen', integral_gens, ids=idfn)
 def test_hash_groupby_bitwise(int_gen):

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -691,7 +691,7 @@ _gen_data_for_collect_set_op_nested = [[
 _all_basic_gens_with_all_nans_cases = all_basic_gens + [SetValuesGen(t, [math.nan, None]) for t in [FloatType(), DoubleType()]]
 
 @ignore_order(local=True)
-# COUNT does not care about ANSI more or not, but include a few tests
+# COUNT does not care about ANSI mode or not, but include a few tests
 # to future proof them
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1496,6 +1496,8 @@ object GpuOverrides extends Logging {
       (a, conf, p, r) => new AggExprMeta[BitAndAgg](a, conf, p, r) {
         override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
           GpuBitAndAgg(childExprs.head)
+
+        override def needsAnsiCheck: Boolean = false
       }),
     expr[BitOrAgg](
       "Returns the bitwise OR of all non-null input values",
@@ -1505,6 +1507,8 @@ object GpuOverrides extends Logging {
       (a, conf, p, r) => new AggExprMeta[BitOrAgg](a, conf, p, r) {
         override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
           GpuBitOrAgg(childExprs.head)
+
+        override def needsAnsiCheck: Boolean = false
       }),
     expr[BitXorAgg](
       "Returns the bitwise XOR of all non-null input values",
@@ -1514,6 +1518,8 @@ object GpuOverrides extends Logging {
       (a, conf, p, r) => new AggExprMeta[BitXorAgg](a, conf, p, r) {
         override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
           GpuBitXorAgg(childExprs.head)
+
+        override def needsAnsiCheck: Boolean = false
       }),
     expr[Coalesce] (
       "Returns the first non-null argument if exists. Otherwise, null",

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -910,7 +910,7 @@ abstract class GpuSum(
     Seq(GpuCast(updateAggregates.head.attr, resultType, ansiMode = failOnErrorOverride))
 
   // output of GpuSum
-  protected lazy val sum: AttributeReference = AttributeReference("sum", internalSumDataType)()
+  protected lazy val sum: AttributeReference = AttributeReference("sum", resultType)()
 
   override lazy val aggBufferAttributes: Seq[AttributeReference] = sum :: Nil
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanSuite.scala
@@ -38,8 +38,7 @@ class CsvScanSuite extends SparkQueryCompareTestSuite {
       "Test CSV count chunked by rows",
       intsFromCsv,
       conf = new SparkConf()
-          .set(RapidsConf.MAX_READER_BATCH_SIZE_ROWS.key, "1"),
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+          .set(RapidsConf.MAX_READER_BATCH_SIZE_ROWS.key, "1")) {
     frameCount
   }
 
@@ -47,8 +46,7 @@ class CsvScanSuite extends SparkQueryCompareTestSuite {
       "Test CSV count chunked by bytes",
       intsFromCsv,
       conf = new SparkConf()
-          .set(RapidsConf.MAX_READER_BATCH_SIZE_BYTES.key, "0"),
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+          .set(RapidsConf.MAX_READER_BATCH_SIZE_BYTES.key, "0")) {
     frameCount
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ExpandExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ExpandExecSuite.scala
@@ -22,8 +22,9 @@ import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 class ExpandExecSuite extends SparkQueryCompareTestSuite {
 
   IGNORE_ORDER_testSparkResultsAreEqual("group with aggregates",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
+    // There are only 100 integer values in the data generated so we don't need
+    // to worry about an overflow in SUM
     frame => {
       import frame.sparkSession.implicits._
       frame.groupBy($"key")
@@ -37,8 +38,7 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("cube with count",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
     frame => {
       import frame.sparkSession.implicits._
       frame.cube($"key", $"cat1", $"cat2").count()
@@ -46,8 +46,7 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("cube with count distinct",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
     frame => {
       import frame.sparkSession.implicits._
       frame.rollup($"key", $"cat2")
@@ -56,8 +55,9 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("cube with sum",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
+    // There are only 100 integer values in the data generated so we don't need
+    // to worry about an overflow in SUM
     frame => {
       import frame.sparkSession.implicits._
       frame.cube($"key", $"cat1", $"cat2").sum()
@@ -65,8 +65,7 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("rollup with count",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
     frame => {
       import frame.sparkSession.implicits._
       frame.rollup($"key", $"cat1", $"cat2").count()
@@ -74,8 +73,7 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("rollup with count distinct",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
     frame => {
       import frame.sparkSession.implicits._
       frame.rollup($"key", $"cat2")
@@ -84,8 +82,7 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("rollup with sum",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
     frame => {
       import frame.sparkSession.implicits._
       frame.rollup($"key", $"cat1", $"cat2").sum()
@@ -93,8 +90,7 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("sql with grouping expressions",
-    createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    createDataFrame, repart = 2) {
     frame => {
       frame.createOrReplaceTempView("t0")
       val sql =
@@ -107,8 +103,7 @@ class ExpandExecSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("sql with different shape " +
-    "grouping expressions", createDataFrame, repart = 2,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    "grouping expressions", createDataFrame, repart = 2) {
     frame => {
       frame.createOrReplaceTempView("t0")
       val sql =

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuBringBackToHostSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuBringBackToHostSuite.scala
@@ -41,7 +41,6 @@ class GpuBringBackToHostSuite extends SparkQueryCompareTestSuite {
   }
 
   test("doExecuteColumnar returns a columnar batch with a valid numRows") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withGpuSparkSession { spark =>
       val data = mixedDf(spark, numSlices = 1)
       val plan = GpuBringBackToHost(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -627,7 +627,9 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       "test count, sum, max, min with shuffle",
       longsFromCSVDf,
       conf = enableCsvConf(),
-      repart = 2) {
+      repart = 2,
+      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5120" +
+        " Multiply does not work in ANSI mode yet")) {
     frame => frame.groupBy(col("more_longs")).agg(
       count("*"),
       sum("more_longs"),
@@ -1450,7 +1452,9 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       execsAllowedNonGpu = Seq("HashAggregateExec", "AggregateExpression", "AttributeReference",
           "Alias", "Average", "Count"),
       conf = nonPartialOnGpuConf,
-      repart = 2) {
+      repart = 2,
+      // Still need AVG for ANSI
+      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
     frame => frame.agg(countDistinct("longs"),
       avg("more_longs"))
   } { (_, gpuPlan) => checkExecPlan(gpuPlan) }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashSortOptimizeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashSortOptimizeSuite.scala
@@ -153,7 +153,6 @@ class HashSortOptimizeSuite extends SparkQueryCompareTestSuite with FunSuiteWith
   }
 
   test("should not insert sort because of missing GpuDataWritingCommandExec") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     val conf = sparkConf.clone()
     withGpuSparkSession(spark => {
       buildDataFrame1(spark).createOrReplaceTempView("t1")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcScanSuite.scala
@@ -31,12 +31,10 @@ class OrcScanSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("Test ORC count chunked by rows", fileSplitsOrc,
-    new SparkConf().set(RapidsConf.MAX_READER_BATCH_SIZE_ROWS.key, "2048"), 
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114"))(frameCount)
+    new SparkConf().set(RapidsConf.MAX_READER_BATCH_SIZE_ROWS.key, "2048"))(frameCount)
 
   testSparkResultsAreEqual("Test ORC count chunked by bytes", fileSplitsOrc,
-    new SparkConf().set(RapidsConf.MAX_READER_BATCH_SIZE_BYTES.key, "100"),
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114"))(frameCount)
+    new SparkConf().set(RapidsConf.MAX_READER_BATCH_SIZE_BYTES.key, "100"))(frameCount)
 
   testSparkResultsAreEqual("schema-can-prune dis-order read schema",
     frameFromOrcWithSchema("schema-can-prune.orc", StructType(Seq(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/UnaryOperatorsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/UnaryOperatorsSuite.scala
@@ -31,14 +31,12 @@ class UnaryOperatorsSuite extends SparkQueryCompareTestSuite {
     frame => frame.selectExpr("pi()")
   }
 
-  testSparkResultsAreEqual("Test md5", mixedDfWithNulls,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+  testSparkResultsAreEqual("Test md5", mixedDfWithNulls) {
     frame => frame.selectExpr("md5(strings)", "md5(cast(ints as string))",
       "md5(cast(longs as binary))")
   }
 
-  testSparkResultsAreEqual("Test murmur3", mixedDfWithNulls,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+  testSparkResultsAreEqual("Test murmur3", mixedDfWithNulls) {
     frame => frame.selectExpr("hash(longs, 1, null, 'stock string', ints, strings)")
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/UnaryOperatorsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/UnaryOperatorsSuite.scala
@@ -33,7 +33,12 @@ class UnaryOperatorsSuite extends SparkQueryCompareTestSuite {
 
   testSparkResultsAreEqual("Test md5", mixedDfWithNulls) {
     frame => frame.selectExpr("md5(strings)", "md5(cast(ints as string))",
-      "md5(cast(longs as binary))")
+      "md5(cast(strings as binary))")
+  }
+
+  testSparkResultsAreEqual("Test md5 - longs as binary", mixedDfWithNulls,
+    assumeCondition = ignoreAnsi("cast long to binary is not supported in ANSI mode")) {
+    frame => frame.selectExpr("md5(cast(longs as binary))")
   }
 
   testSparkResultsAreEqual("Test murmur3", mixedDfWithNulls) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
@@ -88,8 +88,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
                 "row_num", "count_all")
     }
 
-  testSparkResultsAreEqual("[Window] [ROWS] [-2, 3] ", windowTestDfOrc,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+  testSparkResultsAreEqual("[Window] [ROWS] [-2, 3] ", windowTestDfOrc) {
     val rowsWindow = Window.partitionBy("uid")
                            .orderBy("uid", "dateLong", "dollars")
                            .rowsBetween(-2, 3)
@@ -152,8 +151,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
 
   testSparkResultsAreEqual("[Window] [ROWS] [UNBOUNDED PRECEDING, CURRENT ROW] ",
       windowTestDfOrc,
-      new SparkConf().set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true"),
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+      new SparkConf().set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")) {
     val rowsWindow = Window.partitionBy("uid")
       .orderBy("uid", "dateLong", "dollars")
       .rowsBetween(Window.unboundedPreceding, 0)
@@ -163,8 +161,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
 
   testSparkResultsAreEqual("[Window] [ROWS] [UNBOUNDED PRECEDING, CURRENT ROW] [NO PART]",
     windowTestDfOrc,
-    new SparkConf().set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true"),
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    new SparkConf().set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")) {
     val rowsWindow = Window
         .orderBy("uid", "dateLong", "dollars")
         .rowsBetween(Window.unboundedPreceding, 0)
@@ -202,8 +199,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
     windowAggregationTesterForDecimal(rowsWindow)
   }
 
-  testSparkResultsAreEqual("[Window] [ROWS] [Unspecified ordering] ", windowTestDfOrc,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+  testSparkResultsAreEqual("[Window] [ROWS] [Unspecified ordering] ", windowTestDfOrc) {
     val rowsWindow = Window.partitionBy("uid")
                            .rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
     windowAggregationTester(rowsWindow)
@@ -229,8 +225,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
     }
 
   testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [-2 DAYS, 3 DAYS] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -243,8 +238,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [DESC] [-2 DAYS, 3 DAYS] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -257,8 +251,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [-2 DAYS, CURRENT ROW] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -271,8 +264,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [DESC] [-2 DAYS, CURRENT ROW] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -285,8 +277,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [CURRENT ROW, 3 DAYS] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -299,8 +290,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [DESC] [CURRENT ROW, 3 DAYS] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -313,8 +303,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [CURRENT ROW, CURRENT ROW] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -327,8 +316,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [DESC] [CURRENT ROW, CURRENT ROW] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -341,8 +329,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [ASC] [Integral Type]",
-    windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -356,8 +343,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
 
   testSparkResultsAreEqual("[Window] [RANGE] [ASC] [Short Type]", windowTestDfOrc,
       new SparkConf().set("spark.rapids.sql.window.range.short.enabled", "true"),
-      skipCanonicalizationCheck = skipRangeCanon,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+      skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -370,8 +356,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [ASC] [Long Type]",
-    windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -385,8 +370,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
 
   testSparkResultsAreEqual("[Window] [RANGE] [ASC] [Byte Type]", windowTestDfOrc,
       new SparkConf().set("spark.rapids.sql.window.range.byte.enabled", "true"),
-      skipCanonicalizationCheck = skipRangeCanon,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+      skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -399,8 +383,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("[Window] [RANGE] [ASC] [Date Type]",
-    windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+    windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
 
     val windowClause =
       """
@@ -413,8 +396,7 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   }
 
   IGNORE_ORDER_testSparkResultsAreEqual("[Window] [MIXED WINDOW SPECS] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/5114")) {
+      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
     (df : DataFrame) => {
       df.createOrReplaceTempView("mytable")
       // scalastyle:off line.size.limit

--- a/tests/src/test/scala/com/nvidia/spark/rapids/lore/GpuLoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/lore/GpuLoreSuite.scala
@@ -77,7 +77,7 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("Aggregate") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
+    // The max value and number of values make it so that SUM will not overflow, so ANIS is good
     doTestReplay("10[*]") { spark =>
       spark.range(0, 1000, 1, 100)
         .selectExpr("id % 10 as key", "id % 100 as value")
@@ -87,7 +87,7 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("Broadcast join") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
+    // The max value and number of values make it so that SUM will not overflow, so ANIS is good
     doTestReplay("32[*]") { spark =>
       val df1 = spark.range(0, 1000, 1, 10)
         .selectExpr("id % 10 as key", "id % 100 as value")
@@ -104,7 +104,6 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("Subquery Filter") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     doTestReplay("13[*]") { spark =>
       spark.range(0, 100, 1, 10)
         .createTempView("df1")
@@ -117,7 +116,6 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("Subquery in projection") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     doTestReplay("11[*]") { spark =>
       spark.sql(
         """
@@ -136,7 +134,7 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("No broadcast join") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
+    // The max value and number of values make it so that SUM will not overflow, so ANIS is good
     doTestReplay("30[*]") { spark =>
       spark.conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
 
@@ -155,7 +153,7 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("AQE broadcast") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
+    // The max value and number of values make it so that SUM will not overflow, so ANIS is good
     doTestReplay("93[*]") { spark =>
       spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
 
@@ -174,7 +172,7 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("AQE Exchange") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
+    // The max value and number of values make it so that SUM will not overflow, so ANIS is good
     doTestReplay("28[*]") { spark =>
       spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
 
@@ -186,7 +184,6 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("Partition only") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withGpuSparkSession{ spark =>
       spark.conf.set(RapidsConf.LORE_DUMP_PATH.key, TEST_FILES_ROOT.getAbsolutePath)
       spark.conf.set(RapidsConf.LORE_DUMP_IDS.key, "3[0 2]")
@@ -208,7 +205,6 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("Non-empty lore dump path") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withGpuSparkSession{ spark =>
       spark.conf.set(RapidsConf.LORE_DUMP_PATH.key, TEST_FILES_ROOT.getAbsolutePath)
       spark.conf.set(RapidsConf.LORE_DUMP_IDS.key, "3[*]")
@@ -229,7 +225,6 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("GpuShuffledSymmetricHashJoin with SerializedTableColumn") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     doTestReplay("56[*]") { spark =>
       // Disable broadcast join, force hash join
       spark.conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
@@ -246,7 +241,6 @@ class GpuLoreSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir w
   }
 
   test("GpuShuffledSymmetricHashJoin with in Kudo mode") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     doTestReplay("56[*]") { spark =>
       // Disable broadcast join, force hash join
       spark.conf.set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/OrcFilterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/OrcFilterSuite.scala
@@ -39,7 +39,6 @@ class OrcFilterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("Support for pushing down filters for boolean types gpu write gpu read") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withTempPath { file =>
       var gpuPlans: Array[SparkPlan] = Array.empty
       val testConf = new SparkConf().set(
@@ -84,7 +83,6 @@ class OrcFilterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("Support for pushing down filters for boolean types cpu write gpu read") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withTempPath { file =>
       withCpuSparkSession(spark => {
         val data = (0 until 10).map(i => Tuple1(i == 2))
@@ -98,7 +96,6 @@ class OrcFilterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("Support for pushing down filters for decimal types gpu write gpu read") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withTempPath { file =>
       withGpuSparkSession(spark => {
         val data = (0 until 10).map(i => Tuple1(BigDecimal.valueOf(i)))
@@ -123,7 +120,6 @@ class OrcFilterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("Support for pushing down filters for decimal types cpu write gpu read") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withTempPath { file =>
       withCpuSparkSession(spark => {
         val data = (0 until 10).map(i => Tuple1(BigDecimal.valueOf(i)))
@@ -137,7 +133,6 @@ class OrcFilterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("Support for pushing down filters for timestamp types cpu write gpu read") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withTempPath { file =>
       withCpuSparkSession(spark => {
         val timeString = "2015-08-20 14:57:00"
@@ -174,7 +169,6 @@ class OrcFilterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("Support for pushing down filters for timestamp types gpu write gpu read") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withTempPath { file =>
       withGpuSparkSession(spark => {
         val timeString = "2015-08-20 14:57:00"

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFilterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFilterSuite.scala
@@ -263,7 +263,6 @@ class ParquetFilterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("SPARK-31026: Parquet predicate pushdown for fields having dots in the names") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/5114")
     withCpuSparkSession(spark => {
       import spark.implicits._
       val df1 = Seq(Some(1), None).toDF("col.dots")


### PR DESCRIPTION
This contributes to https://github.com/NVIDIA/spark-rapids/issues/5114 but does not finish it. Most aggregations that we support (really everything except SUM and AVG) don't care about ANSI support, so this just updates the tests to enable them and for the bit aggs enables them in the code too.

Some of the time I have it run with ANSI on and off for the tests, but most of the time I just run the test with the default.

There are a few cases where a SUM would overflow or a test will hit another ANSI error. In those cases I typically just force the test to be non-ANSI.

Some of the tests depended on other expressions that are not updated for ANSI yet (like multiply). So in those cases I kept the annotation to skip the test is ansi is on by default and pointed to the issue for it