### PR TITLE
Fix bug with divide by zero in ANSI avg on decimal128 output

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2784,6 +2784,7 @@ def test_avg_long_ansi_groupby_overflow():
     assert_gpu_and_cpu_are_equal_collect(lambda s: s.createDataFrame(overflow_data, schema).groupBy('group_key').agg(f.avg('long_val')), conf=conf)
 
 
+@approximate_float
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_type', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(4,0), DecimalGen(10,0), DecimalGen(12,0), DecimalGen(38,0)], ids=idfn)
 def test_avg_divide_by_zero(data_type, ansi):

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -46,8 +46,8 @@ abstract class GpuDecimalAverage(child: Expression, sumDataType: DecimalType, fa
   // This is to conform with Spark's behavior in the Average aggregate function.
   override lazy val evaluateExpression: Expression = {
     GpuCast(
-      GpuDecimalDivide(sum, count, intermediateSparkDivideType, failOnError = failOnError),
-      dataType, ansiMode = failOnError)
+      GpuDecimalDivide(sum, count, intermediateSparkDivideType, failOnError = failOnError,
+        failOnDivideByZero = false), dataType, ansiMode = failOnError)
   }
 
   // Window
@@ -58,7 +58,7 @@ abstract class GpuDecimalAverage(child: Expression, sumDataType: DecimalType, fa
     val sum = GpuWindowExpression(GpuSum(child, sumDataType,
       failOnErrorOverride = failOnError), spec)
     GpuCast(
-      GpuDecimalDivide(sum, count, intermediateSparkDivideType, failOnError = failOnError),
-      dataType, ansiMode = failOnError)
+      GpuDecimalDivide(sum, count, intermediateSparkDivideType, failOnError = failOnError,
+        failOnDivideByZero = false), dataType, ansiMode = failOnError)
   }
 }

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -51,7 +51,7 @@ abstract class GpuDecimalAverage(child: Expression, sumDataType: DecimalType, fa
   override lazy val evaluateExpression: Expression = {
     GpuCast(
       GpuDecimalDivide(sum, GpuCast(count, DecimalType.LongDecimal), dataType,
-        failOnError = failOnError), dataType, ansiMode = failOnError)
+        failOnError = failOnError, failOnDivideByZero = false), dataType, ansiMode = failOnError)
   }
 
   // Window
@@ -63,6 +63,6 @@ abstract class GpuDecimalAverage(child: Expression, sumDataType: DecimalType, fa
       failOnErrorOverride = failOnError), spec)
     GpuCast(
       GpuDecimalDivide(sum, GpuCast(count, DecimalType.LongDecimal), dataType,
-        failOnError = failOnError), dataType, ansiMode = failOnError)
+        failOnError = failOnError, failOnDivideByZero = false), dataType, ansiMode = failOnError)
   }
 }


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/13188

Effectively I didn't protect against a divide by 0 error on some decimal average aggregations. I just needed to turn it on. I have added in tests to ensure that all divide by zero cases for the different group by aggregations that we support are covered.