### PR TITLE
Workaround for cudf::strings::extract on empty input throwing error

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1529,17 +1529,21 @@ case class GpuRegExpExtract(
     // | 'a1a'  | '1'   | '1'   |
     // | '1a1'  | ''    | NULL  |
 
-    withResource(str.getBase.extractRe(new RegexProgram(extractPattern,
-      EnumSet.of(RegexFlag.EXT_NEWLINE)))) { extract =>
-      withResource(GpuScalar.from("", DataTypes.StringType)) { emptyString =>
-        val outputNullAndInputNotNull =
-          withResource(extract.getColumn(groupIndex).isNull) { outputNull =>
-            withResource(str.getBase.isNotNull) { inputNotNull =>
-              outputNull.and(inputNotNull)
+    if (str.getRowCount == 0) {
+      ColumnVector.fromStrings()
+    } else {
+      withResource(str.getBase.extractRe(new RegexProgram(extractPattern,
+        EnumSet.of(RegexFlag.EXT_NEWLINE)))) { extract =>
+        withResource(GpuScalar.from("", DataTypes.StringType)) { emptyString =>
+          val outputNullAndInputNotNull =
+            withResource(extract.getColumn(groupIndex).isNull) { outputNull =>
+              withResource(str.getBase.isNotNull) { inputNotNull =>
+                outputNull.and(inputNotNull)
+              }
             }
+          withResource(outputNullAndInputNotNull) {
+            _.ifElse(emptyString, extract.getColumn(groupIndex))
           }
-        withResource(outputNullAndInputNotNull) {
-          _.ifElse(emptyString, extract.getColumn(groupIndex))
         }
       }
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -853,7 +853,6 @@ case class GpuStringReplace(
       with HasGpuStringReplace {
 
   override def dataType: DataType = srcExpr.dataType
-
   override def inputTypes: Seq[DataType] = Seq(StringType, StringType, StringType)
 
   override def first: Expression = srcExpr
@@ -1529,6 +1528,8 @@ case class GpuRegExpExtract(
     // | 'a1a'  | '1'   | '1'   |
     // | '1a1'  | ''    | NULL  |
 
+    // TODO: this workaround can be removed for versions of the plugin using
+    //   cuDF that include https://github.com/rapidsai/cudf/pull/19398
     if (str.getRowCount == 0) {
       ColumnVector.fromStrings()
     } else {


### PR DESCRIPTION
This diff is a potential workaround for https://github.com/rapidsai/cudf/issues/19397. I need some confirmation from @revans2 and @tgravescs that this is doing the right thing with the string type (e.g nothing special is going on for UTF8 stings, and perhaps I should do that).

There is work in cuDF to fix this at the `cudf::strings::extract` level https://github.com/rapidsai/cudf/pull/19398, for 25.08 as well. Posting this in case we need a fix right away.