### PR TITLE
Add $ in front of bash variable IS_SPARK_35X in spark-test.sh

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -234,7 +234,7 @@ run_iceberg_tests() {
   fi
 
   # RAPIDS-iceberg only supports Spark 3.5.x yet
-  if [[ "IS_SPARK_35X" -ne "1" ]]; then
+  if [[ "$IS_SPARK_35X" -ne "1" ]]; then
     echo "!!!! Skipping Iceberg tests. GPU acceleration of Iceberg is not supported on $ICEBERG_SPARK_VER"
     return 0
   fi


### PR DESCRIPTION
Adding missing $ in front of a variable in a bash script.  This will enable Iceberg tests for Spark 3.5.x.  