### PR TITLE
Use the original input column to get the overflow decimal values

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1516,13 +1516,14 @@ object GpuCast {
       input: ColumnView,
       fromType: DecimalType,
       toType: DecimalType,
-      ansiMode: Boolean): ColumnVector = {
+      ansiMode: Boolean,
+      originCol: ColumnView): ColumnVector = {
     assert(input.getType.isDecimalType)
     withResource(DecimalUtil.outOfBounds(input, toType)) { outOfBounds =>
       if (ansiMode) {
         withResource(outOfBounds.any()) { isAny =>
           if (isAny.isValid && isAny.getBoolean) {
-            throw RoundingErrorUtil.cannotChangeDecimalPrecisionError(input, outOfBounds,
+            throw RoundingErrorUtil.cannotChangeDecimalPrecisionError(originCol, outOfBounds,
               fromType, toType)
           }
         }
@@ -1576,7 +1577,7 @@ object GpuCast {
           // We need to check for out of bound values.
           // The wholeNumberUpcast is obvious why we have to check, but we also have to check it
           // when we rounded, because rounding can add a digit to the effective precision.
-          checkNFixDecimalBounds(rounded, from, to, ansiMode)
+          checkNFixDecimalBounds(rounded, from, to, ansiMode, input)
         } else {
           rounded.incRefCount()
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -827,7 +827,6 @@ object RoundingErrorUtil {
     val value = withResource(values.copyToHost()){hcv =>
       hcv.getBigDecimal(row_id)
     }
-    RapidsErrorUtils.cannotChangeDecimalPrecisionError(
-      Decimal(value, fromType.precision, fromType.scale), toType)
+    RapidsErrorUtils.cannotChangeDecimalPrecisionError(Decimal(value), toType)
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -827,6 +827,7 @@ object RoundingErrorUtil {
     val value = withResource(values.copyToHost()){hcv =>
       hcv.getBigDecimal(row_id)
     }
-    RapidsErrorUtils.cannotChangeDecimalPrecisionError(Decimal(value), toType)
+    RapidsErrorUtils.cannotChangeDecimalPrecisionError(
+      Decimal(value, fromType.precision, fromType.scale), toType)
   }
 }


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/13065

This PR changes to use the original input column to get the overflow decimal values to build the exception message instead of the rounded column when casting decimals to decimals. Because the rounded column may have decimals with higher precision (e.g. 4) than the one (e.g. 3) of the original column type, leading to the error in the linked issue.
