### PR TITLE
Fix test_delta_optimize_fallback_on_clustered_table test failure with Spark 3.5.6 [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_optimize_table_test.py
+++ b/integration_tests/src/main/python/delta_lake_optimize_table_test.py
@@ -128,7 +128,7 @@ def test_delta_optimize_partitioned_table(spark_tmp_path, enable_deletion_vector
 
 
 @delta_lake
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "AtomicReplaceTableAsSelectExec", "AppendDataExecV1")
+@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "AtomicCreateTableAsSelectExec", "AppendDataExecV1")
 @pytest.mark.skipif(is_before_spark_353(), reason="Liquid clustering requires Delta 3.3+")
 @pytest.mark.skipif(is_databricks_runtime(), reason="OPTIMIZE table command is not supported for Databricks")
 def test_delta_optimize_fallback_on_clustered_table(spark_tmp_path, spark_tmp_table_factory):
@@ -141,7 +141,7 @@ def test_delta_optimize_fallback_on_clustered_table(spark_tmp_path, spark_tmp_ta
 
     def write_clustered_then_optimize(spark, path):
         spark.sql(f"""
-            CREATE OR REPLACE TABLE delta.`{path}`
+            CREATE TABLE delta.`{path}`
             USING DELTA
             CLUSTER BY (a)
             AS SELECT * FROM {view_name}


### PR DESCRIPTION
Fixes #13331.

### Description

It is a [known issue](https://github.com/delta-io/delta/issues/4671) in delta that `CREATE OR REPLACE TABLE` sometimes fails with the error `Table {name} does not support truncate in batch mode`. The test in question in fact does not need to use `CREATE OR REPLACE TABLE`. It is left over after some refactoring. I changed it to `CREATE TABLE` instead. I manually verified this change in my workstation with Spark 3.5.6 and Delta 3.3.0.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
