### PR TITLE
Fix failed to_json test cases

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1120,6 +1120,7 @@ _to_json_datagens=[byte_gen,
     'UTC',
     'Etc/UTC'
 ])
+@allow_non_gpu(*non_utc_project_allow)
 def test_structs_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
     struct_gen = StructGen([
         ('a', data_gen),
@@ -1152,6 +1153,7 @@ def test_structs_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone)
     'UTC',
     'Etc/UTC'
 ])
+@allow_non_gpu(*non_utc_project_allow)
 def test_arrays_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
     array_gen = ArrayGen(data_gen, nullable=True)
     gen = StructGen([("my_array", array_gen)], nullable=False)
@@ -1177,6 +1179,7 @@ def test_arrays_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
     'UTC',
     'Etc/UTC'
 ])
+@allow_non_gpu(*non_utc_project_allow)
 def test_maps_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
     map_gen = MapGen(StringGen('[A-Z]{1,10}', nullable=False), data_gen, nullable=True)
     gen = StructGen([("my_map", map_gen)], nullable=False)
@@ -1204,6 +1207,7 @@ def test_maps_to_json(spark_tmp_path, data_gen, ignore_null_fields, timezone):
     'UTC',
     'Etc/UTC'
 ])
+@allow_non_gpu(*non_utc_project_allow)
 def test_structs_to_json_timestamp(spark_tmp_path, data_gen, timestamp_format, timezone):
     struct_gen = StructGen([
         ("b", StructGen([('child', data_gen)], nullable=True)),


### PR DESCRIPTION
closes #13152

Restores proper fallback behavior for non-UTC timezone scenarios that was inadvertently removed in PR https://github.com/NVIDIA/spark-rapids/pull/13126

### Bug analisis
The test cases update in [PR](https://github.com/NVIDIA/spark-rapids/pull/13126/files#diff-e43717af9471ebedcd992bac98ab4b21fb7a771205fbcbc0760446f283a6d5f0) introduced this bug.

```diff
-structs_read_allowed_non_gpu = non_utc_project_allow if is_before_spark_400() else \
-    ['ProjectExec', 'Invoke', 'Literal']
```
The PR #13126 supports: ['ProjectExec', 'Invoke', 'Literal'] for Spark 400+, but in the above diff, the `non_utc_project_allow` was also removed. For all the Spark versions, it will fallback if timezone is non-UTC.

### Fix
Mark fallback is allowed when timezone is non-UTC.

Signed-off-by: Chong Gao <res_life@163.com>