### PR TITLE
Revert "declare shuffle thread for threaded writer and reader"

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -307,9 +307,13 @@ else
     # Set the Delta log cache size to prevent the driver from caching every Delta log indefinitely
     export PYSP_TEST_spark_databricks_delta_delta_log_cacheSize=${PYSP_TEST_spark_databricks_delta_delta_log_cacheSize:-10}
     deltaCacheSize=$PYSP_TEST_spark_databricks_delta_delta_log_cacheSize
+    # currently the only test feature this enables is OOM injection
+    # we enable the java property in the driver and executor, in case the tests are running in 
+    # local mode or in standalone mode.
+    ENABLE_TEST_FEATURES="-Dcom.nvidia.spark.rapids.runningTests=true"
     DRIVER_EXTRA_JAVA_OPTIONS="-ea -Duser.timezone=$TZ -Ddelta.log.cacheSize=$deltaCacheSize"
-    export PYSP_TEST_spark_driver_extraJavaOptions="$DRIVER_EXTRA_JAVA_OPTIONS $COVERAGE_SUBMIT_FLAGS"
-    export PYSP_TEST_spark_executor_extraJavaOptions="-ea -Duser.timezone=$TZ"
+    export PYSP_TEST_spark_driver_extraJavaOptions="$DRIVER_EXTRA_JAVA_OPTIONS $COVERAGE_SUBMIT_FLAGS $ENABLE_TEST_FEATURES"
+    export PYSP_TEST_spark_executor_extraJavaOptions="-ea -Duser.timezone=$TZ $ENABLE_TEST_FEATURES"
 
     # TODO: https://github.com/NVIDIA/spark-rapids/issues/10940
     export PYSP_TEST_spark_driver_memory=${PYSP_TEST_spark_driver_memory:-"${MB_PER_EXEC}m"}

--- a/pom.xml
+++ b/pom.xml
@@ -1502,7 +1502,6 @@ This will force full Scala code rebuild in downstream modules.
                         <argLine>${argLine} -ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
                         <stderr/>
                         <systemProperties>
-			    <com.nvidia.spark.rapids.runningTests>true</com.nvidia.spark.rapids.runningTests>
                             <rapids.shuffle.manager.override>${rapids.shuffle.manager.override}</rapids.shuffle.manager.override>
                             <ai.rapids.refcount.debug>true</ai.rapids.refcount.debug>
                             <java.awt.headless>true</java.awt.headless>

--- a/pom.xml
+++ b/pom.xml
@@ -1502,6 +1502,7 @@ This will force full Scala code rebuild in downstream modules.
                         <argLine>${argLine} -ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
                         <stderr/>
                         <systemProperties>
+			    <com.nvidia.spark.rapids.runningTests>true</com.nvidia.spark.rapids.runningTests>
                             <rapids.shuffle.manager.override>${rapids.shuffle.manager.override}</rapids.shuffle.manager.override>
                             <ai.rapids.refcount.debug>true</ai.rapids.refcount.debug>
                             <java.awt.headless>true</java.awt.headless>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2586,8 +2586,8 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
       .toLowerCase.toBoolean
     if (!res) {
       logDebug("OOM injection in tests disable. To enable, set java property " +
-        s"`-Dcom.nvidia.spark.rapids.runningTest=true`, and configure using " +
-        "${TEST_RETRY_OOM_INJECTION_MODE.key}.")
+        "`-Dcom.nvidia.spark.rapids.runningTest=true`, and configure using " +
+        s"${TEST_RETRY_OOM_INJECTION_MODE.key}.")
     }
     res
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -318,7 +318,7 @@ object RapidsReaderType extends Enumeration {
   val AUTO, COALESCING, MULTITHREADED, PERFILE = Value
 }
 
