### PR TITLE
Host limits fix device count

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -433,7 +433,8 @@ object GpuDeviceManager extends Logging {
 
   private def initializePinnedPoolAndOffHeapLimits(gpuId: Int, conf: RapidsConf,
                                                    sparkConf: SparkConf): Unit = {
-    val (pinnedSize, nonPinnedLimit) = getPinnedPoolAndOffHeapLimits(conf, sparkConf)
+    val (pinnedSize, nonPinnedLimit) = getPinnedPoolAndOffHeapLimits(
+      conf, sparkConf, Cuda.getDeviceCount)
     // disable the cuDF provided default pinned pool for now
     if (!PinnedMemoryPool.configureDefaultCudfPinnedPoolSize(0L)) {
       // This is OK in tests because they don't unload/reload our shared
@@ -449,7 +450,7 @@ object GpuDeviceManager extends Logging {
   }
 
   // visible for testing
-  def getPinnedPoolAndOffHeapLimits(conf: RapidsConf, sparkConf: SparkConf,
+  def getPinnedPoolAndOffHeapLimits(conf: RapidsConf, sparkConf: SparkConf, deviceCount: Int,
       memCheck: MemoryChecker =
       MemoryCheckerImpl): (Long, Long) = {
     val perTaskOverhead = conf.perTaskOverhead
@@ -461,8 +462,6 @@ object GpuDeviceManager extends Logging {
     // that the previous minimum of 15 MB * num cores was too little for certain benchmark
     // queries to complete, whereas this limit was sufficient.
     val minMemoryLimit = 4L * 1024 * 1024 * 1024
-
-    val deviceCount: Int = Cuda.getDeviceCount()
 
     val executorOverheadKey = "spark.executor.memoryOverhead"
     val pysparkOverheadKey = "spark.executor.pyspark.memory"

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -497,10 +497,9 @@ object GpuDeviceManager extends Logging {
         lazy val basedOnHostMemory = (hostMemUsageFraction * ((1.0 * availableHostMemory /
           deviceCount) - heapSize - pysparkOverhead - sparkOffHeapSize)).toLong
         if (executorOverhead.isDefined) {
-          val basedOnConfiguredOverhead = executorOverhead.get - sparkOffHeapSize
+          val basedOnConfiguredOverhead = executorOverhead.get
           logWarning(s"${RapidsConf.OFF_HEAP_LIMIT_SIZE} is not set; we derived " +
-            s"a memory limit from ($executorOverheadKey - " + s"$sparkOffHeapSizeKey) = " +
-            s"(${executorOverhead.get} - " + s"$sparkOffHeapSize) = $basedOnConfiguredOverhead")
+            s"a memory limit from ($executorOverheadKey = ${executorOverhead.get}")
           if (basedOnConfiguredOverhead < minMemoryLimit) {
             logWarning(s"memory limit $basedOnConfiguredOverhead is less than the minimum of " +
               s"$minMemoryLimit; using the latter")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -165,12 +165,10 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits memoryOverhead configured") {
-    val sparkOffHeapSizeStr = "1g"
     val sparkOverheadStr = "8g"
     val sparkConf = new SparkConf()
       .set("spark.executor.memoryOverhead", sparkOverheadStr)
       .set("spark.memory.offHeap.enabled", "true")
-      .set("spark.memory.offHeap.size", sparkOffHeapSizeStr)
       .set("spark.executor.pyspark.memory", "1g") // should be ignored here
     val rapidsConf = new RapidsConf(sparkConf)
     val (pinnedSize, nonPinnedSize) =
@@ -178,9 +176,8 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
         TestMemoryChecker)
 
     val sparkOverhead = toBytes(sparkOverheadStr)
-    val sparkOffHeapSize = toBytes(sparkOffHeapSizeStr)
     val totalOverhead = toBytes("15m") // default
-    val expectedNonPinned = sparkOverhead - sparkOffHeapSize - totalOverhead
+    val expectedNonPinned = sparkOverhead - totalOverhead
 
     assertResult(0)(pinnedSize)
     assertResult(expectedNonPinned)(nonPinnedSize)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -95,11 +95,12 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits zero config off heap disabled") {
+    val deviceCount = 1
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(Map(
       RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "false"))
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
         TestMemoryChecker)
 
     assertResult(0)(pinnedSize)
@@ -107,10 +108,11 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits zero config") {
+    val deviceCount = 1
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(sparkConf)
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
         TestMemoryChecker)
 
     val minMem = toBytes("4g")
@@ -122,6 +124,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits zero config with host mem") {
+    val deviceCount = 1
     val pySparkOverheadStr = "2g"
     val sparkOffHeapSizeStr = "1g"
     val sparkConf = new SparkConf()
@@ -132,7 +135,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
     val availableHostMem = toBytes("16g")
     TestMemoryChecker.setAvailableMemoryBytes(Some(availableHostMem))
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
         TestMemoryChecker)
     TestMemoryChecker.setAvailableMemoryBytes(None)
 
@@ -148,12 +151,13 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits off heap configured") {
+    val deviceCount = 1
     val offHeapLimitStr = "16g"
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(Map(
       RapidsConf.OFF_HEAP_LIMIT_SIZE.key -> offHeapLimitStr))
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
       TestMemoryChecker)
 
     val offHeapLimit = toBytes(offHeapLimitStr)
@@ -165,6 +169,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits memoryOverhead configured") {
+    val deviceCount = 1
     val sparkOverheadStr = "8g"
     val sparkConf = new SparkConf()
       .set("spark.executor.memoryOverhead", sparkOverheadStr)
@@ -172,7 +177,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
       .set("spark.executor.pyspark.memory", "1g") // should be ignored here
     val rapidsConf = new RapidsConf(sparkConf)
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
         TestMemoryChecker)
 
     val sparkOverhead = toBytes(sparkOverheadStr)
@@ -184,12 +189,13 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits pinned config only") {
+    val deviceCount = 1
     val pinnedSizeStr = "2g"
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(Map(
       RapidsConf.PINNED_POOL_SIZE.key -> pinnedSizeStr))
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
         TestMemoryChecker)
 
     val expectedPinned = toBytes(pinnedSizeStr)
@@ -202,12 +208,13 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits pinned config above memLimit") {
+    val deviceCount = 1
     val pinnedSizeStr = "8g"
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(Map(
       RapidsConf.PINNED_POOL_SIZE.key -> pinnedSizeStr))
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
         TestMemoryChecker)
 
     val minMemLimit = toBytes("4g")
