### PR TITLE
Use non-ANSI mode to fix overflow error on Spark 400

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -427,6 +427,7 @@ def test_multi_tier_ast():
 
 # MUST NOT use GPU AST when project refers to string type(non-fixed-width),
 # or cudf::compute_column will throw error: Invalid, non-fixed-width type
+@disable_ansi_mode
 @ignore_order(local=True)
 def test_refer_to_non_fixed_width_column():
     gens = [('col_int', int_gen), ('col_string', string_gen)]

--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -427,6 +427,7 @@ def test_multi_tier_ast():
 
 # MUST NOT use GPU AST when project refers to string type(non-fixed-width),
 # or cudf::compute_column will throw error: Invalid, non-fixed-width type
+# ANSI mode is disabled here due to an overflow issue with integer multiplication on Spark 4.0.0.
 @disable_ansi_mode
 @ignore_order(local=True)
 def test_refer_to_non_fixed_width_column():


### PR DESCRIPTION
closes #13217

Use non-ANSI mode to fix overflow error on Spark 400

### why the case fails on Spark 400
Unlike Spark versions prior to 400, Spark 400 use ANSI mode by default, and the mulplication(integer * integer) in this test case will easy to cause overflow. 

### fix
Set non-ansi mode.

Signed-off-by: Chong Gao <res_life@163.com>

