### PR TITLE
Disable approx_percentile tests temporarily to unblock CI

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1230,6 +1230,7 @@ def test_exact_percentile_groupby_partial_fallback_to_cpu(data_gen, replace_mode
 
 
 @ignore_order(local=True)
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec',
                'HashAggregateExec', 'HashPartitioning',
@@ -1887,6 +1888,7 @@ def test_agg_nested_map(kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled})
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_reduction(aqe_enabled, kudo_enabled):
@@ -1897,6 +1899,7 @@ def test_hash_groupby_approx_percentile_reduction(aqe_enabled, kudo_enabled):
         [0.05, 0.25, 0.5, 0.75, 0.95], conf, reduction = True)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_reduction_single_row(aqe_enabled, kudo_enabled):
@@ -1907,6 +1910,7 @@ def test_hash_groupby_approx_percentile_reduction_single_row(aqe_enabled, kudo_e
         [0.05, 0.25, 0.5, 0.75, 0.95], conf, reduction = True)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_reduction_no_rows(aqe_enabled, kudo_enabled):
@@ -1917,6 +1921,7 @@ def test_hash_groupby_approx_percentile_reduction_no_rows(aqe_enabled, kudo_enab
         [0.05, 0.25, 0.5, 0.75, 0.95], conf, reduction = True)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_byte(aqe_enabled, kudo_enabled):
@@ -1929,6 +1934,7 @@ def test_hash_groupby_approx_percentile_byte(aqe_enabled, kudo_enabled):
 
 @incompat
 @disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/11198
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_byte_scalar(aqe_enabled, kudo_enabled):
@@ -1940,6 +1946,7 @@ def test_hash_groupby_approx_percentile_byte_scalar(aqe_enabled, kudo_enabled):
         0.5, conf)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled, kudo_enabled):
@@ -1951,6 +1958,7 @@ def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled, kudo_ena
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_long(aqe_enabled, kudo_enabled):
@@ -1962,6 +1970,7 @@ def test_hash_groupby_approx_percentile_long(aqe_enabled, kudo_enabled):
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @disable_ansi_mode  # ANSI mode is tested in test_hash_groupby_approx_percentile_long_single_ansi
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -1975,6 +1984,7 @@ def test_hash_groupby_approx_percentile_long_single(aqe_enabled, kudo_enabled):
 
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec')
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -1994,6 +2004,7 @@ def test_hash_groupby_approx_percentile_long_single_ansi(aqe_enabled, kudo_enabl
 
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_double(aqe_enabled, kudo_enabled):
@@ -2005,6 +2016,7 @@ def test_hash_groupby_approx_percentile_double(aqe_enabled, kudo_enabled):
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_double_single(aqe_enabled, kudo_enabled):
@@ -2016,6 +2028,7 @@ def test_hash_groupby_approx_percentile_double_single(aqe_enabled, kudo_enabled)
         0.05, conf)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @ignore_order(local=True)
@@ -2037,6 +2050,7 @@ def test_hash_groupby_approx_percentile_partial_fallback_to_cpu(aqe_enabled, kud
     assert_gpu_fallback_collect(lambda spark: approx_percentile_query(spark), 'ApproximatePercentile', conf)
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_decimal32(kudo_enabled):
@@ -2048,6 +2062,7 @@ def test_hash_groupby_approx_percentile_decimal32(kudo_enabled):
 
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
 @disable_ansi_mode  # ANSI mode is tested with test_hash_groupby_approx_percentile_decimal_single_ansi.
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -2060,6 +2075,7 @@ def test_hash_groupby_approx_percentile_decimal32_single(kudo_enabled):
 
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
 @allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec')
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -2072,6 +2088,7 @@ def test_hash_groupby_approx_percentile_decimal_single_ansi(kudo_enabled):
 
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_decimal64(kudo_enabled):
@@ -2082,6 +2099,7 @@ def test_hash_groupby_approx_percentile_decimal64(kudo_enabled):
         conf = {kudo_enabled_conf_key: kudo_enabled})
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @disable_ansi_mode  # ANSI mode is tested with test_hash_groupby_approx_percentile_decimal_single_ansi.
 @ignore_order(local=True)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
@@ -2093,6 +2111,7 @@ def test_hash_groupby_approx_percentile_decimal64_single(kudo_enabled):
         conf = {kudo_enabled_conf_key: kudo_enabled})
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_approx_percentile_decimal128(kudo_enabled):
@@ -2103,6 +2122,7 @@ def test_hash_groupby_approx_percentile_decimal128(kudo_enabled):
         conf = {kudo_enabled_conf_key: kudo_enabled})
 
 @incompat
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @disable_ansi_mode  # ANSI mode is tested with test_hash_groupby_approx_percentile_decimal_single_ansi.
 @ignore_order(local=True)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
@@ -19,11 +19,14 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable
 import scala.util.Random
 
+import org.scalatest.Ignore
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.functions.{col, expr}
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
 import org.apache.spark.sql.types.{DataType, DataTypes}
 
+@Ignore
 class ApproximatePercentileSuite extends SparkQueryCompareTestSuite {
 
   val DEFAULT_PERCENTILES = Array(0.005, 0.05, 0.25, 0.45, 0.5, 0.55, 0.75, 0.95, 0.995)


### PR DESCRIPTION
We are investigating https://github.com/NVIDIA/spark-rapids/issues/13049, but while we fix that, this tries to unblock CI/premerge. 

This PR should be reverted once we figure out the likely cuDF issue in tdigest behind https://github.com/NVIDIA/spark-rapids/issues/13049.