### PR TITLE
Fix performance issue with nested add

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -1134,7 +1134,7 @@ abstract class GpuIntegralDivideParent(
     case _ => false
   }
 
-  override def dataType: DataType = LongType
+  override lazy val dataType: DataType = LongType
   override def outputTypeOverride: DType = DType.INT64
   // CUDF does not support casting output implicitly for decimal binary ops, so we work around
   // it here where we want to force the output to be a Long.
@@ -1164,7 +1164,7 @@ abstract class GpuPmodBase(left: Expression, right: Expression)
 
   override def symbol: String = "pmod"
 
-  override def dataType: DataType = left.dataType
+  override lazy val dataType: DataType = left.dataType
 }
 
 trait GpuGreatestLeastBase extends ComplexTypeMergingExpression with GpuExpression

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -65,7 +65,7 @@ abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolera
       resultDecimalType(p1, s1, p2, s2)
     case _ => lhs.dataType
   }
-  override def dataType: DataType = dataTypeInternal(left, right)
+  override lazy val dataType: DataType = dataTypeInternal(left, right)
 
   protected def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
     throw new IllegalStateException(
@@ -421,11 +421,13 @@ object GpuDecimalDivide {
 case class GpuDecimalDivide(
     left: Expression,
     right: Expression,
-    override val dataType: DecimalType,
+    dt: DecimalType,
     override val failOnError: Boolean,
     override val failOnDivideByZero: Boolean)
     extends CudfBinaryArithmetic with GpuDecimalDivideBase {
   override def inputType: AbstractDataType = DecimalType
+
+  override lazy val dataType: DecimalType = dt
 
   override def symbol: String = "/"
 
@@ -463,11 +465,13 @@ case class GpuDecimalDivide(
 case class GpuDecimalMultiply(
     left: Expression,
     right: Expression,
-    override val dataType: DecimalType,
+    dt: DecimalType,
     useLongMultiply: Boolean = false,
     failOnError: Boolean = SQLConf.get.ansiEnabled) extends CudfBinaryArithmetic
     with GpuDecimalMultiplyBase {
   override def inputType: AbstractDataType = DecimalType
+
+  override lazy val dataType: DecimalType = dt
 
   override def symbol: String = "*"
 
@@ -521,7 +525,7 @@ case class GpuIntegralDecimalDivide(
 
   def integerDivide: Boolean = true
 
-  override def dataType: DataType = LongType
+  override lazy val dataType: DataType = LongType
 
   override def symbol: String = "/"
 


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/13224

But I am going to file a follow on issue to look for other similar places

I didn't add any new tests because this is totally a performance improvement, and it does help a lot as the graph shows.

<img width="600" height="371" alt="time to run deep query" src="https://github.com/user-attachments/assets/5de2b048-3f89-4b41-ba3c-cd1d6dbbe793" />


For an add that is 29 deep the performance went from 126.940 seconds to 0.131 seconds.
