### PR TITLE
Add approximate_float decorator to try_avg_fallback_to_cpu  integration test

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1463,6 +1463,7 @@ def test_try_add_fallback_to_cpu(data_gen):
         lambda spark: binary_op_df(spark, data_gen).selectExpr(
             "try_add(a, b) as result"), "Add")
 
+@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_divide_fallback_to_cpu(data_gen):
@@ -1471,6 +1472,7 @@ def test_try_divide_fallback_to_cpu(data_gen):
             "try_divide(a, b) as result"), "Divide")
 
 @pytest.mark.skipif(is_before_spark_400(), reason="try_mod is not supported before Spark 4.0.0")
+@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_mod_fallback_to_cpu(data_gen):
@@ -1479,6 +1481,7 @@ def test_try_mod_fallback_to_cpu(data_gen):
             "try_mod(a, b) as result"), "Remainder")
 
 @pytest.mark.skipif(is_before_spark_330(), reason="try_subtract is not supported before Spark 3.3.0")
+@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_subtract_fallback_to_cpu(data_gen):
@@ -1487,6 +1490,7 @@ def test_try_subtract_fallback_to_cpu(data_gen):
             "try_subtract(a, b) as result"), "Subtract")
 
 @pytest.mark.skipif(is_before_spark_330(), reason="try_multiply is not supported before Spark 3.3.0")
+@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_multiply_fallback_to_cpu(data_gen):
@@ -1513,6 +1517,7 @@ def test_try_sum_groupby_fallback_to_cpu(data_gen):
         'HashAggregateExec')
 
 @pytest.mark.skipif(is_before_spark_330(), reason="try_avg is not supported before Spark 3.3.0")
+@approximate_float
 @ignore_order(local=True)
 @allow_non_gpu('HashAggregateExec', 'ShuffleExchangeExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1463,7 +1463,6 @@ def test_try_add_fallback_to_cpu(data_gen):
         lambda spark: binary_op_df(spark, data_gen).selectExpr(
             "try_add(a, b) as result"), "Add")
 
-@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_divide_fallback_to_cpu(data_gen):
@@ -1472,7 +1471,6 @@ def test_try_divide_fallback_to_cpu(data_gen):
             "try_divide(a, b) as result"), "Divide")
 
 @pytest.mark.skipif(is_before_spark_400(), reason="try_mod is not supported before Spark 4.0.0")
-@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_mod_fallback_to_cpu(data_gen):
@@ -1481,7 +1479,6 @@ def test_try_mod_fallback_to_cpu(data_gen):
             "try_mod(a, b) as result"), "Remainder")
 
 @pytest.mark.skipif(is_before_spark_330(), reason="try_subtract is not supported before Spark 3.3.0")
-@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_subtract_fallback_to_cpu(data_gen):
@@ -1490,7 +1487,6 @@ def test_try_subtract_fallback_to_cpu(data_gen):
             "try_subtract(a, b) as result"), "Subtract")
 
 @pytest.mark.skipif(is_before_spark_330(), reason="try_multiply is not supported before Spark 3.3.0")
-@approximate_float
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
 def test_try_multiply_fallback_to_cpu(data_gen):


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/13153

We added integration tests for try_ functions in https://github.com/NVIDIA/spark-rapids/pull/13095. 
This PR fixes the issue of mismatch between CPU and GPU results by adding approximate_float decorator for the aggregation test that have floats or doubles as input.  


