### PR TITLE
Add Spark 400 shim for get_json_object to handle named string with '?'

### DIFF
--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -122,8 +122,6 @@ def test_get_json_object_normalize_non_string_output():
             f.col('jsonStr'),
             f.get_json_object('jsonStr', '$')))
 
-@pytest.mark.skipif(condition=not is_before_spark_400(),
-                    reason="https://github.com/NVIDIA/spark-rapids/issues/11130")
 def test_get_json_object_quoted_question():
     schema = StructType([StructField("jsonStr", StringType())])
     data = [[r'{"?":"QUESTION"}']]

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -23,7 +23,7 @@ import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.JSONUtils
-import com.nvidia.spark.rapids.shims.ShimExpression
+import com.nvidia.spark.rapids.shims.{GetJsonObjectShim, ShimExpression}
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Alias, ExpectsInputTypes, Expression, GetJsonObject}
@@ -66,7 +66,7 @@ object JsonPathParser extends RegexParsers {
   // parse `.name` or `['name']` child expressions
   def named: Parser[List[PathInstruction]] =
     for {
-      name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']"
+      name <- '.' ~> "[^\\.\\[]+".r | "['" ~> GetJsonObjectShim.partRegexpInNamed.r <~ "']"
     } yield {
       Key :: Named(name) :: Nil
     }

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GetJsonObjectShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GetJsonObjectShim.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+object GetJsonObjectShim {
+  /**
+   * Return a shim string for a part in named Regexp.
+   * For Spark versions before 400, named Regexp is:
+   *   name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']"
+   * For Spark versions 400 and 400+, named Regexp is:
+   *   name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\']+".r <~ "']"
+   * This is the shim to distinct "[^\\'\\?]+" and "[^\\']+"
+   *
+   * "[^\\'\\?]+" : One or more chars which are not: ' or ?
+   * "[^\\']+"    : One or more chars which are not: '
+   */
+  def partRegexpInNamed: String = "[^\\'\\?]+"
+}

--- a/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/GetJsonObjectShim.scala
+++ b/sql-plugin/src/main/spark400/scala/com/nvidia/spark/rapids/shims/GetJsonObjectShim.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "400"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+object GetJsonObjectShim {
+  /**
+   * Return a shim string for a part in named Regexp.
+   * For Spark versions before 400, named Regexp is:
+   *   name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']"
+   * For Spark versions 400 and 400+, named Regexp is:
+   *   name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\']+".r <~ "']"
+   * This is the shim to distinct "[^\\'\\?]+" and "[^\\']+"
+   *
+   * "[^\\'\\?]+" : One or more chars which are not: ' or ?
+   * "[^\\']+"    : One or more chars which are not: '
+   */
+  def partRegexpInNamed: String = "[^\\']+"
+}


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/11130

### Bug description
Spark 400 changed the regexp for `named` , refer to the [issue](https://issues.apache.org/jira/browse/SPARK-46761)
Fix is in [PR](https://github.com/apache/spark/pull/45420):
```diff
-      name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']"
+     name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\']+".r <~ "']"
```
This PR allows `named` contains ? char.

### Fix
Add Spark 400 shim to adapt this behavior.

Signed-off-by: Chong Gao <res_life@163.com>