### PR TITLE
Add test to verify materialization while merging [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_merge_test.py
+++ b/integration_tests/src/main/python/delta_lake_merge_test.py
@@ -146,7 +146,7 @@ def test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_facto
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
-@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+@pytest.mark.skipif(is_before_spark_353(), reason="The conf merge.materializeSource isn't available before Delta 3.3.x")
 # As part of the merge command, Delta Lake will try to materialize tables in the process.
 # This materialize will not show up as part of the original plan as it's done dynamically from GpuMergeIntoCommand
 # therefore we will use the same technique OSS is using to assert it was materialized

--- a/integration_tests/src/main/python/delta_lake_merge_test.py
+++ b/integration_tests/src/main/python/delta_lake_merge_test.py
@@ -147,6 +147,47 @@ def test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_facto
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+# As part of the merge command, Delta Lake will try to materialize tables in the process.
+# This materialize will not show up as part of the original plan as it's done dynamically from GpuMergeIntoCommand
+# therefore we will use the same technique OSS is using to assert it was materialized
+# ref: https://github.com/delta-io/delta/blob/4b2beb096017d813475f692270bc20c113c0d974/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala#L364
+# This test forces materialization by setting the delta property
+def test_delta_materialize_merge(spark_tmp_path, spark_tmp_table_factory):
+    materialize_conf = copy_and_update(delta_merge_enabled_conf, {"spark.databricks.delta.merge.materializeSource": "all"})
+    src_table_func = lambda spark: make_df(spark, SetValuesGen(IntegerType(), range(20)), num_slices=10)
+    dest_table_func = lambda spark: make_df(spark, SetValuesGen(IntegerType(), range(10)), num_slices=10)
+    merge_sql = "MERGE INTO {dest_table} USING {src_table} ON {dest_table}.a == {src_table}.a" \
+                " WHEN NOT MATCHED THEN INSERT *"
+
+    def read_data(spark, path):
+        df = read_delta_path(spark, path)
+        return df.sort(df.columns)
+
+    def checker(data_path, do_merge):
+        cpu_path = data_path + "/CPU"
+        gpu_path = data_path + "/GPU"
+        # compare resulting dataframe from the merge operation (some older Spark versions return empty here)
+        assert_collect(do_merge, read_delta_path, data_path, materialize_conf)
+        # compare merged table data results, read both via CPU to make sure GPU write can be read by CPU
+        cpu_result = with_cpu_session(lambda spark: read_data(spark, cpu_path).rdd.isCheckpointed(), conf=materialize_conf)
+        gpu_result = with_cpu_session(lambda spark: read_data(spark, gpu_path).rdd.isCheckpointed(), conf=materialize_conf)
+        assert(cpu_result, True)
+        assert_equal(cpu_result, gpu_result)
+
+    delta_sql_merge_test(spark_tmp_path, spark_tmp_table_factory,
+                            use_cdf=False,
+                            enable_deletion_vectors=False,
+                            src_table_func=src_table_func,
+                            dest_table_func=dest_table_func,
+                            merge_sql=merge_sql,
+                            check_func=checker,
+                            partition_columns=None)
+
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @pytest.mark.parametrize("table_ranges", [(range(10), range(20)),  # partial delete of target
                                           (range(5), range(5)),  # full delete of target
                                           (range(10), range(20, 30))  # no-op delete

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -98,10 +98,12 @@ def test_delta_write_disabled_fallback(spark_tmp_path, disable_conf, enable_dele
         delta_write_fallback_check,
         conf=copy_and_update(writer_confs, disable_conf))
 
-
+# unsupported WriteIntoDeltaCommand tracked by https://github.com/NVIDIA/spark-rapids/issues/11169
+@allow_non_gpu_conditional(is_databricks143_or_later(), "DataWritingCommandExec, WriteFilesExec")
 @allow_non_gpu("AppendDataExecV1", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
+@pytest.mark.xfail(is_databricks143_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/13106")
 @pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_350DB143_xfail_reasons(
     enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
 def test_delta_write_round_trip_managed(spark_tmp_table_factory, enable_deletion_vectors):

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -98,12 +98,10 @@ def test_delta_write_disabled_fallback(spark_tmp_path, disable_conf, enable_dele
         delta_write_fallback_check,
         conf=copy_and_update(writer_confs, disable_conf))
 
-# unsupported WriteIntoDeltaCommand tracked by https://github.com/NVIDIA/spark-rapids/issues/11169
-@allow_non_gpu_conditional(is_databricks143_or_later(), "DataWritingCommandExec, WriteFilesExec")
+
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.xfail(is_databricks143_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/13106")
 @pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values_with_350DB143_xfail_reasons(
     enabled_xfail_reason="https://github.com/NVIDIA/spark-rapids/issues/12027"), ids=idfn)
 def test_delta_write_round_trip_managed(spark_tmp_table_factory, enable_deletion_vectors):


### PR DESCRIPTION
This PR adds a test for making sure we materialize merge 

The PR introduces a new test case that explicitly checks whether the merge operation materializes its intermediate data as intended, both while running on CPU and GPU session. Be mindful that the materialization is still going to happen on the CPU but there is no way for us to verify that from pytest as it doesn't appear in the plan 


fixes #13041 