### PR TITLE
Fix skip condition for test_delta_write_optimized_supported_types_partitioned [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -989,7 +989,7 @@ def test_delta_write_optimized_supported_types(spark_tmp_path):
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.skipif(not is_databricks_runtime() and is_spark_353_or_later(), reason="Delta Lake optimized writes are not supported before Spark 3.5.3 on Apache Spark")
+@pytest.mark.skipif(not is_databricks_runtime() and is_before_spark_353(), reason="Delta Lake optimized writes are not supported before Spark 3.5.3 on Apache Spark")
 def test_delta_write_optimized_supported_types_partitioned(spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     confs=copy_and_update(writer_confs, delta_writes_enabled_conf, {


### PR DESCRIPTION
This PR fixes a bad condition for skipping the test that was merged in #13119  

Optimized write is only supported in Databricks and Spark3.5.3/Delta 3.3.x

fixes #13129 