### PR TITLE
Fix failed to_json cases on non-UTC timezones

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1127,6 +1127,7 @@ structs_read_allowed_non_gpu = non_utc_project_allow if is_before_spark_400() el
     'UTC',
     'Etc/UTC'
 ])
+@allow_non_gpu(*non_utc_project_allow)
 def test_structs_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
     struct_gen = StructGen([
         ('a', data_gen),


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/13051

### bug explaination
https://github.com/NVIDIA/spark-rapids/pull/13039 introduced this bug.
#13039 did not consider the non-UTC pipelines.

Originally it's:
```
structs_read_allowed_non_gpu = non_utc_project_allow if is_before_spark_400() else \
    ['ProjectExec', 'Invoke', 'Literal']

@allow_non_gpu(*structs_read_allowed_non_gpu)
```

After #13039, it removed the `@allow_non_gpu`
It should be:
```
@allow_non_gpu(*non_utc_project_allow)
```

### fix
```
@allow_non_gpu(*non_utc_project_allow)
```

Signed-off-by: Chong Gao <res_life@163.com>