### PR TITLE
Skip `test_time_travel_on_non_existing_table` with 'AS OF' before Spark 3.3.0

### DIFF
--- a/integration_tests/src/main/python/delta_lake_time_travel_test.py
+++ b/integration_tests/src/main/python/delta_lake_time_travel_test.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 in_commit_ts_param_id = lambda val: f"in_commit_ts={val}"
 
 @delta_lake
+@pytest.mark.skipif(is_before_spark_330(), reason = "AS OF sql syntax is only supported after spark 3.3.0")
 def test_time_travel_on_non_existing_table():
     def time_travel_on_non_existing_table():
         with_gpu_session(lambda spark: spark.sql("SELECT * FROM not_existing VERSION AS OF 0"))
@@ -126,7 +127,7 @@ def test_time_travel_df_version(spark_tmp_path, spark_tmp_table_factory, in_comm
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.skipif(is_before_spark_330(), reason = "AS OF sql syntax is only supported after spark.3.0")
+@pytest.mark.skipif(is_before_spark_330(), reason = "AS OF sql syntax is only supported after spark 3.3.0")
 @pytest.mark.parametrize("in_commit_ts", enable_in_commit_ts(), ids=in_commit_ts_param_id)
 def test_time_travel_sql_version(spark_tmp_path, spark_tmp_table_factory, in_commit_ts):
     result = do_set_up_tables_for_time_travel(spark_tmp_path, spark_tmp_table_factory,
@@ -160,7 +161,7 @@ def test_time_travel_df_timestamp(spark_tmp_path, spark_tmp_table_factory, in_co
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.skipif(is_before_spark_330(), reason = "AS OF sql syntax is only supported after spark.3.0")
+@pytest.mark.skipif(is_before_spark_330(), reason = "AS OF sql syntax is only supported after spark 3.3.0")
 @pytest.mark.parametrize("in_commit_ts", enable_in_commit_ts(), ids=in_commit_ts_param_id)
 def test_time_travel_sql_timestamp(spark_tmp_path, spark_tmp_table_factory, in_commit_ts):
     result = do_set_up_tables_for_time_travel(spark_tmp_path, spark_tmp_table_factory,


### PR DESCRIPTION
One test was missed as part of #13066, this PR skips the failing test for Spark versions before 3.3.0 

fixes #13063 