### PR TITLE
Temporarily disable timezone America/Coyhaique to unblock branch-25.08 release

### DIFF
--- a/integration_tests/src/main/python/timezones.py
+++ b/integration_tests/src/main/python/timezones.py
@@ -21,4 +21,5 @@ variable_offset_timezones_iana = ["America/Los_Angeles", "America/St_Johns", "Am
 
 # Dynamically get supported timezones from JVM.
 # Different JVMs can have different timezones, should not use a constant list here.
-all_timezones = spark_jvm().java.time.ZoneId.getAvailableZoneIds()
+# Note: excludes `America/Coyhaique`, refer to bug: https://github.com/NVIDIA/spark-rapids/issues/13285
+all_timezones = [tz for tz in spark_jvm().java.time.ZoneId.getAvailableZoneIds() if tz != 'America/Coyhaique']


### PR DESCRIPTION
Related to https://github.com/NVIDIA/spark-rapids/issues/13285

### Description
From the issue,  we can see `TimestampGen` in `data_gen.py` can not handle this America/Coyhaique timezone.
This America/Coyhaique timezone is new introduced into the JVM in dataproc-serverless-2.2.
This PR is not to fix the bug in `data_gen.py`, only aims to unblock branch-25.08 release.

### Checklists


This PR has:

- [x] added documentation for new or modified features or behaviors.
- [x] updated the license in the source code files when it is required.
- [x] added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)

Please select one of the following options:
- [x] Performance testing has been performed and its results are added in the PR description.
- [x] An issue is filed for performance testing and its link is added in the PR description. (Select this if performance testing will not be completed before the PR is submitted.)
