### PR TITLE
Use pytest.ExceptionInfo to create the same exception text as pytest raises

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -711,7 +711,7 @@ def make_exception_info(ex):
         return pytest.ExceptionInfo.from_exception(ex)
     except AttributeError:
         exc_info = (type(ex), ex, ex.__traceback__)
-        return pytest.ExceptionInfo.from_exc_info(exc_info).exconly()
+        return pytest.ExceptionInfo.from_exc_info(exc_info)
 
 
 def collect_data_or_exception(func, error_message, expect_exception=None):


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13265

### Description

https://github.com/NVIDIA/spark-rapids/pull/13236 introduced a change where the error checking logic we have in asserts.py could instead optionally check an error, if and only if the cpu failed. I changed `pytest.raise` to a try/catch to allow me to optionally compare the error message, which was necessary since `pytest.raise` always fails the test, without any way to configure it, or catch it. 

That said, the change above changed the string we used to compare. Notably, it doesn't include the pyspark exception class name. Some tests use the text and some tests use the classname. Our tests are checking the classname or text, and this isn't consistent between spark versions (I had tests passing with 3.3.3. and CI pased, but spark 3.4.1 reproduced the issue locally). So instead, I decided to rebuild the `pytest.ExceptionInfo` object, using their established method for doing so, or a newer one if available.

### Checklists

<!-- Check the items below by putting "x" in the brackets for what is done. Not all of these items may be relevant to every PR. -->

This PR has:

- [x] added documentation for new or modified features or behaviors.
- [x] updated the license in the source code files when it is required.
- [ ] added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)

Please select one of the following options:
- [ ] Performance testing has been performed and its results are added in the PR description.
- [ ] An issue is filed for performance testing and its link is added in the PR description. (Select this if performance testing will not be completed before the PR is submitted.)
