### PR TITLE
Improve performance of ANSI SUM integer aggregations

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -780,14 +780,10 @@ class GpuEquivalentExpressionsSuite extends AnyFunSuite with Logging {
       GpuCast(quantity, DecimalType(10, 0)), price, DecimalType(18,2))
     val nullCheck = GpuIsNull(product)
     val castProduct = GpuCast(product, DecimalType(28,2))
-    val extract0 = GpuExtractChunk32(castProduct, 0, replaceNullsWithZero = true,
-      isForDecimal = true)
-    val extract1 = GpuExtractChunk32(castProduct, 1, replaceNullsWithZero = true,
-      isForDecimal = true)
-    val extract2 = GpuExtractChunk32(castProduct, 2, replaceNullsWithZero = true,
-      isForDecimal = true)
-    val extract3 = GpuExtractChunk32(castProduct, 3, replaceNullsWithZero = true,
-      isForDecimal = true)
+    val extract0 = GpuExtractChunk32(castProduct, 0, replaceNullsWithZero = true)
+    val extract1 = GpuExtractChunk32(castProduct, 1, replaceNullsWithZero = true)
+    val extract2 = GpuExtractChunk32(castProduct, 2, replaceNullsWithZero = true)
+    val extract3 = GpuExtractChunk32(castProduct, 3, replaceNullsWithZero = true)
     val initialExprs = Seq(customer, extract0, extract1, extract2, extract3, nullCheck)
     val exprTiers = GpuEquivalentExpressions.getExprTiers(initialExprs)
     validateExprTiers(exprTiers, initialExprs,

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
@@ -780,10 +780,14 @@ class GpuEquivalentExpressionsSuite extends AnyFunSuite with Logging {
       GpuCast(quantity, DecimalType(10, 0)), price, DecimalType(18,2))
     val nullCheck = GpuIsNull(product)
     val castProduct = GpuCast(product, DecimalType(28,2))
-    val extract0 = GpuExtractChunk32(castProduct, 0, replaceNullsWithZero = true)
-    val extract1 = GpuExtractChunk32(castProduct, 1, replaceNullsWithZero = true)
-    val extract2 = GpuExtractChunk32(castProduct, 2, replaceNullsWithZero = true)
-    val extract3 = GpuExtractChunk32(castProduct, 3, replaceNullsWithZero = true)
+    val extract0 = GpuExtractChunk32(castProduct, 0, replaceNullsWithZero = true,
+      isForDecimal = true)
+    val extract1 = GpuExtractChunk32(castProduct, 1, replaceNullsWithZero = true,
+      isForDecimal = true)
+    val extract2 = GpuExtractChunk32(castProduct, 2, replaceNullsWithZero = true,
+      isForDecimal = true)
+    val extract3 = GpuExtractChunk32(castProduct, 3, replaceNullsWithZero = true,
+      isForDecimal = true)
     val initialExprs = Seq(customer, extract0, extract1, extract2, extract3, nullCheck)
     val exprTiers = GpuEquivalentExpressions.getExprTiers(initialExprs)
     validateExprTiers(exprTiers, initialExprs,


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/13007

This also depends on https://github.com/NVIDIA/spark-rapids-jni/pull/3531

I did not really change how window operations work as the performance is not that bad (especially if you compare it to the CPU), and the current solution would not use less memory, so there really isn't a reason to do it.

It is not a perfect solution, but in my testing the "cost" of enabling ANSI for a SUM group by aggregation went from 5x to 1.5x.


Here are the full numbers.

version | ANSI | computation | reduction long | group by long | window long | reduction 128 | group by 128 | window 128
-- | -- | -- | -- | -- | -- | -- | -- | --
baseline | TRUE | GPU | 28,139 | 196,038 | 53,739 | 76,974 | 125,086 | 3,642
baseline | FALSE | GPU | 13,874 | 40,008 | 55,485 | 76,946 | 121,506 | 3,687
patched | TRUE | GPU | 24,556 | 62,965 | 56,690 | 77,157 | 124,848 | 3,656
patched | FALSE | GPU | 13,899 | 39,969 | 58,160 | 76,954 | 122,037 | 4,058
SPARK_3.4.2 16 threads | TRUE | CPU | 35,251 | 205,947 | 735,858 | CRASH | TOO LONG (estimated > 1h) | 900,986
SPARK_3.4.2 16 threads | FALSE | CPU | 17,952 | 203,618 | 593,716 | CRASH | TOO LONG (estimated > 1h) | 1,197,458
baseline ANSI ON vs OFF | BOTH | GPU | 2.03 | 4.90 | 0.97 | 1.00 | 1.03 | 0.99
patched ANSI ON vs OFF | BOTH | GPU | 1.77 | 1.58 | 0.97 | 1.00 | 1.02 | 0.90



Some of the numbers are only the median of 1 run instead of 3 or 5. But the time was too long to feel like I could do more runs so I don't really trust them for anything but order of magnitude.