### PR TITLE
enable offheap limits by default

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -354,7 +354,7 @@ object RapidsConf extends Logging {
       // This might change as a part of https://github.com/NVIDIA/spark-rapids/issues/8878
       .internal()
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val OFF_HEAP_LIMIT_SIZE = conf("spark.rapids.memory.host.offHeapLimit.size")
       .doc("The maximum amount of off heap memory that the plugin will use. " +


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/12471

### Description

Enables CPU offHeap limits by default. This means the plugin will limit the amount of host memory that can be allocated rather than relying on the underlying system limits. The size of the limit is configurable, but defaults to an amount equal to spark.executor.memoryOverhead if set, otherwise an amount based on the available host memory it detects in the environment.

This change is following the resolution https://github.com/NVIDIA/spark-rapids/issues/13101 and related issues from a prior attempt at enabling these limits by default.

Performance testing has shown no change on NDS.

### Checklists

This PR has:

- [x] added documentation for new or modified features or behaviors.
- [x] updated the license in the source code files when it is required.
- [x] added new tests or modified existing tests to cover new code paths.

Please select one of the following options:
- [x] Performance testing has been performed and its results are added in the PR description.
- [ ] An issue is filed for performance testing and its link is added in the PR description. (Select this if performance testing will not be completed before the PR is submitted.)
