### PR TITLE
Suppress deprecation warnings for `ParseURI`

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
@@ -23,6 +23,8 @@ import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.ParseURI
 import com.nvidia.spark.rapids.shims.ShimExpression
 
+import scala.annotation.nowarn
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -58,6 +60,7 @@ case class GpuParseUrl(children: Seq[Expression])
 
   import GpuParseUrl._
 
+  @nowarn("msg=in class ParseURI is deprecated")
   def doColumnar(url: GpuColumnVector, partToExtract: GpuScalar): ColumnVector = {
     val part = partToExtract.getValue.asInstanceOf[UTF8String].toString
     part match {
@@ -77,6 +80,7 @@ case class GpuParseUrl(children: Seq[Expression])
     }
   }
 
+  @nowarn("msg=in class ParseURI is deprecated")
   def doColumnar(col: GpuColumnVector, partToExtract: GpuScalar, key: GpuScalar): ColumnVector = {
     val part = partToExtract.getValue.asInstanceOf[UTF8String].toString
     if (part != QUERY || key == null || !key.isValid) {
@@ -87,6 +91,7 @@ case class GpuParseUrl(children: Seq[Expression])
     ParseURI.parseURIQueryWithLiteral(col.getBase, keyStr)
   }
 
+  @nowarn("msg=in class ParseURI is deprecated")
   def doColumnar(col: GpuColumnVector, partToExtract: GpuScalar, 
       key: GpuColumnVector): ColumnVector = {
     val part = partToExtract.getValue.asInstanceOf[UTF8String].toString

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
@@ -22,7 +22,6 @@ import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.ParseURI
 import com.nvidia.spark.rapids.shims.ShimExpression
-
 import scala.annotation.nowarn
 
 import org.apache.spark.sql.catalyst.expressions._


### PR DESCRIPTION
This PR fixes https://github.com/NVIDIA/spark-rapids/issues/13337

The recent spark-rapids-jni PR #3617 added ANSI mode support to ParseURI methods, deprecating the old methods without ANSI flags. This causes compilation failures in Scala 2.12 builds due to -Xfatal-warnings.

Add @nowarn annotations to suppress deprecation warnings for the deprecated ParseURI method calls until we can migrate to the new ANSI-aware APIs.

### Checklists
- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
