### PR TITLE
Disable fastparquet tests for [databricks] versions < 13.3

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -19,6 +19,5 @@ pyarrow == 19.0.1 ; python_version >= '3.9'
 pytest-xdist >= 2.0.0
 findspark
 fsspec == 2025.3.0
-fastparquet == 0.8.3 ; python_version == '3.8'
 fastparquet == 2024.5.0 ; python_version >= '3.9'
 setuptools ; python_version >= '3.12'

--- a/integration_tests/src/main/python/fastparquet_compatibility_test.py
+++ b/integration_tests/src/main/python/fastparquet_compatibility_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
 from fastparquet_utils import get_fastparquet_result_canonicalizer
-from spark_session import is_databricks_runtime, spark_version, with_cpu_session, with_gpu_session
+from spark_session import is_databricks_runtime, is_databricks133_or_later, spark_version, with_cpu_session, with_gpu_session
 
 
 def fastparquet_unavailable():
@@ -94,6 +94,9 @@ def read_parquet(data_path, local_data_path):
     return read_with_fastparquet_or_plugin
 
 
+@pytest.mark.skipif(condition=is_databricks_runtime() and not is_databricks133_or_later(),
+                    reason="Fastparquet is incompatible with Databricks versions < 13.3. "
+                           "(https://github.com/NVIDIA/spark-rapids/issues/13197)")
 @pytest.mark.skipif(condition=fastparquet_unavailable(),
                     reason="fastparquet is required for testing fastparquet compatibility")
 @pytest.mark.skipif(condition=spark_version() < "3.4.0",
@@ -171,6 +174,9 @@ def test_reading_file_written_by_spark_cpu(data_gen, spark_tmp_path):
         delete_local_directory(local_base_path)
 
 
+@pytest.mark.skipif(condition=is_databricks_runtime() and not is_databricks133_or_later(),
+                    reason="Fastparquet is incompatible with Databricks versions < 13.3. "
+                           "(https://github.com/NVIDIA/spark-rapids/issues/13197)")
 @pytest.mark.skipif(condition=fastparquet_unavailable(),
                     reason="fastparquet is required for testing fastparquet compatibility")
 @pytest.mark.skipif(condition=spark_version() < "3.4.0",
@@ -252,6 +258,9 @@ def copy_from_local(spark, local_source, hdfs_target):
     fs.copyFromLocalFile(Path(local_source), Path(hdfs_target))
 
 
+@pytest.mark.skipif(condition=is_databricks_runtime() and not is_databricks133_or_later(),
+                    reason="Fastparquet is incompatible with Databricks versions < 13.3. "
+                           "(https://github.com/NVIDIA/spark-rapids/issues/13197)")
 @pytest.mark.skipif(condition=fastparquet_unavailable(),
                     reason="fastparquet is required for testing fastparquet compatibility")
 @pytest.mark.parametrize('column_gen', [
@@ -345,6 +354,9 @@ def test_reading_file_written_with_fastparquet(column_gen, spark_tmp_path):
         rebase_write_corrected_conf)
 
 
+@pytest.mark.skipif(condition=is_databricks_runtime() and not is_databricks133_or_later(),
+                    reason="Fastparquet is incompatible with Databricks versions < 13.3. "
+                           "(https://github.com/NVIDIA/spark-rapids/issues/13197)")
 @pytest.mark.skipif(condition=fastparquet_unavailable(),
                     reason="fastparquet is required for testing fastparquet compatibility")
 @pytest.mark.parametrize('column_gen, time_format', [


### PR DESCRIPTION
Fixes #13197.

This commit skips `fastparquet` compatibility tests for Databricks 12.2 and below.

## Background:
Databricks versions 12.2 and below use Python 3.8 by default.  (3.8 has reached end of life.)

For the `fastparquet` compatibility tests to run on Databricks 12.2, the latest `fastparquet` package available for Python 3.8 is `fastparquet-0.8.3`.  

The later versions of Databricks run with Python 3.9+, and `fastparquet` version `2024.5.0`.

## The problem:
`fastparquet-0.8.3` has now stopped being compatible with Databricks 12.2 because of a dependency (`cramjam`) being bumped to an incompatible version on 2025/07/27.
See #13197 for the gory details.

## The fix:
Rather than chase through these dependencies to support an EOLed Python version on a dated Databricks release, these tests are now skipped on Databricks 12.2.  These tests will continue to run on Databricks versions whose default Python exceeds 3.8.

The test `requirements.txt` has been updated to remove the incompatible `fastparquet` versions.  The relevant tests are explicitly skipped.