### PR TITLE
Implements scalar * scalar overload function

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -802,7 +802,9 @@ case class GpuMultiply(
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
-    throw new RuntimeException("Error in multiplication: Spark already did the constant folding")
+    withResource(GpuColumnVector.from(lhs, numRows, lhs.dataType)) { lhs_cv =>
+      doColumnar(lhs_cv, rhs)
+    }
   }
 }
 


### PR DESCRIPTION
### bug description

Usually Spark will fold for scalar * scalar, but Spark2a and SparkH both reports:
java.lang.RuntimeException: Error in multiplication: Spark already did the constant folding

### fix
Implements scalar * scalar overload function

### follow-up
It first construct a column from left scalar, it will consume memory, find a way do not expand a scalar to a column.

Signed-off-by: Chong Gao <res_life@163.com>