### PR TITLE
Add sanity check in `GpuOptimizeExecutor` to ensure deletion vector is disabled.

### DIFF
--- a/delta-lake/common/src/main/delta-33x/scala/org/apache/spark/sql/delta/rapids/commands/GpuOptimizeExecutor.scala
+++ b/delta-lake/common/src/main/delta-33x/scala/org/apache/spark/sql/delta/rapids/commands/GpuOptimizeExecutor.scala
@@ -71,7 +71,7 @@ class GpuOptimizeExecutor(
   private def ensureDeletionVectorDisabled(): Unit = {
     val dvFeatureEnabled = DeletionVectorUtils.deletionVectorsWritable(snapshot)
 
-    // Currently optimize executor will only be triggerred by auto compaction, and we should
+    // Currently optimize executor will only be triggered by auto compaction, and we should
     // already fallback to cpu when deletion vector enabled. This check ensures that the fallback
     // actually works.
     if (dvFeatureEnabled) {


### PR DESCRIPTION
Close #13045 

Since currently we don't support deletion vector, we need to ensure that when we exercise `GpuOptimizeExecutor`, deletion vector has been disabled.


