### PR TITLE
Fallback to CPU for unsupported binary formats

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2846,6 +2846,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
     entry.get(conf)
   }
 
+  def getStr(key: String): Option[String] = conf.get(key)
+
   lazy val rapidsConfMap: util.Map[String, String] = conf.filterKeys(
     _.startsWith("spark.rapids.")).toMap.asJava
 


### PR DESCRIPTION
This partially addresses https://github.com/NVIDIA/spark-rapids/issues/10884

I did not add in any tests because toPrettyString only shows up when show is called, and we don't really have any tests to cover the meta tagging for ToPrettyString. If people really want me to add something I can.