### PR TITLE
Re-xfail test_delta_update_fallback_with_deletion_vectors for databricks

### DIFF
--- a/integration_tests/src/main/python/delta_lake_update_test.py
+++ b/integration_tests/src/main/python/delta_lake_update_test.py
@@ -67,6 +67,7 @@ def assert_delta_sql_update_collect(spark_tmp_path, use_cdf, enable_deletion_vec
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors(), reason="Deletion vectors aren't supported")
+@pytest.mark.xfail(condition=is_databricks_runtime() and not is_databricks143_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12123")
 def test_delta_update_fallback_with_deletion_vectors(spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     def setup_tables(spark):


### PR DESCRIPTION
`test_delta_update_fallback_with_deletion_vectors` was accidentally unxfailed for databricks in https://github.com/NVIDIA/spark-rapids/pull/13014. We still need it to xfail for databricks.