### PR TITLE
Fix failed cases in ParseDateTimeSuite for Spark 400

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -741,6 +741,25 @@ def test_to_date(ansi_enabled):
             .select(f.to_date(f.col("a").cast('string'), "yyyy-MM-dd")),
         {'spark.sql.ansi.enabled': ansi_enabled})
 
+# invalid values for operators: to_date, to_timestamp; Spark 320 and 320+ do not support special datetime: e.g.: now, today, ...
+_invalid_values_for_to_datetime = ['now', 'today', '']
+
+# test ANSI mode, invalid input
+@pytest.mark.parametrize('invalid', _invalid_values_for_to_datetime)
+def test_to_date_ansi_on_invalid_value(invalid):
+    assert_gpu_and_cpu_error(
+        lambda spark: spark.createDataFrame([(invalid,)], "a string").select(f.to_date(f.col("a"), "yyyy-MM-dd")).collect(),
+        conf = ansi_enabled_conf,
+        error_message="Exception")
+
+# test ANSI mode, invalid input
+@pytest.mark.parametrize('invalid', _invalid_values_for_to_datetime)
+def test_to_timestamp_ansi_on_invalid_value(invalid):
+    assert_gpu_and_cpu_error(
+        lambda spark: spark.createDataFrame([(invalid,)], "a string").select(f.to_timestamp(f.col("a"), "yyyy-MM-dd")).collect(),
+        conf = ansi_enabled_conf,
+        error_message="Exception")
+
 @tz_sensitive_test
 @pytest.mark.parametrize('data_gen', [StringGen('0[1-9][0-9]{4}')], ids=idfn)
 def test_to_date_format_MMyyyy(data_gen):

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -39,10 +39,12 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   private val CORRECTED_TIME_PARSER_POLICY: SparkConf = new SparkConf()
     .set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")
+    .set("spark.sql.ansi.enabled", "false")
 
   private val LEGACY_TIME_PARSER_POLICY_CONF: SparkConf = new SparkConf()
     .set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "LEGACY")
     .set(RapidsConf.INCOMPATIBLE_DATE_FORMATS.key, "true")
+    .set("spark.sql.ansi.enabled", "false")
 
   override def beforeEach(): Unit = {
     GpuOverrides.removeAllListeners()
@@ -56,61 +58,54 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     datesAsStrings,
     conf = new SparkConf().set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")
         .set(RapidsConf.INCOMPATIBLE_DATE_FORMATS.key, "true")
+        .set("spark.sql.ansi.enabled", "false")
         // until we fix https://github.com/NVIDIA/spark-rapids/issues/2118 we need to fall
         // back to CPU when parsing two-digit years
         .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,Alias,Cast,GetTimestamp,UnixTimestamp,Literal,ShuffleExchangeExec"),
-          assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+          "ProjectExec,Alias,Cast,GetTimestamp,UnixTimestamp,Literal,ShuffleExchangeExec")) {
     df => df.withColumn("c1", to_date(col("c0"), "dd/MM/yy"))
   }
 
 
   testSparkResultsAreEqual("to_date yyyy-MM-dd",
       datesAsStrings,
-      conf = CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("to_date yyyy-MM-dd LEGACY",
     datesAsStrings,
-    conf = LEGACY_TIME_PARSER_POLICY_CONF,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    conf = LEGACY_TIME_PARSER_POLICY_CONF) {
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("to_date yyyy/MM/dd LEGACY",
     datesAsStrings,
-    conf = LEGACY_TIME_PARSER_POLICY_CONF,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    conf = LEGACY_TIME_PARSER_POLICY_CONF) {
     df => df.withColumn("c1", to_date(col("c0"), "yyyy/MM/dd"))
   }
 
   testSparkResultsAreEqual("to_date dd/MM/yyyy",
       datesAsStrings,
-      conf = CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_date(col("c0"), "dd/MM/yyyy"))
   }
 
   testSparkResultsAreEqual("to_date dd/MM/yyyy LEGACY",
     datesAsStrings,
-    conf = LEGACY_TIME_PARSER_POLICY_CONF,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    conf = LEGACY_TIME_PARSER_POLICY_CONF) {
     df => df.withColumn("c1", to_date(col("c0"), "dd/MM/yyyy"))
   }
 
   testSparkResultsAreEqual("to_date MM/dd/yyyy",
       datesAsStrings,
-      conf = CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_date(col("c0"), "MM/dd/yyyy"))
   }
 
   testSparkResultsAreEqual("to_date yyyy/MM",
     datesAsStrings,
-    conf = CORRECTED_TIME_PARSER_POLICY,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_date(col("c0"), "yyyy/MM"))
   }
 
@@ -128,15 +123,13 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
       timestampsAsStrings,
-      conf = CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_timestamp(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("to_timestamp dd/MM/yyyy",
       timestampsAsStrings,
-      conf = CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_timestamp(col("c0"), "dd/MM/yyyy"))
   }
 
@@ -144,29 +137,26 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     datesAsStrings,
     CORRECTED_TIME_PARSER_POLICY
         // All of the dates being parsed are valid for all of the versions of Spark supported.
