### PR TITLE
Run try_ functions aggregation arithmetic tests on single partition

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1494,31 +1494,3 @@ def test_try_multiply_fallback_to_cpu(data_gen):
         lambda spark: binary_op_df(spark, data_gen).selectExpr(
             "try_multiply(a, b) as result"), "Multiply")
 
-@pytest.mark.skipif(is_before_spark_330(), reason="try_sum is not supported before Spark 3.3.0")
-@allow_non_gpu('HashAggregateExec', 'ShuffleExchangeExec')
-@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
-def test_try_sum_fallback_to_cpu(data_gen):
-    assert_gpu_fallback_collect(
-        lambda spark: gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100, num_slices=1)
-                     .selectExpr("try_sum(b) as result"),'HashAggregateExec')
-
-@pytest.mark.skipif(is_before_spark_330(), reason="try_sum is not supported before Spark 3.3.0")
-@ignore_order(local=True)
-@allow_non_gpu('HashAggregateExec', 'ShuffleExchangeExec')
-@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
-def test_try_sum_groupby_fallback_to_cpu(data_gen):
-    assert_gpu_fallback_collect(
-        lambda spark: gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100, num_slices=1)
-                     .groupBy('a').agg(f.expr("try_sum(b)").alias("result")),
-        'HashAggregateExec')
-
-@pytest.mark.skipif(is_before_spark_330(), reason="try_avg is not supported before Spark 3.3.0")
-@approximate_float
-@ignore_order(local=True)
-@allow_non_gpu('HashAggregateExec', 'ShuffleExchangeExec')
-@pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
-def test_try_avg_fallback_to_cpu(data_gen):
-    assert_gpu_fallback_collect(
-        lambda spark: gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100, num_slices=1)
-                     .groupBy('a').agg(f.expr("try_avg(b)").alias("result")),
-        'HashAggregateExec')

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2004,6 +2004,41 @@ def test_agg_nested_map(kudo_enabled):
         # Disable ANSI mode to avoid issues with array indexes and map keys not being present
         'spark.sql.ansi.enabled': False})
 
+@pytest.mark.skipif(is_before_spark_330(), reason="try_sum is not supported before Spark 3.3.0")
+@allow_non_gpu('HashAggregateExec', 'ShuffleExchangeExec')
+@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+def test_try_sum_fallback_to_cpu(data_gen):
+    assert_gpu_fallback_collect(
+        # Use single partition (num_slices=1) to avoid non-deterministic
+        # results from order-dependent overflow detection.
+        lambda spark: gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100, num_slices=1)
+                     .selectExpr("try_sum(b) as result"),'HashAggregateExec')
+
+@pytest.mark.skipif(is_before_spark_330(), reason="try_sum is not supported before Spark 3.3.0")
+@ignore_order(local=True)
+@allow_non_gpu('HashAggregateExec', 'ShuffleExchangeExec')
+@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+def test_try_sum_groupby_fallback_to_cpu(data_gen):
+    assert_gpu_fallback_collect(
+        # Use single partition (num_slices=1) to avoid non-deterministic
+        # results from order-dependent overflow detection.
+        lambda spark: gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100, num_slices=1)
+                     .groupBy('a').agg(f.expr("try_sum(b)").alias("result")),
+        'HashAggregateExec')
+
+@pytest.mark.skipif(is_before_spark_330(), reason="try_avg is not supported before Spark 3.3.0")
+@approximate_float
+@ignore_order(local=True)
+@allow_non_gpu('HashAggregateExec', 'ShuffleExchangeExec')
+@pytest.mark.parametrize('data_gen', numeric_gens, ids=idfn)
+def test_try_avg_fallback_to_cpu(data_gen):
+    assert_gpu_fallback_collect(
+        # Use single partition (num_slices=1) to avoid non-deterministic
+        # results from order-dependent overflow detection.
+        lambda spark: gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100, num_slices=1)
+                     .groupBy('a').agg(f.expr("try_avg(b)").alias("result")),
+        'HashAggregateExec')
+
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/13179

The test_try_sum_groupby_fallback_to_cpu was intermittently failing in nightly builds, showing different results between "CPU" and "GPU" runs despite both correctly falling back to CPU execution. So the CPU results were not deterministic.
The overflow detection on aggregations is inconsistent for the CPU. These functions use sequential addition at each row with overflow checking so the result depends on partitioning and the order of the data being processed.
In this PR, we force the data to be on a single partition so that the results are always deterministic as the updateExpression step happens in a single partition and the mergeExpression has the same data for all the runs.

Updated the other try_ arithmetic tests with num_slices since the above issue can happen on the both groupBy queries and reduction queries. 
