### PR TITLE
Spark-4.0: Enable ansi mode for some of the integration tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -19,7 +19,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_cpu_and_gpu_are
 from conftest import is_databricks_runtime, is_not_utc
 from data_gen import *
 from spark_session import is_spark_400_or_later
-from marks import ignore_order, allow_non_gpu, disable_ansi_mode
+from marks import ignore_order, allow_non_gpu
 from spark_session import with_cpu_session, is_databricks113_or_later, is_before_spark_330, is_databricks_version_or_later
 
 # allow non gpu when time zone is non-UTC because of https://github.com/NVIDIA/spark-rapids/issues/9653'
@@ -58,8 +58,6 @@ def test_aqe_skew_join():
 # Test the computeStats(...) implementation in GpuDataSourceScanExec
 @ignore_order(local=True)
 @pytest.mark.parametrize("data_gen", integral_gens, ids=idfn)
-# https://github.com/NVIDIA/spark-rapids/issues/5114
-@disable_ansi_mode
 def test_aqe_join_parquet(spark_tmp_path, data_gen):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     with_cpu_session(
@@ -77,8 +75,6 @@ def test_aqe_join_parquet(spark_tmp_path, data_gen):
 # Test the computeStats(...) implementation in GpuBatchScanExec
 @ignore_order(local=True)
 @pytest.mark.parametrize("data_gen", integral_gens, ids=idfn)
-# https://github.com/NVIDIA/spark-rapids/issues/5114
-@disable_ansi_mode
 def test_aqe_join_parquet_batch(spark_tmp_path, data_gen):
     # force v2 source for parquet to use BatchScanExec
     conf = copy_and_update(_adaptive_conf, {

--- a/integration_tests/src/main/python/datasourcev2_read_test.py
+++ b/integration_tests/src/main/python/datasourcev2_read_test.py
@@ -45,8 +45,6 @@ def test_read_all_types():
 
 
 @allow_non_gpu('BatchScanExec')
-@disable_ansi_mode  # Cannot run in ANSI mode until COUNT aggregation is supported.
-                    # See https://github.com/NVIDIA/spark-rapids/issues/5114
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_all_types_count():
     assert_gpu_and_cpu_row_counts_equal(

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -19,7 +19,7 @@ from pyspark.sql.types import IntegerType
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_and_cpu_are_equal_collect
 from conftest import spark_tmp_table_factory
 from data_gen import *
-from marks import ignore_order, allow_non_gpu, datagen_overrides, disable_ansi_mode
+from marks import ignore_order, allow_non_gpu, datagen_overrides
 from spark_session import is_before_spark_320, with_cpu_session, is_before_spark_312, is_databricks_runtime, is_databricks113_or_later, is_databricks_version_or_later
 
 # non-positive values here can produce a degenerative join, so here we ensure that most values are
@@ -173,7 +173,6 @@ _statements = [
 # Further details are furnished at https://github.com/NVIDIA/spark-rapids/issues/11764.
 dpp_fallback_execs=["CollectLimitExec"] if is_databricks_version_or_later(14,3) else []
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # When BroadcastExchangeExec is available on filtering side, and it can be reused:
 # DynamicPruningExpression(InSubqueryExec(value, GpuSubqueryBroadcastExec)))
 @ignore_order
@@ -205,7 +204,6 @@ def test_dpp_reuse_broadcast_exchange(spark_tmp_table_factory, store_format, s_i
         conf=dict(_exchange_reuse_conf + [('spark.sql.adaptive.enabled', aqe_enabled)]))
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # The SubqueryBroadcast can work on GPU even if the scan who holds it fallbacks into CPU.
 @ignore_order
 @pytest.mark.allow_non_gpu('FileSourceScanExec')
@@ -223,7 +221,6 @@ def test_dpp_reuse_broadcast_exchange_cpu_scan(spark_tmp_table_factory):
             ('spark.rapids.sql.format.parquet.read.enabled', 'false')]))
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # When BroadcastExchange is not available and non-broadcast DPPs are forbidden, Spark will bypass it:
 # DynamicPruningExpression(Literal.TrueLiteral)
 @ignore_order
@@ -247,7 +244,6 @@ def test_dpp_bypass(spark_tmp_table_factory, store_format, s_index, aqe_enabled)
         conf=dict(_bypass_conf + [('spark.sql.adaptive.enabled', aqe_enabled)]))
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # When BroadcastExchange is not available, but it is still worthwhile to run DPP,
 # then Spark will plan an extra Aggregate to collect filtering values:
 # DynamicPruningExpression(InSubqueryExec(value, SubqueryExec(Aggregate(...))))
@@ -272,7 +268,6 @@ def test_dpp_via_aggregate_subquery(spark_tmp_table_factory, store_format, s_ind
         conf=dict(_no_exchange_reuse_conf + [('spark.sql.adaptive.enabled', aqe_enabled)]))
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # When BroadcastExchange is not available, Spark will skip DPP if there is no potential benefit
 @ignore_order
 @pytest.mark.parametrize('store_format', ['parquet', 'orc'], ids=idfn)
@@ -335,7 +330,6 @@ def test_dpp_like_any(spark_tmp_table_factory, store_format, aqe_enabled):
         conf=dict(_exchange_reuse_conf + [('spark.sql.adaptive.enabled', aqe_enabled)]))
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @allow_non_gpu(*dpp_fallback_execs)
 # Test handling DPP expressions from a HashedRelation that rearranges columns
 @pytest.mark.parametrize('aqe_enabled', [
@@ -369,7 +363,6 @@ def test_dpp_from_swizzled_hash_keys(spark_tmp_table_factory, aqe_enabled):
 
 
 @allow_non_gpu("EmptyRelationExec")  # 'EmptyRelationExec' is introduced from Spark 400
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # Test handling DPP subquery that could broadcast EmptyRelation rather than a GPU serialized batch
 @pytest.mark.parametrize('aqe_enabled', [
     'false',

--- a/integration_tests/src/main/python/grouping_sets_test.py
+++ b/integration_tests/src/main/python/grouping_sets_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/grouping_sets_test.py
+++ b/integration_tests/src/main/python/grouping_sets_test.py
@@ -42,7 +42,6 @@ _grouping_set_sqls = [
 ]
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # test nested syntax of grouping set, rollup and cube
 @ignore_order
 @pytest.mark.parametrize('data_gen', [_grouping_set_gen], ids=idfn)

--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -475,8 +475,6 @@ def test_custom_timestamp_formats_disabled(spark_tmp_path, data_gen, spark_tmp_t
         conf=hive_text_enabled_conf)
 
 
-@disable_ansi_mode  # Cannot run in ANSI mode until COUNT aggregation is supported.
-                    # See https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.skipif(is_spark_cdh(),
                     reason="Hive text reads are disabled on CDH, as per "
                            "https://github.com/NVIDIA/spark-rapids/pull/7628")

--- a/integration_tests/src/main/python/kudo_dump_test.py
+++ b/integration_tests/src/main/python/kudo_dump_test.py
@@ -21,7 +21,6 @@ from data_gen import *
 from marks import *
 import pyspark.sql.functions as f
 
-@disable_ansi_mode
 @ignore_order(local=True)
 @pytest.mark.skipif(not is_apache_runtime() and not is_databricks_runtime(), reason="only test on local file system")
 def test_kudo_serializer_debug_dump(spark_tmp_path):

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -527,7 +527,6 @@ def test_parquet_read_buffer_allocation_empty_blocks(spark_tmp_path, v1_enabled_
             conf=all_confs)
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/7733")
@@ -849,7 +848,7 @@ def test_parquet_read_nano_as_longs_true(std_input_path):
         conf=conf)
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
+@allow_non_gpu('ProjectExec') # ProjectExec will fallback to CPU on Spark-4.0 due to some optimizations.
 def test_many_column_project():
     def _create_wide_data_frame(spark, num_cols):
         schema_dict = {}
@@ -1586,7 +1585,6 @@ def test_parquet_read_encryption(spark_tmp_path, reader_confs, v1_enabled_list):
         error_message='The GPU does not support reading encrypted Parquet files')
 
 
-@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 def test_parquet_read_count(spark_tmp_path):
     parquet_gens = [int_gen, string_gen, double_gen]
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -848,7 +848,9 @@ def test_parquet_read_nano_as_longs_true(std_input_path):
         conf=conf)
 
 
