### PR TITLE
Replace 'get' with `getOrElse` to avoid None.get exception in GpuBatchScanExec[databricks]

### DIFF
--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -95,7 +95,7 @@ case class GpuBatchScanExec(
               s"through HasPartitionKey remain the same but do not exactly match")
           }
 
-          groupPartitions(newPartitions).map(_._2).getOrElse(Seq.empty)
+          groupPartitions(newPartitions).map(_.map(_._2)).getOrElse(Seq.empty)
 
         case _ =>
           // no validation is needed as the data source did not report any specific partitioning

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -94,7 +94,7 @@ case class GpuBatchScanExec(
               s"through HasPartitionKey remain the same but do not exactly match")
           }
 
-          groupPartitions(newPartitions).map(_._2).getOrElse(Seq.empty)
+          groupPartitions(newPartitions).map(_.map(_._2)).getOrElse(Seq.empty)
 
         case _ =>
           // no validation is needed as the data source did not report any specific partitioning

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -94,7 +94,7 @@ case class GpuBatchScanExec(
               s"through HasPartitionKey remain the same but do not exactly match")
           }
 
-          groupPartitions(newPartitions).map(_._2).getOrElse(Seq.empty)
+          groupPartitions(newPartitions).map(_.map(_._2)).getOrElse(Seq.empty)
 
         case _ =>
           // no validation is needed as the data source did not report any specific partitioning


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/10200

This PR follows the change in https://github.com/apache/spark/commit/8c11804c440 to fix the potential "None.get" exception in GpuBatchScanExec for all the shims.

It is not easy to test, but the change is ok since it is very simple and straightforward. Anyway filed https://github.com/NVIDIA/spark-rapids/issues/13290 to track the tests things.