@@ -219,6 +226,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("get host memory limits zero config with host mem with heap size set") {
+    val deviceCount = 1
     val pySparkOverheadStr = "2g"
     val heapSizeStr = "2g"
     val sparkConf = new SparkConf()
@@ -228,7 +236,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
     val hostBytes = toBytes("16g")
     TestMemoryChecker.setAvailableMemoryBytes(Some(hostBytes))
     val (pinnedSize, nonPinnedSize) =
-      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
+      GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf, deviceCount,
         TestMemoryChecker)
     TestMemoryChecker.setAvailableMemoryBytes(None)
 


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/13040

(this branch is also based on another PR branch, https://github.com/NVIDIA/spark-rapids/pull/13157)

Spark RAPIDS jobs are often run on hosts with only one GPU. However, it's possible to run on a host with multiple GPUs, but the plugin will only use one GPU within an executor. If we see multiple GPUs on the host during initialization, we want to be conservative and assume some other process, whether it's another executor in the Spark job or just some entirely different workload, is running and using the other GPUs, and presumably would also need a proportional amount of the available host memory. Therefore, we divide the total amount of host memory we see by the number of GPUs.

This PR addresses an issue where the unit tests were all assuming the host has only one GPU. These tests would then pass if that's true but fail if there are multiple devices (a workaround is to set `CUDA_VISIBLE_DEVICES` to one device id, but regardless it won't be necessary after this fix). Instead of checking the actual device count on the host as in a real query execution, the tests would now just inject values in order to be more hermetic and also test different scenarios.