### PR TITLE
Use the "StringType" object for the string type comparison in `case-match` statements

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DataTypeUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DataTypeUtils.scala
@@ -26,7 +26,7 @@ object DataTypeUtils {
   }
 
   def hasOffset(dataType: DataType): Boolean = dataType match {
-    case _: ArrayType | _: StringType | _: BinaryType => true
+    case _: ArrayType | StringType | _: BinaryType => true
     case _ => false
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -115,7 +115,7 @@ abstract class CastExprMetaBase[INPUT <: UnaryLike[Expression] with TimeZoneAwar
       case (FloatType | DoubleType, ByteType | ShortType | IntegerType | LongType) if
           doFloatToIntCheck && !conf.isCastFloatToIntegralTypesEnabled =>
         willNotWorkOnGpu(buildTagMessage(RapidsConf.ENABLE_CAST_FLOAT_TO_INTEGRAL_TYPES))
-      case (dt: DecimalType, _: StringType) =>
+      case (dt: DecimalType, StringType) =>
         if (dt.precision > DType.DECIMAL128_MAX_PRECISION) {
           willNotWorkOnGpu(s"decimal to string with a " +
               s"precision > ${DType.DECIMAL128_MAX_PRECISION} is not supported yet")
@@ -130,12 +130,12 @@ abstract class CastExprMetaBase[INPUT <: UnaryLike[Expression] with TimeZoneAwar
             "to convert floating point data types to decimals and this can produce results that " +
             "slightly differ from the default behavior in Spark.  To enable this operation on " +
             s"the GPU, set ${RapidsConf.ENABLE_CAST_FLOAT_TO_DECIMAL} to true.")
-      case (_: FloatType | _: DoubleType, _: StringType) if !conf.isCastFloatToStringEnabled =>
+      case (_: FloatType | _: DoubleType, StringType) if !conf.isCastFloatToStringEnabled =>
         willNotWorkOnGpu("the GPU will use different precision than Java's toString method when " +
             "converting floating point data types to strings and this can produce results that " +
             "differ from the default behavior in Spark.  To enable this operation on the GPU, set" +
             s" ${RapidsConf.ENABLE_CAST_FLOAT_TO_STRING} to true.")
-      case (_: StringType, _: FloatType | _: DoubleType) if !conf.isCastStringToFloatEnabled =>
+      case (StringType, _: FloatType | _: DoubleType) if !conf.isCastStringToFloatEnabled =>
         willNotWorkOnGpu("Currently hex values aren't supported on the GPU. Also note " +
             "that casting from string to float types on the GPU returns incorrect results when " +
             "the string represents any number \"1.7976931348623158E308\" <= x < " +
@@ -143,12 +143,12 @@ abstract class CastExprMetaBase[INPUT <: UnaryLike[Expression] with TimeZoneAwar
             "\"-1.7976931348623158E308\" in both these cases the GPU returns Double.MaxValue " +
             "while CPU returns \"+Infinity\" and \"-Infinity\" respectively. To enable this " +
             s"operation on the GPU, set ${RapidsConf.ENABLE_CAST_STRING_TO_FLOAT} to true.")
-      case (_: StringType, _: TimestampType) =>
+      case (StringType, _: TimestampType) =>
         if (!conf.isCastStringToTimestampEnabled) {
           willNotWorkOnGpu("Casting strings to timestamps is disabled, please set" +
             s" ${RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP} to true.")
         }
-      case (_: StringType, dt:DecimalType) =>
+      case (StringType, dt:DecimalType) =>
         if (dt.scale < 0 && !SparkShimImpl.isCastingStringToNegDecimalScaleSupported) {
           willNotWorkOnGpu("RAPIDS doesn't support casting string to decimal for " +
               "negative scale decimal in this version of Spark because of SPARK-37451")
@@ -587,10 +587,10 @@ object GpuCast {
       case (from: MapType, to: MapType) =>
         castMapToMap(from, to, input, options)
 
-      case (dayTime: DataType, _: StringType) if GpuTypeShims.isSupportedDayTimeType(dayTime) =>
+      case (dayTime: DataType, StringType) if GpuTypeShims.isSupportedDayTimeType(dayTime) =>
         GpuIntervalUtils.toDayTimeIntervalString(input, dayTime)
 
-      case (_: StringType, dayTime: DataType) if GpuTypeShims.isSupportedDayTimeType(dayTime) =>
+      case (StringType, dayTime: DataType) if GpuTypeShims.isSupportedDayTimeType(dayTime) =>
         GpuIntervalUtils.castStringToDayTimeIntervalWithThrow(input, dayTime)
 
       // cast(`day time interval` as integral)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3983,7 +3983,7 @@ object GpuOverrides extends Logging {
 
         override def tagExprForGpu(): Unit = {
           a.schema match {
-            case MapType(_: StringType, _: StringType, _) => ()
+            case MapType(StringType, StringType, _) => ()
             case st: StructType =>
               if (hasDuplicateFieldNames(st)) {
                 willNotWorkOnGpu("from_json on GPU does not support duplicate field " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SchemaUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,8 +217,8 @@ object SchemaUtils {
       case (fromDec: DecimalType, toDec: DecimalType) if fromDec == toDec &&
           !GpuColumnVector.getNonNestedRapidsType(fromDec).equals(col.getType) =>
         col.castTo(DecimalUtil.createCudfDecimal(fromDec))
-      case (fromChar: CharType, toStringType: StringType) =>
-        castFunc.map(f => f(col, toStringType, fromChar))
+      case (fromChar: CharType, StringType) =>
+        castFunc.map(f => f(col, StringType, fromChar))
           .getOrElse(throw new QueryExecutionException("Casting function is missing for " +
             s"type conversion from $colType to $targetType"))
       case _ if !GpuColumnVector.getNonNestedRapidsType(targetType).equals(col.getType) =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -879,7 +879,7 @@ abstract class GpuToTimestamp
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     val tmp = lhs.dataType match {
-      case _: StringType =>
+      case StringType =>
         // rhs is ignored we already parsed the format
         val res = if (getTimeParserPolicy == LegacyTimeParserPolicy) {
           parseStringAsTimestampWithLegacyParserPolicy(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -339,12 +339,12 @@ case class GpuConcatWs(children: Seq[Expression])
     withResourceIfAllowed(expr.columnarEvalAny(batch)) {
       case vector: GpuColumnVector =>
         vector.dataType() match {
-          case ArrayType(_: StringType, _) => concatArrayCol(colOrScalarSep, vector.getBase)
+          case ArrayType(StringType, _) => concatArrayCol(colOrScalarSep, vector.getBase)
           case _ => vector.incRefCount()
         }
       case s: GpuScalar =>
         s.dataType match {
-          case ArrayType(_: StringType, _) =>
+          case ArrayType(StringType, _) =>
             // we have to first concatenate any array types
             withResource(GpuColumnVector.from(s, numRows, s.dataType).getBase) { cv =>
               concatArrayCol(colOrScalarSep, cv)

--- a/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/rapids/shims/InvokeExprMeta.scala
+++ b/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/rapids/shims/InvokeExprMeta.scala
@@ -61,7 +61,7 @@ class InvokeExprMeta(
       case Invoke(
       Literal(_: StructsToJsonEvaluator, _: ObjectType),
       functionName: String,
-      _: StringType,
+      StringType,
       arguments: Seq[Expression],
       methodInputTypes: Seq[AbstractDataType],
       _: Boolean,


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/11931

As mentioned in the linked issue, from Spark 400, `_: StringType` will also match the `VarcharType` and `CharType`, not the only `StringType` any more.

To keep the original logic unchanged, this PR replaces all the `_: StringType` with the `StringType` object which still represents the `StringType` we expect as before, to avoid any unexpected issues may be caused by the match extension of data types introduced in the Spark change at https://github.com/apache/spark/pull/48883.
