### PR TITLE
Add a write round trip test for managed delta tables

### DIFF
--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -17,7 +17,9 @@ import os.path
 import pytest
 import re
 
-from spark_session import is_databricks122_or_later, supports_delta_lake_deletion_vectors, is_databricks143_or_later
+from spark_session import is_databricks122_or_later, supports_delta_lake_deletion_vectors, is_databricks143_or_later, \
+    with_cpu_session
+from asserts import assert_equal
 
 delta_meta_allow = [
     "DeserializeToObjectExec",
@@ -82,6 +84,17 @@ def _fixup_operation_parameters(opp):
             subbed = TMP_TABLE_PATTERN.sub("tmp_table", pred)
             subbed = TMP_TABLE_PATH_PATTERN.sub("tmp_table", subbed)
             opp[key] = REF_ID_PATTERN.sub("#refid", subbed)
+
+def assert_delta_history_equal(conf, cpu_table, gpu_table):
+    # Project all columns except for the `timestamp` column, which won't match between CPU and GPU.
+    cols = ["version", "userId", "userName", "operation", "operationParameters", "job", "notebook",
+            "clusterId", "readVersion", "isolationLevel", "isBlindAppend", "operationMetrics", "userMetadata"]
+    cpu_history = with_cpu_session(lambda spark: spark.sql("DESCRIBE HISTORY {}".format(cpu_table))
+                                   .select(cols).collect(), conf=conf)
+    gpu_history = with_cpu_session(lambda spark: spark.sql("DESCRIBE HISTORY {}".format(gpu_table))
+                                   .select(cols).collect(), conf=conf)
+    assert_equal(cpu_history, gpu_history)
+
 
 def assert_delta_log_json_equivalent(filename, c_json, g_json):
     assert c_json.keys() == g_json.keys(), "Delta log {} has mismatched keys:\nCPU: {}\nGPU: {}".format(filename, c_json, g_json)

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -114,13 +114,7 @@ def test_delta_write_round_trip_managed(spark_tmp_table_factory, enable_deletion
             .saveAsTable(table),
         conf=conf
     )
-    cols = ["version", "userId", "userName", "operation", "operationParameters", "job", "notebook",
-            "clusterId", "readVersion", "isolationLevel", "isBlindAppend", "operationMetrics", "userMetadata"]
-    cpu_history = with_cpu_session(lambda spark: spark.sql("DESCRIBE HISTORY {}".format(cpu_table))
-                                   .select(cols).collect(), conf=conf)
-    gpu_history = with_cpu_session(lambda spark: spark.sql("DESCRIBE HISTORY {}".format(gpu_table))
-                                   .select(cols).collect(), conf=conf)
-    assert_equal(cpu_history, gpu_history)
+    assert_delta_history_equal(conf, cpu_table, gpu_table)
 
 
 @allow_non_gpu(*delta_meta_allow)


### PR DESCRIPTION
This PR adds a write round trip test for managed delta tables. Since we have the [hive metastore enabled](https://github.com/NVIDIA/spark-rapids/blob/802590d983e6159aba9ee66ef460d53cffc646e0/integration_tests/src/main/python/spark_init_internal.py#L147-L148) for integration tests, this partially addresses https://github.com/NVIDIA/spark-rapids/issues/13020. I think we should add more tests for more complex scenarios, such as overwriting, merging, updating, etc, after this PR is merged. I also manually verified that I can access the tables created by the test within a separate pyspark session that used the same hive metastore