### PR TITLE
disable offheap limit by default

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -354,7 +354,7 @@ object RapidsConf extends Logging {
       // This might change as a part of https://github.com/NVIDIA/spark-rapids/issues/8878
       .internal()
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val OFF_HEAP_LIMIT_SIZE = conf("spark.rapids.memory.host.offHeapLimit.size")
       .doc("The maximum amount of off heap memory that the plugin will use. " +

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -108,7 +108,8 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
 
   test("get host memory limits zero config") {
     val sparkConf = new SparkConf()
-    val rapidsConf = new RapidsConf(sparkConf)
+    val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true"))
     val (pinnedSize, nonPinnedSize) =
       GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
         TestMemoryChecker)
@@ -128,7 +129,8 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
       .set("spark.executor.pyspark.memory", pySparkOverheadStr)
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", sparkOffHeapSizeStr)
-    val rapidsConf = new RapidsConf(sparkConf)
+    val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true"))
     val availableHostMem = toBytes("16g")
     TestMemoryChecker.setAvailableMemoryBytes(Some(availableHostMem))
     val (pinnedSize, nonPinnedSize) =
@@ -151,6 +153,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
     val offHeapLimitStr = "16g"
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true",
       RapidsConf.OFF_HEAP_LIMIT_SIZE.key -> offHeapLimitStr))
     val (pinnedSize, nonPinnedSize) =
       GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
@@ -170,7 +173,8 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
       .set("spark.executor.memoryOverhead", sparkOverheadStr)
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.executor.pyspark.memory", "1g") // should be ignored here
-    val rapidsConf = new RapidsConf(sparkConf)
+    val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true"))
     val (pinnedSize, nonPinnedSize) =
       GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
         TestMemoryChecker)
@@ -187,6 +191,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
     val pinnedSizeStr = "2g"
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true",
       RapidsConf.PINNED_POOL_SIZE.key -> pinnedSizeStr))
     val (pinnedSize, nonPinnedSize) =
       GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
@@ -205,6 +210,7 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
     val pinnedSizeStr = "8g"
     val sparkConf = new SparkConf()
     val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true",
       RapidsConf.PINNED_POOL_SIZE.key -> pinnedSizeStr))
     val (pinnedSize, nonPinnedSize) =
       GpuDeviceManager.getPinnedPoolAndOffHeapLimits(rapidsConf, sparkConf,
@@ -224,7 +230,8 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
     val sparkConf = new SparkConf()
       .set("spark.executor.pyspark.memory", pySparkOverheadStr)
       .set("spark.executor.memory", heapSizeStr)
-    val rapidsConf = new RapidsConf(sparkConf)
+    val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true"))
     val hostBytes = toBytes("16g")
     TestMemoryChecker.setAvailableMemoryBytes(Some(hostBytes))
     val (pinnedSize, nonPinnedSize) =

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -160,7 +160,8 @@ class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
       .set("spark.executor.pyspark.memory", pySparkOverheadStr)
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", sparkOffHeapSizeStr)
-    val rapidsConf = new RapidsConf(sparkConf)
+    val rapidsConf = new RapidsConf(Map(
+      RapidsConf.OFF_HEAP_LIMIT_ENABLED.key -> "true"))
     val availableHostMem = toBytes("32g")
     TestMemoryChecker.setAvailableMemoryBytes(Some(availableHostMem))
     val (pinnedSize, nonPinnedSize) =


### PR DESCRIPTION
Due to some outstanding unresolved issues in https://github.com/NVIDIA/spark-rapids/issues/13101, we want to keep the offheap limits disabled by default in 25.08.

For more context, see the original issue for the off heap limits feature: https://github.com/NVIDIA/spark-rapids/issues/12471