-        .set(RapidsConf.HAS_EXTENDED_YEAR_VALUES.key, "false"),
-        assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+        .set(RapidsConf.HAS_EXTENDED_YEAR_VALUES.key, "false")
+        .set("spark.sql.ansi.enabled", "false")) {
     df => df.withColumn("c1", to_date(col("c0")))
   }
 
   testSparkResultsAreEqual("unix_timestamp parse date",
       timestampsAsStrings,
-      CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("unix_timestamp parse yyyy/MM",
     timestampsAsStrings,
-    CORRECTED_TIME_PARSER_POLICY,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy/MM"))
   }
 
   testSparkResultsAreEqual("to_unix_timestamp parse yyyy/MM",
     timestampsAsStrings,
-    CORRECTED_TIME_PARSER_POLICY,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    CORRECTED_TIME_PARSER_POLICY) {
     df => {
       df.createOrReplaceTempView("df")
       val spark = getActiveSession
@@ -176,22 +166,19 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   testSparkResultsAreEqual("unix_timestamp parse timestamp",
       timestampsAsStrings,
-      CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd HH:mm:ss"))
   }
 
   testSparkResultsAreEqual("unix_timestamp parse yyyy-MM-dd HH:mm:ss LEGACY",
     timestampsAsStrings,
-    LEGACY_TIME_PARSER_POLICY_CONF,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    LEGACY_TIME_PARSER_POLICY_CONF) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd HH:mm:ss"))
   }
 
   testSparkResultsAreEqual("unix_timestamp parse yyyy/MM/dd HH:mm:ss LEGACY",
     timestampsAsStrings,
-    LEGACY_TIME_PARSER_POLICY_CONF,
-    assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+    LEGACY_TIME_PARSER_POLICY_CONF) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy/MM/dd HH:mm:ss"))
   }
 
@@ -199,15 +186,14 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     timestampsAsStrings,
     new SparkConf().set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-        "ProjectExec,Alias,UnixTimestamp,Literal,ShuffleExchangeExec"),
-        assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+        "ProjectExec,Alias,UnixTimestamp,Literal,ShuffleExchangeExec")
+      .set("spark.sql.ansi.enabled", "false")) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd HH:mm:ss.SSS"))
   }
 
   testSparkResultsAreEqual("unix_timestamp parse timestamp default pattern",
       timestampsAsStrings,
-      CORRECTED_TIME_PARSER_POLICY,
-      assumeCondition = ignoreAnsi("https://github.com/NVIDIA/spark-rapids/issues/12632")) {
+      CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", unix_timestamp(col("c0")))
   }
 
@@ -250,26 +236,6 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     // make sure we aren't suggesting enabling INCOMPATIBLE_DATE_FORMATS for something we
     // can never support
     assert(!planStr.contains(RapidsConf.INCOMPATIBLE_DATE_FORMATS.key))
-  }
-
-  test("parse now") {
-    skipIfAnsiEnabled("https://github.com/NVIDIA/spark-rapids/issues/12632")
-    def now(spark: SparkSession) = {
-      import spark.implicits._
-      Seq("now").toDF("c0")
-          .repartition(2)
-          .withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd HH:mm:ss"))
-    }
-    val startTimeSeconds = System.currentTimeMillis() / 1000L
-    val cpuNowSeconds = withCpuSparkSession(now).collect().head.toSeq(1).asInstanceOf[Long]
-    val gpuNowSeconds = withGpuSparkSession(now).collect().head.toSeq(1).asInstanceOf[Long]
-    // For Spark 3.2+, "now" will NOT be parsed as the current time
-    if (!VersionUtils.isSpark320OrLater) {
-      assert(cpuNowSeconds >= startTimeSeconds)
-      assert(gpuNowSeconds >= startTimeSeconds)
-    }
-    // CPU ran first so cannot have a greater value than the GPU run (but could be the same second)
-    assert(cpuNowSeconds <= gpuNowSeconds)
   }
 
   test("Regex: Remove whitespace from month and day") {


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/12632

This PR first enable all the skipped cases.

### Why these cases failed before
Spark 400 changed  the default Ansi mode from false to true.
Before Spark 400 versions, these cases always pass although data contains invalid values which result in nulls.
But for Spark 400 version, these cases throw exception.

### Fixes
- Explicitly specify Ansi mode is off.
- Add pytest cases to test Ansi on and invalid values
- Remove the case: test("parse now"), it's a invalid from Spark 320.
  For Spark 320 and 320+,  `now` special datetime results in null, and thus the query of the timestamp is a wrong behavior:

```scala
scala> import spark.implicits._
scala> Seq("now").toDF("c0").withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd HH:mm:ss")).show()
+---+----+
| c0|  c1|
+---+----+
|now|NULL|
+---+----+

scala> Seq("now").toDF("c0").withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd HH:mm:ss")).collect().head.toSeq(1).asInstanceOf[Long]
val res8: Long = 0

```

Signed-off-by: Chong Gao <res_life@163.com>