-object RapidsConf {
+object RapidsConf extends Logging {
   val MULTITHREAD_READ_NUM_THREADS_DEFAULT = 20
   private val registeredConfs = new ListBuffer[ConfEntry[_]]()
 
@@ -2571,6 +2571,79 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
       .bytesConf(ByteUnit.BYTE)
       .createWithDefault(2L * 1024 * 1024 * 1024)
 
+  // default value for the OOM injection logic (no injection, for regular operation)
+  private val noInjection = OomInjectionConf(
+    numOoms = 0,
+    skipCount = 0,
+    oomInjectionFilter = OomInjectionType.CPU_OR_GPU,
+    withSplit = false)
+
+  // a java property to tell whether we need to check for oom injection configs in SQLConf
+  // only if we are running tests. This is set to true in
+  // integration_tests/run_pyspark_from_build.sh
+  lazy val runningTests = {
+    val res = System.getProperty("com.nvidia.spark.rapids.runningTests", "false")
+      .toLowerCase.toBoolean
+    if (!res) {
+      logDebug("OOM injection in tests disable. To enable, set java property " +
+        s"`-Dcom.nvidia.spark.rapids.runningTest=true`, and configure using " +
+        "${TEST_RETRY_OOM_INJECTION_MODE.key}.")
+    }
+    res
+  }
+
+  /**
+   * Convert a configured injection string to the injection configuration OomInjection,
+   * if enabled via com.nvidia.spark.rapids.runningTests java property.
+   *
+   * The new format is a CSV in any order
+   *  "num_ooms=<integer>,skip=<integer>,type=<string value of OomInjectionType>"
+   *
+   * "type" maps to OomInjectionType to run count against oomCount and skipCount
+   * "num_ooms" maps to oomCount (default 1), the number of allocations resulting in an OOM
+   * "skip" maps to skipCount (default 0), the number of matching  allocations to skip before
+   * injecting an OOM at the skip+1st allocation.
+   * *split* maps to withSplit (default false), determining whether to inject
+   * *SplitAndRetryOOM instead of plain *RetryOOM exceptions
+   *
+   * For backwards compatibility support existing binary configuration
+   *   "false", disabled, i.e. oomCount=0, skipCount=0, injectionType=None
+   *   "true" or anything else but "false"  yields the default
+   *      oomCount=1, skipCount=0, injectionType=CPU_OR_GPU, withSplit=false
+   */
+  def testRetryOOMInjectionMode(): OomInjectionConf = {
+    if (!runningTests) {
+      // this is the common case
+      noInjection
+    } else {
+      TEST_RETRY_OOM_INJECTION_MODE.get(SQLConf.get).toLowerCase match {
+        case "false" => noInjection
+        case "true" =>
+          OomInjectionConf(numOoms = 1, skipCount = 0,
+            oomInjectionFilter = OomInjectionType.CPU_OR_GPU, withSplit = false)
+        case injectConfStr =>
+          val injectConfMap = injectConfStr.split(',').map(_.split('=')).collect {
+            case Array(k, v) => k -> v
+          }.toMap
+          val numOoms = injectConfMap.getOrElse("num_ooms", 1.toString)
+          val skipCount = injectConfMap.getOrElse("skip", 0.toString)
+          val oomFilterStr = injectConfMap
+            .getOrElse("type", OomInjectionType.CPU_OR_GPU.toString)
+            .toUpperCase()
+          val oomFilter = OomInjectionType.valueOf(oomFilterStr)
+          val withSplit = injectConfMap.getOrElse("split", false.toString)
+          val ret = OomInjectionConf(
+            numOoms = numOoms.toInt,
+            skipCount = skipCount.toInt,
+            oomInjectionFilter = oomFilter,
+            withSplit = withSplit.toBoolean
+          )
+          logDebug(s"Parsed ${ret} from ${injectConfStr} via injectConfMap=${injectConfMap}");
+          ret
+      }
+    }
+  }
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -2840,54 +2913,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val asyncWriteMaxInFlightHostMemoryBytes: Long =
     get(ASYNC_WRITE_MAX_IN_FLIGHT_HOST_MEMORY_BYTES)
-
-  /**
-   * Convert a string value to the injection configuration OomInjection.
-   *
-   * The new format is a CSV in any order
-   *  "num_ooms=<integer>,skip=<integer>,type=<string value of OomInjectionType>"
-   *
-   * "type" maps to OomInjectionType to run count against oomCount and skipCount
-   * "num_ooms" maps to oomCount (default 1), the number of allocations resulting in an OOM
-   * "skip" maps to skipCount (default 0), the number of matching  allocations to skip before
-   * injecting an OOM at the skip+1st allocation.
-   * *split* maps to withSplit (default false), determining whether to inject
-   * *SplitAndRetryOOM instead of plain *RetryOOM exceptions
-   *
-   * For backwards compatibility support existing binary configuration
-   *   "false", disabled, i.e. oomCount=0, skipCount=0, injectionType=None
-   *   "true" or anything else but "false"  yields the default
-   *      oomCount=1, skipCount=0, injectionType=CPU_OR_GPU, withSplit=false
-   */
-  lazy val testRetryOOMInjectionMode : OomInjectionConf = {
-    get(TEST_RETRY_OOM_INJECTION_MODE).toLowerCase match {
-      case "false" =>
-        OomInjectionConf(numOoms = 0, skipCount = 0,
-        oomInjectionFilter = OomInjectionType.CPU_OR_GPU, withSplit = false)
-      case "true" =>
-        OomInjectionConf(numOoms = 1, skipCount = 0,
-          oomInjectionFilter = OomInjectionType.CPU_OR_GPU, withSplit = false)
-      case injectConfStr =>
-        val injectConfMap = injectConfStr.split(',').map(_.split('=')).collect {
-          case Array(k, v) => k -> v
-        }.toMap
-        val numOoms = injectConfMap.getOrElse("num_ooms", 1.toString)
-        val skipCount = injectConfMap.getOrElse("skip", 0.toString)
-        val oomFilterStr = injectConfMap
-          .getOrElse("type", OomInjectionType.CPU_OR_GPU.toString)
-          .toUpperCase()
-        val oomFilter = OomInjectionType.valueOf(oomFilterStr)
-        val withSplit = injectConfMap.getOrElse("split", false.toString)
-        val ret = OomInjectionConf(
-          numOoms = numOoms.toInt,
-          skipCount = skipCount.toInt,
-          oomInjectionFilter = oomFilter,
-          withSplit = withSplit.toBoolean
-        )
-        logDebug(s"Parsed ${ret} from ${injectConfStr} via injectConfMap=${injectConfMap}");
-        ret
-    }
-  }
 
   lazy val testingAllowedNonGpu: Seq[String] = get(TEST_ALLOWED_NONGPU)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -654,7 +654,7 @@ object RmmRapidsRetryIterator extends Logging {
             case mode if !injectedOOM && mode.numOoms > 0 =>
               injectedOOM = true
               // ensure we have associated our thread with the running task, as
-              // `forceRetryOOM` requires a prior association.v
+              // `forceRetryOOM` requires a prior association.
               var threadAssociated = true
               if (!RmmSpark.isThreadWorkingOnTaskAsPoolThread) {
                 // If RmmSpark isn't aware of this thread, we are going to

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -30,7 +30,6 @@ import com.nvidia.spark.rapids.NvtxRegistry
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.format.TableMeta
-import com.nvidia.spark.rapids.jni.RmmSpark
 import com.nvidia.spark.rapids.shuffle.{RapidsShuffleRequestHandler, RapidsShuffleServer, RapidsShuffleTransport}
 
 import org.apache.spark.{InterruptibleIterator, MapOutputTracker, ShuffleDependency, SparkConf, SparkEnv, TaskContext}
@@ -238,7 +237,6 @@ trait RapidsShuffleWriterShimHelper {
 abstract class RapidsShuffleThreadedWriterBase[K, V](
     blockManager: BlockManager,
     handle: ShuffleHandleWithMetrics[K, V, V],
-    context: TaskContext,
     mapId: Long,
     sparkConf: SparkConf,
     writeMetrics: ShuffleWriteMetricsReporter,
@@ -366,13 +364,11 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
                 writeFutures += RapidsShuffleInternalManagerBase.queueWriteTask(slotNum, () => {
                   withResource(cb) { _ =>
                     try {
-                      RmmSpark.shuffleThreadWorkingOnTasks(Array(context.taskAttemptId()))
                       val recordWriteTimeStart = System.nanoTime()
                       myWriter.write(key, value)
                       recordWriteTime.getAndAdd(System.nanoTime() - recordWriteTimeStart)
                     } finally {
                       limiter.release(size)
-                      RmmSpark.shuffleThreadFinishedForTasks(Array(context.taskAttemptId()))
                     }
                   }
                 })
@@ -879,7 +875,6 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
       futures += RapidsShuffleInternalManagerBase.queueReadTask(slot, () => {
         var success = false
         try {
-          RmmSpark.shuffleThreadWorkingOnTasks(Array(context.taskAttemptId()))
           var currentBatchSize = blockState.getNextBatchSize
           var didFit = true
           while (blockState.hasNext && didFit) {
@@ -899,7 +894,6 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
           if (!success) {
             blockState.close()
           }
-          RmmSpark.shuffleThreadFinishedForTasks(Array(context.taskAttemptId()))
         }
       })
     }
@@ -1363,7 +1357,6 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
             new RapidsShuffleThreadedWriter[K, V](
               blockManager,
               handleWithMetrics,
-              context,
               mapId,
               conf,
               new ThreadSafeShuffleWriteMetricsReporter(metricsReporter),

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedWriter.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedWriter.scala
@@ -48,7 +48,7 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
 import org.apache.spark.shuffle.api.{ShuffleExecutorComponents, ShuffleMapOutputWriter}
 import org.apache.spark.sql.rapids.{RapidsShuffleThreadedWriterBase, ShuffleHandleWithMetrics}
@@ -63,7 +63,6 @@ object RapidsShuffleThreadedWriter {
 class RapidsShuffleThreadedWriter[K, V](
     blockManager: BlockManager,
     handle: ShuffleHandleWithMetrics[K, V, V],
-    context: TaskContext,
     mapId: Long,
     sparkConf: SparkConf,
     writeMetrics: ShuffleWriteMetricsReporter,
@@ -73,7 +72,6 @@ class RapidsShuffleThreadedWriter[K, V](
   extends RapidsShuffleThreadedWriterBase[K, V](
     blockManager,
     handle,
-    context,
     mapId,
     sparkConf,
     writeMetrics,

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -288,7 +288,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     val writer = new RapidsShuffleThreadedWriter[Int, Int](
       blockManager,
       shuffleHandle,
-      taskContext,
       0L, // MapId
       conf,
       taskContext.taskMetrics().shuffleWriteMetrics,
@@ -317,7 +316,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
       val writer = new RapidsShuffleThreadedWriter[Int, Int](
         blockManager,
         shuffleHandle,
-        taskContext,
         0L, // MapId
         transferConf,
         new ThreadSafeShuffleWriteMetricsReporter(taskContext.taskMetrics().shuffleWriteMetrics),
@@ -356,7 +354,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     val writer = new RapidsShuffleThreadedWriter[Int, Int](
       blockManager,
       shuffleHandle,
-      taskContext,
       0L, // MapId
       conf,
       taskContext.taskMetrics().shuffleWriteMetrics,
@@ -381,7 +378,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     val writer = new RapidsShuffleThreadedWriter[Int, Int](
       blockManager,
       shuffleHandle,
-      taskContext,
       0L, // MapId
       conf,
       taskContext.taskMetrics().shuffleWriteMetrics,
@@ -439,7 +435,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     val writer = new RapidsShuffleThreadedWriter[Int, Int](
       blockManager,
       shuffleHandle,
-      taskContext,
       mapId,
       conf,
       new ThreadSafeShuffleWriteMetricsReporter(taskContext.taskMetrics().shuffleWriteMetrics),
@@ -471,7 +466,6 @@ class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
       val writer = new RapidsShuffleThreadedWriter[Int, BadSerializable](
         blockManager,
         shuffleHandle,
-        taskContext,
         0L, // MapId
         conf,
         new ThreadSafeShuffleWriteMetricsReporter(taskContext.taskMetrics().shuffleWriteMetrics),


### PR DESCRIPTION
This reverts https://github.com/NVIDIA/spark-rapids/pull/12973 for the 25.08 release. 

We have seen this change cause regressions that relate to locking within the SparkResourceAdaptor in spark-rapids-jni. We would like to hold off on the change for now. The main effect of reverting is we go back to having a higher chance of OOM false positives => added spill pressure.

There's a second report of CI failing after this change, and this change may clear that too, but we want to get to the bottom of the CI issue separately.

I have filed https://github.com/NVIDIA/spark-rapids/pull/13056 for follow up after this PR