### PR TITLE
replace action

### DIFF
--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -26,7 +26,7 @@ jobs:
     - name: work around permission issue
       run: git config --global --add safe.directory /github/workspace
     - uses: NVIDIA/spark-rapids-common/checkout@main
-    - uses: NVIDIA/spark-rapids-common/markdown-link-check@main
+    - uses: YanxuanLiu/spark-rapids-common/markdown-link-check@markdown-check-sha
       with:
         max-depth: -1
         use-verbose-mode: 'yes'

--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ jobs:
     steps:
     - name: work around permission issue
       run: git config --global --add safe.directory /github/workspace
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: NVIDIA/spark-rapids-common/checkout@main
+    - uses: NVIDIA/spark-rapids-common/markdown-link-check@main
       with:
         max-depth: -1
         use-verbose-mode: 'yes'


### PR DESCRIPTION
Replace `markdown-link-check` github action with custom one of common repo.