### PR TITLE
Define the DB required method named 'ensReqDPMetricTag' in GpuShuffleExechangeExec. [databricks]

### DIFF
--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
@@ -22,6 +22,7 @@ import com.nvidia.spark.rapids.GpuPartitioning
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveRepartitioningStatus
 import org.apache.spark.sql.execution.exchange.{ShuffleExchangeLike, ShuffleOrigin}
@@ -62,5 +63,5 @@ case class GpuShuffleExchangeExec(
 
   // DB SPECIFIC - not sure how it is used, so try to return one at first.
   // For more details, refer to https://github.com/NVIDIA/spark-rapids/issues/13242.
-  def ensReqDPMetricTag(): TreeNode[Object] = TreeNodeTag[Object]("GpuShuffleExchangeExec")
+  def ensReqDPMetricTag(): TreeNodeTag[Object] = TreeNodeTag[Object]("GpuShuffleExchangeExec")
 }

--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,4 +59,8 @@ case class GpuShuffleExchangeExec(
      ShuffleExchangeLike = {
     throw new IllegalArgumentException("NOT IMPLEMENTED YET")
   }
+
+  // DB SPECIFIC - not sure how it is used, so try to return one at first.
+  // For more details, refer to https://github.com/NVIDIA/spark-rapids/issues/13242.
+  def ensReqDPMetricTag(): TreeNode[Object] = TreeNodeTag[Object]("GpuShuffleExchangeExec")
 }


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/13242

This PR is trying to fix 13242 by defining the DB required method named `ensReqDPMetricTag` in the GpuShuffleExechangeExec of the DB143 shim.

