### PR TITLE
Fix incorrect deltalake update fallback test

### DIFF
--- a/integration_tests/src/main/python/delta_lake_update_test.py
+++ b/integration_tests/src/main/python/delta_lake_update_test.py
@@ -66,7 +66,7 @@ def assert_delta_sql_update_collect(spark_tmp_path, use_cdf, enable_deletion_vec
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors(), reason="Deletion vectors aren't supported")
-@pytest.mark.skipif((not is_databricks_runtime()) or is_before_spark_353(),
+@pytest.mark.skipif((not is_databricks_runtime()) and is_before_spark_353(),
                     reason="Update with deletion vector is only supported after delta.io 3.0.0")
 @pytest.mark.xfail(condition=is_databricks_runtime() and not is_databricks143_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/12123")
 def test_delta_update_fallback_with_deletion_vectors(spark_tmp_path):


### PR DESCRIPTION
Close #13064 
In delta.io update with deletion vector is only supported after 3.0.0, e.g. spark 3.5.3+ in spark rapids. We should skip the test if it's oss spark runtime and before 3.5.3.
