### PR TITLE
Set CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes for CI docker build and support python 3.12+ IT test [skip ci]

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -21,3 +21,4 @@ findspark
 fsspec == 2025.3.0
 fastparquet == 0.8.3 ; python_version == '3.8'
 fastparquet == 2024.5.0 ; python_version >= '3.9'
+setuptools ; python_version >= '3.12'

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -45,7 +45,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
-RUN conda tos accept --override-channels -c conda-forge -c defaults
+ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda init && conda install -n base -c conda-forge mamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -66,7 +66,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
-RUN conda tos accept --override-channels -c conda-forge -c defaults
+ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda init && conda install -n base -c conda-forge mamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below


### PR DESCRIPTION
per https://github.com/NVIDIA/spark-rapids/pull/13114#issuecomment-3084687586

1. Use `CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes` in dockerfile
2. Also update IT requirement file to support python3.12+ (dropped distuils which will fail spark tests)
```
E   ModuleNotFoundError: No module named 'distutils'
```

Verified in internal CI