### PR TITLE
Make the iceberg bug easier to produce.

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_merge_on_read_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_merge_on_read_test.py
@@ -99,11 +99,6 @@ def test_iceberg_v2_mixed_deletes(spark_tmp_table_factory, spark_tmp_path, reade
                                   register_iceberg_add_eq_deletes_udf):
     # We use a fixed seed here to ensure that data deletion vector has been generated
     table_name = setup_base_iceberg_table(spark_tmp_table_factory)
-    # Equation deletes
-    _change_table(table_name,
-                  lambda spark: _add_eq_deletes(spark, ["_c0"], 170, table_name, spark_tmp_path),
-                  "No equation deletes generated")
-
     # Position deletes
     _change_table(table_name,
                   lambda spark: spark.sql(f"DELETE FROM {table_name} where _c1 < 0"),
@@ -111,13 +106,19 @@ def test_iceberg_v2_mixed_deletes(spark_tmp_table_factory, spark_tmp_path, reade
 
     # Equation deletes
     _change_table(table_name,
-                  lambda spark: _add_eq_deletes(spark, ["_c1", "_c2"], 110, table_name,
+                  lambda spark: _add_eq_deletes(spark, ["_c0"], 170, table_name, spark_tmp_path),
+                  "No equation deletes generated")
+
+
+    # Equation deletes
+    _change_table(table_name,
+                  lambda spark: _add_eq_deletes(spark, ["_c2", "_c3", "_c6"], 140, table_name,
                                                 spark_tmp_path),
                   "No equation deletes generated")
 
     # Equation deletes
     _change_table(table_name,
-                  lambda spark: _add_eq_deletes(spark, ["_c2", "_c3", "_c6"], 140, table_name,
+                  lambda spark: _add_eq_deletes(spark, ["_c1", "_c2"], 110, table_name,
                                                 spark_tmp_path),
                   "No equation deletes generated")
 


### PR DESCRIPTION
Related to #12885 .

### Description

This pr did small modification to the test_iceberg_v2_mixed_deletes test to make it easier to reproduce. 

As stated in https://github.com/NVIDIA/spark-rapids/issues/12885#issuecomment-3205124465 , this is in fact not a bug of spark-rapids, but oss iceberg.

This is a test only change, and we will not do extra test and perf test.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
