### PR TITLE
Add the project name for jdk-profiles [skip ci]

### DIFF
--- a/jdk-profiles/pom.xml
+++ b/jdk-profiles/pom.xml
@@ -26,6 +26,7 @@
     </parent>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark-jdk-profiles_2.12</artifactId>
+    <name>RAPIDS Accelerator for Apache Spark JDK Profiles</name>
     <packaging>pom</packaging>
     <description>Shim JDK Profiles</description>
     <version>25.08.0-SNAPSHOT</version>

--- a/scala2.13/jdk-profiles/pom.xml
+++ b/scala2.13/jdk-profiles/pom.xml
@@ -26,6 +26,7 @@
     </parent>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark-jdk-profiles_2.13</artifactId>
+    <name>RAPIDS Accelerator for Apache Spark JDK Profiles</name>
     <packaging>pom</packaging>
     <description>Shim JDK Profiles</description>
     <version>25.08.0-SNAPSHOT</version>


### PR DESCRIPTION
A project name is required by the Central Sonatype Publisher in order to release.


![image](https://github.com/user-attachments/assets/1d1b1079-6e8c-4ef5-adad-14ec77e2684c)
