### PR TITLE
dont subtract spark offheap from spark memoryOverhead

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -497,10 +497,9 @@ object GpuDeviceManager extends Logging {
         lazy val basedOnHostMemory = (hostMemUsageFraction * ((1.0 * availableHostMemory /
           deviceCount) - heapSize - pysparkOverhead - sparkOffHeapSize)).toLong
         if (executorOverhead.isDefined) {
-          val basedOnConfiguredOverhead = executorOverhead.get - sparkOffHeapSize
+          val basedOnConfiguredOverhead = executorOverhead.get
           logWarning(s"${RapidsConf.OFF_HEAP_LIMIT_SIZE} is not set; we derived " +
-            s"a memory limit from ($executorOverheadKey - " + s"$sparkOffHeapSizeKey) = " +
-            s"(${executorOverhead.get} - " + s"$sparkOffHeapSize) = $basedOnConfiguredOverhead")
+            s"a memory limit from ($executorOverheadKey = ${executorOverhead.get}")
           if (basedOnConfiguredOverhead < minMemoryLimit) {
             logWarning(s"memory limit $basedOnConfiguredOverhead is less than the minimum of " +
               s"$minMemoryLimit; using the latter")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -165,12 +165,10 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits memoryOverhead configured") {
-    val sparkOffHeapSizeStr = "1g"
     val sparkOverheadStr = "8g"
     val sparkConf = new SparkConf()
       .set("spark.executor.memoryOverhead", sparkOverheadStr)
       .set("spark.memory.offHeap.enabled", "true")
-      .set("spark.memory.offHeap.size", sparkOffHeapSizeStr)
       .set("spark.executor.pyspark.memory", "1g") // should be ignored here
     val rapidsConf = new RapidsConf(sparkConf)
     val (pinnedSize, nonPinnedSize) =
@@ -178,9 +176,8 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
         TestMemoryChecker)
 
     val sparkOverhead = toBytes(sparkOverheadStr)
-    val sparkOffHeapSize = toBytes(sparkOffHeapSizeStr)
     val totalOverhead = toBytes("15m") // default
-    val expectedNonPinned = sparkOverhead - sparkOffHeapSize - totalOverhead
+    val expectedNonPinned = sparkOverhead - totalOverhead
 
     assertResult(0)(pinnedSize)
     assertResult(expectedNonPinned)(nonPinnedSize)


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/13146

When first implementing the offHeap limit defaults, I mistakenly thought that the way spark does the accounting for total memory allocation to the running container is that it includes `spark.memory.offHeap.size` into the setting of `spark.executor.memoryOverhead`, but it turns out that they are accounted for separately, as shown in https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala#L553-L556, therefore when we choose our RAPIDS off heap limit based on these configs, we don't need to subtract out `spark.memory.offHeap.size`

That said, If we don't have memoryOverhead explicitly configured and we are estimating based on the total host memory available, that figure *would* include the spark offHeap size (which we currently don't want to use any of) and so we would still subtract it in that estimate, so that part is left as is.