### PR TITLE
Add override tag to the 'ensReqDPMetricTag' and change it to a 'val'

### DIFF
--- a/sql-plugin/src/main/spark350db143/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/spark350db143/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
@@ -63,5 +63,5 @@ case class GpuShuffleExchangeExec(
 
   // DB SPECIFIC - not sure how it is used, so try to return one at first.
   // For more details, refer to https://github.com/NVIDIA/spark-rapids/issues/13242.
-  def ensReqDPMetricTag(): TreeNodeTag[Object] = TreeNodeTag[Object]("GpuShuffleExchangeExec")
+  override val ensReqDPMetricTag: TreeNodeTag[Int] = TreeNodeTag[Int]("GpuShuffleExchangeExec")
 }


### PR DESCRIPTION
This is a follow-up fix for https://github.com/NVIDIA/spark-rapids/pull/13243.

'ensReqDPMetricTag' turns out to be a 'val' of Scala and required to be overrided.