### PR TITLE
Fixed bug with arithmetic overflow on some map_zip_with tests

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -776,12 +776,11 @@ def test_map_zip_with(data_gen):
             columns.extend([
                     'map_zip_with(a, b,  (key, value1, value2) -> concat(coalesce(value1, ""), "-test-", coalesce(value2, ""))) as string_concat',])
         if isinstance(value_type, ArrayType):
-            {'spark.sql.ansi.enabled': False}
             columns.extend([
                     'map_zip_with(a, b,  (key, value1, value2) -> concat(value1, value2)) as array_concat',])
         df = two_col_df(spark, data_gen, data_gen)
         return df.selectExpr(columns)
-    assert_gpu_and_cpu_are_equal_collect(do_it)
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', [MapGen(IntegerGen(False, min_val=-5, max_val=5), ArrayGen(int_gen, max_length=5), min_length=7)], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
@@ -813,7 +812,7 @@ def test_map_zip_with_mismatch_keys(data_gen):
         b_gen = MapGen(ByteGen(False), ByteGen())
         df = two_col_df(spark, data_gen, b_gen)
         return df.selectExpr(columns)
-    assert_gpu_and_cpu_are_equal_collect(do_it)
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', map_gens_sample, ids=idfn)
 @allow_non_gpu(*non_utc_allow)

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -780,7 +780,10 @@ def test_map_zip_with(data_gen):
                     'map_zip_with(a, b,  (key, value1, value2) -> concat(value1, value2)) as array_concat',])
         df = two_col_df(spark, data_gen, data_gen)
         return df.selectExpr(columns)
-    # Disable ansi due to arithmetic overflow
+    # ANSI mode is disabled since this test verifies the behaviour of map_zip_with and the evaluation of the associated lambda. 
+    # Exceptions during overflow conditions are tested in the arithmetic-ops tests.
+    # Furthermore, we disable ansi here to force the test to run with ANSI disabled. 
+    # Skipping tests on versions of Spark with ANSI on by default causes us to lose test coverage.
     assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', [MapGen(IntegerGen(False, min_val=-5, max_val=5), ArrayGen(int_gen, max_length=5), min_length=7)], ids=idfn)
@@ -813,7 +816,10 @@ def test_map_zip_with_mismatch_keys(data_gen):
         b_gen = MapGen(ByteGen(False), ByteGen())
         df = two_col_df(spark, data_gen, b_gen)
         return df.selectExpr(columns)
-    # Disable ansi due to arithmetic overflow
+    # ANSI mode is disabled since this test verifies the behaviour of map_zip_with and the evaluation of the associated lambda. 
+    # Exceptions during overflow conditions are tested in the arithmetic-ops tests.
+    # Furthermore, we disable ansi here to force the test to run with ANSI disabled. 
+    # Skipping tests on versions of Spark with ANSI on by default causes us to lose test coverage.
     assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', map_gens_sample, ids=idfn)

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -780,6 +780,7 @@ def test_map_zip_with(data_gen):
                     'map_zip_with(a, b,  (key, value1, value2) -> concat(value1, value2)) as array_concat',])
         df = two_col_df(spark, data_gen, data_gen)
         return df.selectExpr(columns)
+    # Disable ansi due to arithmetic overflow
     assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', [MapGen(IntegerGen(False, min_val=-5, max_val=5), ArrayGen(int_gen, max_length=5), min_length=7)], ids=idfn)
@@ -812,6 +813,7 @@ def test_map_zip_with_mismatch_keys(data_gen):
         b_gen = MapGen(ByteGen(False), ByteGen())
         df = two_col_df(spark, data_gen, b_gen)
         return df.selectExpr(columns)
+    # Disable ansi due to arithmetic overflow
     assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', map_gens_sample, ids=idfn)

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -782,8 +782,7 @@ def test_map_zip_with(data_gen):
         return df.selectExpr(columns)
     # ANSI mode is disabled since this test verifies the behaviour of map_zip_with and the evaluation of the associated lambda. 
     # Exceptions during overflow conditions are tested in the arithmetic-ops tests.
-    # Furthermore, we disable ansi here to force the test to run with ANSI disabled. 
-    # Skipping tests on versions of Spark with ANSI on by default causes us to lose test coverage.
+    # Not using @disable_ansi_mode because of https://github.com/NVIDIA/spark-rapids/issues/13214.  Using explicit setting instead.
     assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', [MapGen(IntegerGen(False, min_val=-5, max_val=5), ArrayGen(int_gen, max_length=5), min_length=7)], ids=idfn)
@@ -818,8 +817,7 @@ def test_map_zip_with_mismatch_keys(data_gen):
         return df.selectExpr(columns)
     # ANSI mode is disabled since this test verifies the behaviour of map_zip_with and the evaluation of the associated lambda. 
     # Exceptions during overflow conditions are tested in the arithmetic-ops tests.
-    # Furthermore, we disable ansi here to force the test to run with ANSI disabled. 
-    # Skipping tests on versions of Spark with ANSI on by default causes us to lose test coverage.
+    # Not using @disable_ansi_mode because of https://github.com/NVIDIA/spark-rapids/issues/13214.  Using explicit setting instead.
     assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.sql.ansi.enabled': False})
 
 @pytest.mark.parametrize('data_gen', map_gens_sample, ids=idfn)


### PR DESCRIPTION
This PR disables ansi mode on two tests, test_map_zip_with and test_map_zip_with_mismatch_keys, to fix the arithmetic overflow issues seen in #13312 