### PR TITLE
Fix conda build CondaToSNonInteractiveError issue [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -45,6 +45,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
+RUN conda tos accept --override-channels -c conda-forge -c defaults
 RUN conda init && conda install -n base -c conda-forge mamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -66,6 +66,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
+RUN conda tos accept --override-channels -c conda-forge -c defaults
 RUN conda init && conda install -n base -c conda-forge mamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below


### PR DESCRIPTION
conda now requires accepting the default channel to proceed. Otherwise it would fail
```
[2025-07-15T19:41:39.043Z] CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
[2025-07-15T19:41:39.043Z]     • https://repo.anaconda.com/pkgs/main
[2025-07-15T19:41:39.043Z]     • https://repo.anaconda.com/pkgs/r
```

explicitly accept terms to avoid failing `CondaToSNonInteractiveError`. This has been verified in both local dev and internal CI