-@allow_non_gpu('ProjectExec') # ProjectExec will fallback to CPU on Spark-4.0 due to some optimizations.
+# ProjectExec will fallback to CPU since Multiply expr is not supported with ANSI mode.
+# https://github.com/NVIDIA/spark-rapids/issues/13054
+@allow_non_gpu('ProjectExec')
 def test_many_column_project():
     def _create_wide_data_frame(spark, num_cols):
         schema_dict = {}

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -848,8 +848,8 @@ def test_parquet_read_nano_as_longs_true(std_input_path):
         conf=conf)
 
 
-def test_many_column_project(spark_tmp_path):
-
+@allow_non_gpu('ProjectExec') # ProjectExec will fallback to CPU on Spark-4.0 due to some optimizations.
+def test_many_column_project():
     def _create_wide_data_frame(spark, num_cols):
         schema_dict = {}
         for i in range(num_cols):
@@ -857,11 +857,8 @@ def test_many_column_project(spark_tmp_path):
         return spark.createDataFrame([Row(**r) for r in [schema_dict]])\
             .withColumn('out', f.col('c1') * 100)
 
-    data_path = spark_tmp_path + '/PARQUET_DATA'
-    with_cpu_session(lambda spark: _create_wide_data_frame(spark, 1000).write.parquet(data_path))
-
     assert_gpu_and_cpu_are_equal_collect(
-        func=lambda spark: spark.read.parquet(data_path),
+        func=lambda spark: _create_wide_data_frame(spark, 1000),
         is_cpu_first=False)
 
 def setup_parquet_file_with_column_names(spark, table_name):


### PR DESCRIPTION
This PR contributes to https://github.com/NVIDIA/spark-rapids/issues/11106

After revisiting all the tests with disable_ansi_mode label, the tests in this PR can be enabled to run with ansi enabled for Spark-4.0. Most of the tests were disabled due to lack of ansi support for SUM aggregation. It was added recently and the tests pass now.

For `test_many_column_project` in parquet_test.py:
- The ProjectExec would fallback to CPU if the dataframe is read from Scan ExistingRDD, so added allow_non_gpu for that test.


Testing:

Ran the integration tests on each file in this PR and there are no failures:
 `./integration_tests/run_pyspark_from_build.sh -k '<PYTHON_FILE_NAME>` 