### PR TITLE
Support side-effect check for the "else" path in GpuCaseWhen

### DIFF
--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -421,19 +421,18 @@ def test_combine_string_contains_in_case_when(combine_string_contains_enabled):
 def test_case_when_with_side_effect_in_else():
     sql = """
         SELECT
-            a, b,
+            a,
             CASE
-                WHEN size(filter(a, x -> x >= b)) = 0 THEN NULL
-                ELSE element_at(filter(a, x -> x >= b), size(filter(a, x -> x >= b)))
+                WHEN size(a) > 0 THEN NULL
+                ELSE element_at(a, 0)
             END
         FROM else_side_effect
     """
 
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: two_col_df(spark,
-                                 SetValuesGen(ArrayType(IntegerType()), [[1, 2, 3]]),
-                                 SetValuesGen(IntegerType(), [4, 5]),
-                                 length=10),
+        lambda spark: unary_op_df(spark,
+                                  SetValuesGen(ArrayType(IntegerType()), [[1, 2, 3]]),
+                                  length=10),
         "else_side_effect",
         sql
     )

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -430,9 +430,7 @@ def test_case_when_with_side_effect_in_else():
     """
 
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: unary_op_df(spark,
-                                  SetValuesGen(ArrayType(IntegerType()), [[1, 2, 3]]),
-                                  length=10),
+        lambda spark: unary_op_df(spark, SetValuesGen(ArrayType(IntegerType()), [[1, 2, 3]]), 10),
         "else_side_effect",
         sql
     )

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -428,7 +428,7 @@ def test_case_when_with_side_effect_in_else():
             END
         FROM else_side_effect
     """
-    # spark.rapids.sql.combined.expressions.enabled is true by default
+
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: two_col_df(spark,
                                  SetValuesGen(ArrayType(IntegerType()), [[1, 2, 3]]),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
@@ -332,7 +332,7 @@ case class GpuCaseWhen(
     branches.map(_._2.dataType) ++ elseValue.map(_.dataType)
   }
 
-  private lazy val hasSideEffects =
+  private lazy val haveSideEffects =
     branches.exists(_._2.asInstanceOf[GpuExpression].hasSideEffects) ||
       elseValue.exists(_.asInstanceOf[GpuExpression].hasSideEffects)
 
@@ -367,7 +367,7 @@ case class GpuCaseWhen(
   }
 
   override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
-    if (hasSideEffects) {
+    if (haveSideEffects) {
       columnarEvalWithSideEffects(batch)
     } else {
       if (useFusion) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -441,7 +441,9 @@ object GpuElementAtMeta {
 case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolean)
   extends GpuBinaryExpression with ExpectsInputTypes {
 
-  override def hasSideEffects: Boolean = super.hasSideEffects || failOnError
+  // It always blow up whenever there is at least one "0" as the index regardless of
+  // whether "failOnError" is true or not, so "hasSideEffects" should be true.
+  override def hasSideEffects: Boolean = true
 
   override lazy val dataType: DataType = left.dataType match {
     case ArrayType(elementType, _) => elementType

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -443,7 +443,7 @@ case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolea
 
   override def hasSideEffects: Boolean = super.hasSideEffects || failOnError || {
     right match {
-      case GpuLiteral(index, _) if index != 0 => false
+      case GpuLiteral(index: Int, _) if index != 0 => false
       case _ => true
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -441,9 +441,12 @@ object GpuElementAtMeta {
 case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolean)
   extends GpuBinaryExpression with ExpectsInputTypes {
 
-  // It always throws exception when the index is 0 even it's non-ANSI mode.
-  // whether "failOnError" is true or not, so "hasSideEffects" should be true.
-  override def hasSideEffects: Boolean = true
+  override def hasSideEffects: Boolean = super.hasSideEffects || failOnError || {
+    right match {
+      case GpuLiteral(index, _) if index != 0 => false
+      case _ => true
+    }
+  }
 
   override lazy val dataType: DataType = left.dataType match {
     case ArrayType(elementType, _) => elementType

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -441,7 +441,7 @@ object GpuElementAtMeta {
 case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolean)
   extends GpuBinaryExpression with ExpectsInputTypes {
 
-  // It always blow up whenever there is at least one "0" as the index regardless of
+  // It always throws exception when the index is 0 even it's non-ANSI mode.
   // whether "failOnError" is true or not, so "hasSideEffects" should be true.
   override def hasSideEffects: Boolean = true
 


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/13137

This PR adds in side-effect check to the "else" path in `GpuCaseWhen`. And the `hasSideEffects` should be always true for `GpuElementAt` because it will throw out exceptions whenever there is 0 index, even the ansi mode is off.

Before this PR, `GpuCaseWhen` will not run into the evaluation with side-effect if only the "else" path has side-effect. Then the "else" expression will always be evaluated, leading to the error in the linked issue.

The test case is simplfied from the example in the linked issue.
