### PR TITLE
Fix docstring typo in collect_data_or_exception [skip ci]

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -704,7 +704,7 @@ def collect_data_or_exception(func, error_message, expect_exception=None):
     :param expect_exception:
             - if none, we check the error if and only if it was raised
             - if true, we will assert False if func() doesn't raise an exception,
-            - if false, we fail if we did not raise an exception
+            - if false, we fail if raise an exception
 
     :return: (true, None) if the code failed with an exception and the text matches `error_message`.
              (false, result) if `expect_exception` is false and the function doesn't throw

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -704,7 +704,7 @@ def collect_data_or_exception(func, error_message, expect_exception=None):
     :param expect_exception:
             - if none, we check the error if and only if it was raised
             - if true, we will assert False if func() doesn't raise an exception,
-            - if false, we fail if raise an exception
+            - if false, we fail if we raise an exception
 
     :return: (true, None) if the code failed with an exception and the text matches `error_message`.
              (false, result) if `expect_exception` is false and the function doesn't throw


### PR DESCRIPTION
This is a very small few-character PR, to fix text in a doctring that github copilot caught.

### Description

I am trying to address this comment by copilot: https://github.com/NVIDIA/spark-rapids/pull/13236/files/36c6d87b9507f6328bc6f36b855f5c622df59088#r2251688875

### Checklists

This PR has:

- [x] added documentation for new or modified features or behaviors.
- [ ] updated the license in the source code files when it is required.
- [ ] added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)

Please select one of the following options:
- [ ] Performance testing has been performed and its results are added in the PR description.
- [ ] An issue is filed for performance testing and its link is added in the PR description. (Select this if performance testing will not be completed before the PR is submitted.)
