### PR TITLE
Fix fallback test params for Delta MergeCommand, UpdateCommand, and DeleteCommand

### DIFF
--- a/integration_tests/src/main/python/delta_lake_delete_test.py
+++ b/integration_tests/src/main/python/delta_lake_delete_test.py
@@ -19,7 +19,7 @@ from data_gen import *
 from delta_lake_utils import *
 from marks import *
 from spark_session import is_before_spark_320, is_databricks_runtime, supports_delta_lake_deletion_vectors, \
-    with_cpu_session, with_gpu_session, is_databricks143_or_later
+    with_cpu_session, with_gpu_session, is_before_spark_353
 
 delta_delete_enabled_conf = copy_and_update(delta_writes_enabled_conf,
                                             {"spark.rapids.sql.command.DeleteCommand": "true",
@@ -63,16 +63,19 @@ def assert_delta_sql_delete_collect(spark_tmp_path, use_cdf, dest_table_func, de
     delta_sql_delete_test(spark_tmp_path, use_cdf, dest_table_func, delete_sql, checker, enable_deletion_vectors,
                           partition_columns)
 
+fallback_test_params = [{"spark.rapids.sql.format.delta.write.enabled": "false"},
+                        {"spark.rapids.sql.format.parquet.enabled": "false"},
+                        {"spark.rapids.sql.format.parquet.write.enabled": "false"},
+                        {"spark.rapids.sql.command.DeleteCommand": "false"},
+                        ]
+if is_before_spark_353():
+    # DeleteCommand is disabled by default before Spark 3.5.3
+    fallback_test_params.append(delta_writes_enabled_conf)
+
 @allow_non_gpu("ExecutedCommandExec", *delta_meta_allow)
 @delta_lake
 @ignore_order
-@pytest.mark.parametrize("disable_conf",
-                          [{"spark.rapids.sql.format.delta.write.enabled": "false"},
-                           {"spark.rapids.sql.format.parquet.enabled": "false"},
-                           {"spark.rapids.sql.format.parquet.write.enabled": "false"},
-                           {"spark.rapids.sql.command.DeleteCommand": "false"},
-                           delta_writes_enabled_conf  # Test disabled by default
-                           ], ids=idfn)
+@pytest.mark.parametrize("disable_conf", fallback_test_params, ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @pytest.mark.parametrize("enable_deletion_vectors", deletion_vector_values, ids=idfn)
 def test_delta_delete_disabled_fallback(spark_tmp_path, disable_conf, enable_deletion_vectors):


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13279.

### Description

We have integration tests that test the fallback for merge, update, and delete commands with various configs. One of the cases tested is the "default" config when there is no config set for these commands. As these commands are enabled by default now, the fallback tests are failing for this case. Since the default behavior is changed only for spark 3.5.3+, the test parameters are now set differently based on the spark version so that the default case won't be tested for spark 3.5.3+. 

### Checklists

This PR has:

- [ ] added documentation for new or modified features or behaviors.
- [ ] updated the license in the source code files when it is required.
- [x] added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)

Please select one of the following options:
- [ ] Performance testing has been performed and its results are added in the PR description.
- [ ] An issue is filed for performance testing and its link is added in the PR description. (Select this if performance testing will not be completed before the PR is submitted.)
