### PR TITLE
Remove deprecated methods.

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
@@ -64,18 +64,18 @@ case class GpuParseUrl(children: Seq[Expression])
     val part = partToExtract.getValue.asInstanceOf[UTF8String].toString
     part match {
       case PROTOCOL =>
-        ParseURI.parseURIProtocol(url.getBase)
+        ParseURI.parseURIProtocol(url.getBase, false)
       case HOST =>
-        ParseURI.parseURIHost(url.getBase)
+        ParseURI.parseURIHost(url.getBase, false)
       case QUERY =>
-        ParseURI.parseURIQuery(url.getBase)
+        ParseURI.parseURIQuery(url.getBase, false)
       case PATH =>
-        ParseURI.parseURIPath(url.getBase)
+        ParseURI.parseURIPath(url.getBase, false)
       case REF | FILE | AUTHORITY | USERINFO =>
         throw new UnsupportedOperationException(s"$this is not supported partToExtract=$part. " +
             s"Only PROTOCOL, HOST, QUERY and PATH are supported")
       case _ =>
-        return GpuColumnVector.columnVectorFromNull(url.getRowCount.toInt, StringType)
+        GpuColumnVector.columnVectorFromNull(url.getRowCount.toInt, StringType)
     }
   }
 
@@ -87,7 +87,7 @@ case class GpuParseUrl(children: Seq[Expression])
       return GpuColumnVector.columnVectorFromNull(col.getRowCount.toInt, StringType)
     }
     val keyStr = key.getValue.asInstanceOf[UTF8String].toString
-    ParseURI.parseURIQueryWithLiteral(col.getBase, keyStr)
+    ParseURI.parseURIQueryWithLiteral(col.getBase, keyStr, false)
   }
 
   @nowarn("msg=in class ParseURI is deprecated")
@@ -98,7 +98,7 @@ case class GpuParseUrl(children: Seq[Expression])
       // return a null columnvector
       return GpuColumnVector.columnVectorFromNull(col.getRowCount.toInt, StringType)
     }
-    ParseURI.parseURIQueryWithColumn(col.getBase, key.getBase)
+    ParseURI.parseURIQueryWithColumn(col.getBase, key.getBase, false)
   }
 
   override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {


### PR DESCRIPTION

Fixes #13342 .

### Description

In https://github.com/NVIDIA/spark-rapids-jni/pull/3617 some methods in ParseURI are deprecated, which leads to build failure of spark-rapids. This pr fix the build break by removing usage of deprecated methods.

The replaced method are identical, so I believe exisiting tests has covered the changes.

Also we don't need to do extra perf test as it's identical changes.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
