### PR TITLE
Close shared buffers at batch read completion in kudo deser stream iter

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -688,6 +688,8 @@ class KudoSerializedBatchIterator(dIn: DataInputStream, deserTime: GpuMetric)
             nextHeader = header
           } else {
             dIn.close()
+            sharedBuffer.foreach(_.close())
+            sharedBuffer = None
             streamClosed = true
             nextHeader = None
           }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13145

Currently we allocate shared buffers in the deser iterators as an optimization. The issue is we wait until the task completes to  close these buffers, but a single task can be associated with a large numbers of these iterators. This change closes the buffers as soon as we see that we are finished with a batch.