### PR TITLE
Add Debug Metrics tracking the parallelism of multithreaded reader

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids
 import java.io.{File, IOException}
 import java.net.{URI, URISyntaxException}
 import java.util.concurrent.{Callable, ConcurrentLinkedQueue, ExecutorCompletionService, Future, ThreadPoolExecutor, TimeUnit}
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -354,6 +354,9 @@ abstract class MultiFileCloudPartitionReaderBase(
   // like in the case of a limit call and we don't read all files
   private var fcs: ExecutorCompletionService[HostMemoryBuffersWithMetaDataBase] = null
 
+  // Tracking the number of running tasks in the thread pool.
+  private val runningTaskNum = new AtomicInteger(0)
+
   // If I/O eager prefetch is enabled, submit async reading tasks eagerly instead of triggering
   // async reading tasks when the first batch is requested.
   // TODO: manage the priority of the read tasks, on-demand tasks should have the highest priority
@@ -364,18 +367,12 @@ abstract class MultiFileCloudPartitionReaderBase(
     logInfo(s"[${ctx.taskAttemptId()}] submit $numTasks async tasks eagerly for prefetch")
   }
 
-  private def addTaskFuture(fut: Future[HostMemoryBuffersWithMetaDataBase]): Unit = {
-    tasks.add(fut)
-    GpuTaskMetrics.get.updateMultithreadReaderMaxParallelism(tasks.size())
-  }
-
   private def initAndStartReaders(): Int = {
     // apply CAS to make sure we only init once
     if (!isInit.compareAndSet(false, true)) {
       return 0
     }
 
-    execMetrics.get("numPartedFiles").foreach(_.add(inputFiles.length))
     // limit the number we submit at once according to the config if set
     val limit = math.min(maxNumFileProcessed, inputFiles.length)
     val tc = TaskContext.get
@@ -392,6 +389,24 @@ abstract class MultiFileCloudPartitionReaderBase(
       logDebug("Keeping reads in same order")
     }
 
+    // A callable wrapper used to update related metrics
+    val newTaskRunner = (file: PartitionedFile) => {
+      new Callable[HostMemoryBuffersWithMetaDataBase] {
+
+        private val impl = getBatchRunner(tc, file, conf, filters)
+        private val metrics = GpuTaskMetrics.get
+
+        override def call(): HostMemoryBuffersWithMetaDataBase = {
+          metrics.updateMultithreadReaderMaxParallelism(runningTaskNum.incrementAndGet())
+          try {
+            impl.call()
+          } finally {
+            runningTaskNum.decrementAndGet()
+          }
+        }
+      }
+    }
+
     // Currently just add the files in order, we may consider doing something with the size of
     // the files in the future. ie try to start some of the larger files but we may not want
     // them all to be large
@@ -399,19 +414,19 @@ abstract class MultiFileCloudPartitionReaderBase(
       val file = inputFiles(i)
       logDebug(s"MultiFile reader using file $file")
       if (!keepReadsInOrder) {
-        val futureRunner = fcs.submit(getBatchRunner(tc, file, conf, filters))
-        addTaskFuture(futureRunner)
+        val futureRunner = fcs.submit(newTaskRunner(file))
+        tasks.add(futureRunner)
       } else {
         // Add these in the order as we got them so that we can make sure
         // we process them in the same order as CPU would.
         val threadPool = MultiFileReaderThreadPool.getOrCreateThreadPool(numThreads)
-        addTaskFuture(threadPool.submit(getBatchRunner(tc, file, conf, filters)))
+        tasks.add(threadPool.submit(newTaskRunner(file)))
       }
     }
     // queue up any left to add once others finish
     for (i <- limit until inputFiles.length) {
       val file = inputFiles(i)
-      tasksToRun.enqueue(getBatchRunner(tc, file, conf, filters))
+      tasksToRun.enqueue(newTaskRunner(file))
     }
     filesToRead = inputFiles.length
     limit
@@ -713,10 +728,10 @@ abstract class MultiFileCloudPartitionReaderBase(
       val runner = tasksToRun.dequeue()
       if (!keepReadsInOrder) {
         val futureRunner = fcs.submit(runner)
-        addTaskFuture(futureRunner)
+        tasks.add(futureRunner)
       } else {
         val threadPool = MultiFileReaderThreadPool.getOrCreateThreadPool(numThreads)
-        addTaskFuture(threadPool.submit(runner))
+        tasks.add(threadPool.submit(runner))
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -1918,6 +1918,15 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
       clippedSchema: MessageType,
       filePath: Path): (SpillableHostBuffer, Seq[BlockMetaData]) = {
     withResource(new NvtxRange("Parquet buffer file split", NvtxColor.YELLOW)) { _ =>
+      // Track the actual read buffer size, since some columns or partitions may be pruned
+      execMetrics.get("readBufferSize").foreach { metric =>
+        blocks.foreach { block =>
+          block.getColumns.asScala.foreach { column =>
+            metric += column.getTotalSize
+          }
+        }
+      }
+
       val estTotalSize = calculateParquetOutputSize(blocks, clippedSchema)
       val outHostBuf = withRetryNoSplit[HostMemoryBuffer] {
         HostMemoryBuffer.allocate(estTotalSize)
@@ -2235,6 +2244,15 @@ class MultiFileParquetPartitionReader(
       blocks: ArrayBuffer[DataBlockBase],
       offset: Long,
       batchContext: BatchContext): Callable[(Seq[DataBlockBase], Long)] = {
+    // Track the actual read buffer size, since some columns or partitions may be pruned
+    execMetrics.get("readBufferSize").foreach { metric =>
+      blocks.foreach { block =>
+        block.getColumns.asScala.foreach { column =>
+          metric += column.getTotalSize
+        }
+      }
+    }
+
     new ParquetCopyBlocksRunner(taskContext, file, outhmb, blocks, offset, compressCfg)
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -404,7 +404,7 @@ case class GpuFileSourceScanExec(
     DELETION_VECTOR_SIZE -> createSizeMetric(MODERATE_LEVEL, DESCRIPTION_DELETION_VECTOR_SIZE)
   ) ++ fileCacheMetrics ++ {
     relation.fileFormat match {
-      case fmt: GpuReadParquetFileFormat | _: GpuOrcFileFormat =>
+      case _: GpuReadParquetFileFormat | _: GpuOrcFileFormat =>
         val bf = Map.newBuilder[String, GpuMetric]
         bf += READ_FS_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_READ_FS_TIME)
         bf += WRITE_BUFFER_TIME -> createNanoTimingMetric(DEBUG_LEVEL,
@@ -413,7 +413,7 @@ case class GpuFileSourceScanExec(
           // Track the task number of multithreaded asynchronous I/O workloads
           bf += "numPartedFiles" -> createMetric(DEBUG_LEVEL, "number of PartitionedFiles")
         }
-        if (fmt.isInstanceOf[GpuReadParquetFileFormat]) {
+        if (relation.fileFormat.isInstanceOf[GpuReadParquetFileFormat]) {
           // Track the actual data size read from the file system, excluding data being pruned
           // by meta-level pruning.
           bf += "readBufferSize" -> createSizeMetric(DEBUG_LEVEL, "size of read buffer")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -221,6 +221,8 @@ class GpuTaskMetrics extends Serializable {
   private val onGpuTasksInWaitingQueueAvgCount = new AvgLongAccumulator
   private val onGpuTasksInWaitingQueueMaxCount = new MaxLongAccumulator
 
+  // This is used to track the max parallelism of multithreaded readers
+  private val multithreadReaderMaxParallelism = new MaxLongAccumulator
 
   // Spill
   private val spillToHostTimeNs = new NanoSecondAccumulator
@@ -292,7 +294,8 @@ class GpuTaskMetrics extends Serializable {
     "gpuMaxPinnedMemoryBytes" -> maxPinnedMemoryBytes,
     "gpuOnGpuTasksWaitingGPUAvgCount" -> onGpuTasksInWaitingQueueAvgCount,
     "gpuOnGpuTasksWaitingGPUMaxCount" -> onGpuTasksInWaitingQueueMaxCount,
-    "gpuMaxTaskFootprint" -> maxGpuFootprint
+    "gpuMaxTaskFootprint" -> maxGpuFootprint,
+    "multithreadReaderMaxParallelism" -> multithreadReaderMaxParallelism
   )
 
   def register(sc: SparkContext): Unit = {
@@ -422,6 +425,10 @@ class GpuTaskMetrics extends Serializable {
   def recordOnGpuTasksWaitingNumber(num: Int): Unit = {
     onGpuTasksInWaitingQueueAvgCount.add(num)
     onGpuTasksInWaitingQueueMaxCount.add(num)
+  }
+
+  def updateMultithreadReaderMaxParallelism(parallelism: Long): Unit = synchronized {
+    multithreadReaderMaxParallelism.add(parallelism)
   }
 }
 


### PR DESCRIPTION
Closes #13035

This PR adds two plan-level metrics: 
1.  `readBufferSize` tracks the actual amount of data reading through the I/O system, regarding the column pruning and partition filtering
2. `numPartedFiles` tracks the total number of PartitionedFiles which indicates the background I/O task number of multithread reader.

In addition, this PR tries to add a task-level metric as well(`multithreadReaderMaxParallelism`), to track the actual max I/O parallelism of multithread reader taken place during the run.