### PR TITLE
Fix expression combining when only some can combine

### DIFF
--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -344,7 +344,6 @@ def test_unsupported_fallback_get_json_object(json_str_pattern):
                                       StringGen(r'''-?[1-9]\d{0,5}E-?\d{1,20}''', nullable=False),
                                       StringGen(r'''-?[1-9]\d{0,20}E-?\d{1,5}''', nullable=False)], ids=idfn)
 def test_get_json_object_floating_normalization(data_gen):
-    schema = StructType([StructField("jsonStr", StringType())])
     normalization = lambda spark: unary_op_df(spark, data_gen).selectExpr(
                         'a',
                         'get_json_object(a,"$")'
@@ -362,3 +361,32 @@ def test_get_json_object_floating_normalization(data_gen):
     for i in range(len(gpu_res)):
         # verify relatively diff < 1e-9 (default value for is_close)
         assert math.isclose(json_string_to_float(gpu_res[i][0]), json_string_to_float(cpu_res[i][0]))
+
+
+@pytest.mark.parametrize('ansi', [True, False], ids=["ANSI", "NO_ANSI"])
+def test_multi_get_json_object_basic(ansi):
+    data_gen = StringGen(r'''\{"num_a":[1-9]\d{0,5},"num_b":[1-9]\d{0,5}\}''')
+    conf={'spark.sql.ansi.enabled': ansi}
+    assert_gpu_and_cpu_are_equal_collect(lambda spark:
+            gen_df(spark, [('jsonStr', data_gen)]).selectExpr(
+                'CAST(get_json_object(jsonStr, "$.num_a") AS INTEGER) / CAST(get_json_object(jsonStr, "$.num_b") AS INTEGER) as result'),
+            conf = conf)
+
+@pytest.mark.parametrize('ansi', [True, False], ids=["ANSI", "NO_ANSI"])
+def test_multi_get_json_object_conditional(ansi):
+    """
+    The point of this test is that case/when statements behave differently when an operation under
+    them can have side effects. When this happens the combining code does not combine expressions
+    that might not execute, becuase there could be exceptions thrown there too. So this purposely
+    causes a case when some can be combined, but others cannot.
+    """
+    data_gen = StringGen(r'''\{"num_a":[1-9]\d{0,5},"num_b":[1-9]\d{0,5},"num_c":[1-9]\d{0,5}\}''')
+    conf={'spark.sql.ansi.enabled': ansi}
+    assert_gpu_and_cpu_are_equal_collect(lambda spark:
+            gen_df(spark, [('jsonStr', data_gen)]).selectExpr(
+                '''CASE
+                    WHEN CAST(get_json_object(jsonStr, "$.num_a") AS INTEGER) / CAST(get_json_object(jsonStr, "$.num_b") AS INTEGER) > 0.5 THEN 1
+                    WHEN CAST(get_json_object(jsonStr, "$.num_c") AS INTEGER) / CAST(get_json_object(jsonStr, "$.num_b") AS INTEGER) > 0.5 THEN 2
+                    ELSE 3
+                END as result'''),
+            conf = conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -323,9 +323,10 @@ class GetJsonObjectCombiner(private val exp: GpuGetJsonObject) extends GpuExpres
     GpuMultiGetJsonObject(json, fieldsNPaths.map(_._2), dt)(targetBatchSize)
   }
 
-  override def getReplacementExpression(e: Expression): Expression = {
-    val localId = toCombine(GpuExpressionEquals(e))
-    GpuGetStructField(multiGet, localId, Some(fieldName(localId)))
+  override def getReplacementExpression(e: Expression): Option[Expression] = {
+    toCombine.get(GpuExpressionEquals(e)).map { localId =>
+      GpuGetStructField(multiGet, localId, Some(fieldName(localId)))
+    }
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -513,9 +513,10 @@ class ContainsCombiner(private val exp: GpuContains) extends GpuExpressionCombin
     GpuMultiContains(input, fieldsNPaths.map(_._2), dt)
   }
 
-  override def getReplacementExpression(e: Expression): Expression = {
-    val localId = toCombine(GpuExpressionEquals(e))
-    GpuGetStructField(multiContains, localId, Some(fieldName(localId)))
+  override def getReplacementExpression(e: Expression): Option[Expression] = {
+    toCombine.get(GpuExpressionEquals(e)).map { localId =>
+      GpuGetStructField(multiContains, localId, Some(fieldName(localId)))
+    }
   }
 }
 


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/13204

The code is kind of complicated aka a bit of a hack, with how it finds expressions that can be combined together. It works and it is this way for performance. I simply made the code that gets the replacement return it optionally so that we can then not replace it if we should not.