### PR TITLE
Improve the pull request template [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,32 +2,42 @@
 
 Thank you for contributing to RAPIDS Accelerator for Apache Spark!
 
-Here are some guidelines to help the review process go smoothly.
+Please read `CONTRIBUTING.md#creating-a-pull-request` in https://github.com/NVIDIA/spark-rapids before making this PR.
 
-1. Please write a description in this text box of the changes that are being
-   made.
-
-2. Please ensure that you have written units tests for the changes made/features
-   added.
-
-3. If you are closing an issue please use one of the automatic closing words as
-   noted here: https://help.github.com/articles/closing-issues-using-keywords/
-
-4. If your pull request is not ready for review but you want to make use of the
-   continuous integration testing facilities please label it with `[WIP]`.
-
-5. If your pull request is ready to be reviewed without requiring additional
-   work on top of it, then remove the `[WIP]` label (if present).
-
-6. Once all work has been done and review has taken place please do not add
-   features or make changes out of the scope of those requested by the reviewer
-   (doing this just add delays as already reviewed code ends up having to be
-   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
-   rebasing your branch during the review process, as this causes the context
-   of any comments made by reviewers to be lost. If conflicts occur during
-   review then they should be resolved by merging into the branch used for
-   making the pull request.
+Followings are the guidelines to help the review process go smoothly. Please read them carefully and fill out relevant information as much as possible.
 
 Many thanks in advance for your cooperation!
 
 -->
+
+<!--
+Please replace #xxxx with the ID of the issue fixed in this PR. If such issue does not exist, please consider file one and link it here.
+-->
+Fixes #xxxx.
+
+### Description
+
+<!--
+Please provide a description of the changes proposed in this pull request. Here are some questions to help you fill out the description:
+
+- What is the problem you are trying to solve? Describe it from the user's perspective or link an existing github issue if it exists.
+- After this change, what will the user experience be like?
+- Is your change introducing any user-facing changes, such as new configurations or new behaviors? Please describe them.
+- How are you fixing the problem? Please provide a technical description of your solution. You can add or link your design doc if it exists.
+- How are the new features/behaviors tested? Please describe the test cases you added or modified. If they are tested in a cluster, please describe it as well.
+-->
+
+### Checklists
+
+<!-- Check the items below by putting "x" in the brackets for what is done. Not all of these items may be relevant to every PR. -->
+
+This PR has:
+
+- [ ] added documentation for new or modified features or behaviors.
+- [ ] updated the license in the source code files when it is required.
+- [ ] added new tests or modified existing tests to cover new code paths.
+      (Please explain in the PR description how the new code paths are tested, such as names of the tests that cover them.)
+
+Please select one of the following options:
+- [ ] Performance testing has been performed and its results are added in the PR description.
+- [ ] An issue is filed for performance testing and its link is added in the PR description.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Please read https://github.com/NVIDIA/spark-rapids/blob/HEAD/CONTRIBUTING.md#cre
 
 The following are the guidelines to help the review process go smoothly. Please read them carefully and fill out relevant information as much as possible.
 
-Many thanks in advance for your cooperation!
+Thank you for your cooperation!
 
 -->
 
@@ -35,7 +35,7 @@ This PR has:
 - [ ] added documentation for new or modified features or behaviors.
 - [ ] updated the license in the source code files when it is required.
 - [ ] added new tests or modified existing tests to cover new code paths.
-      (Please explain in the PR description how the new code paths are tested, such as names of the tests that cover them.)
+      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
 
 Please select one of the following options:
 - [ ] Performance testing has been performed and its results are added in the PR description.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Many thanks in advance for your cooperation!
 -->
 
 <!--
-Please replace #xxxx with the ID of the issue fixed in this PR. If such issue does not exist, please consider file one and link it here.
+Please replace #xxxx with the ID of the issue fixed in this PR. If such issue does not exist, please consider filing one and link it here.
 -->
 Fixes #xxxx.
 
@@ -20,9 +20,8 @@ Fixes #xxxx.
 <!--
 Please provide a description of the changes proposed in this pull request. Here are some questions to help you fill out the description:
 
-- What is the problem you are trying to solve? Describe it from the user's perspective or link an existing github issue if it exists.
-- After this change, what will the user experience be like?
-- Is your change introducing any user-facing changes, such as new configurations or new behaviors? Please describe them.
+- What is the problem you are trying to solve? Describe it from the user's perspective. If you have an existing github issue, please add a summary of the issue here.
+- After this change, what will the user experience be like? Please describe any user-facing changes, such as new configurations or new behaviors.
 - How are you fixing the problem? Please provide a technical description of your solution. You can add or link your design doc if it exists.
 - How are the new features/behaviors tested? Please describe the test cases you added or modified. If they are tested in a cluster, please describe it as well.
 -->
@@ -40,4 +39,4 @@ This PR has:
 
 Please select one of the following options:
 - [ ] Performance testing has been performed and its results are added in the PR description.
-- [ ] An issue is filed for performance testing and its link is added in the PR description.
+- [ ] An issue is filed for performance testing and its link is added in the PR description. (Select this if performance testing will not be completed before the PR is submitted.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ Fixes #xxxx.
 Please provide a description of the changes proposed in this pull request. Here are some questions to help you fill out the description:
 
 - What is the problem you are trying to solve? Describe it from the user's perspective. If you have an existing github issue, please add a summary of the issue here.
-- After this change, what will the user experience be like? Please describe any user-facing changes, such as new configurations or new behaviors.
+- After this change, what will the user experience be like? Please describe any user-facing changes, such as new configurations or new behaviors. If you are introducing new configurations, please add some guidelines on how to use them.
 - How are you fixing the problem? Please provide a technical description of your solution. You can add or link your design doc if it exists.
 - How are the new features/behaviors tested? Please describe the test cases you added or modified. If they are tested in a cluster, please describe it as well.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Thank you for contributing to RAPIDS Accelerator for Apache Spark!
 
 Please read `CONTRIBUTING.md#creating-a-pull-request` in https://github.com/NVIDIA/spark-rapids before making this PR.
 
-Followings are the guidelines to help the review process go smoothly. Please read them carefully and fill out relevant information as much as possible.
+The following are the guidelines to help the review process go smoothly. Please read them carefully and fill out relevant information as much as possible.
 
 Many thanks in advance for your cooperation!
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Thank you for contributing to RAPIDS Accelerator for Apache Spark!
 
-Please read `CONTRIBUTING.md#creating-a-pull-request` in https://github.com/NVIDIA/spark-rapids before making this PR.
+Please read https://github.com/NVIDIA/spark-rapids/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request before making this PR.
 
 The following are the guidelines to help the review process go smoothly. Please read them carefully and fill out relevant information as much as possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -599,6 +599,27 @@ brew install gnu-sed
 export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 
+### Creating a Pull Request
+
+Here are some guidelines to follow when creating a pull request:
+
+1. If your pull request is not ready for review but you want to make use of the
+   continuous integration testing facilities, please make it as a draft and label it with `[WIP]`.
+
+2. If your pull request is ready to be reviewed without requiring additional
+   work on top of it, then convert it to a regular pull request and remove the `[WIP]` label
+   (if applicable).
+
+3. Once the review has taken place, please do not add features or make changes
+   out of the scope of those even if the reviewer requests them. Instead, please
+   consider filing new issues for those changes.
+
+4. Please avoid rebasing your branch during the review process, as this causes the context
+   of any comments made by reviewers to be lost. If conflicts occur during
+   review, then they should be resolved by merging into the branch used for
+   making the pull request.
+
+
 ### Pull request status checks
 A pull request should pass all status checks before being merged.
 #### sign-off check


### PR DESCRIPTION
Good PR descriptions can make the review process faster as they can fill in the gap in the context between the contributor and the reviewer. We currently have a PR template to encourage contributors to write good PR descriptions, but the guidelines in the template are somewhat high level. It is still unclear to many people exactly what should be written to help the reviewers. This PR adds more detailed guidelines so that they can remind contributors of what to write in the PR description. Here are key changes:

- Guidelines for making a PR and guidelines for writing a PR description have been separated. The former is moved to the `CONTRIBUTING.md` file.
- New `Description` and `Checklists` sections are added in the PR template. In the `Description` section, there are some questions to help contributors describe the change being made. In the `Checklists` section, there are two checklists for the contributor. These can be thought as review comments for self-review as the reviewers will eventually ask them if applicable but not addressed. This can be useful to avoid unnecessary review rounds.

Credit: I was inspired by the [PR template](https://github.com/apache/druid/blob/master/.github/pull_request_template.md) of the Apache Druid project.