### PR TITLE
This fixes a big regression due to serialization of the hadoop configuration

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -1109,6 +1109,10 @@ case class GpuParquetMultiFilePartitionReaderFactory(
     queryUsesInputFile: Boolean)
   extends MultiFilePartitionReaderFactoryBase(sqlConf, broadcastedConf, rapidsConf) {
 
+  // we make sure we mark this as a transient lazy val, so we only materialize it
+  // from a task when we need to create the fileIO instance. This stops a regression
+  // when we materialize the hadoop conf eagerly, see:
+  // https://github.com/NVIDIA/spark-rapids/issues/13353
   @transient private lazy val fileIO = new HadoopFileIO(broadcastedConf.value.value)
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val debugDumpPrefix = rapidsConf.parquetDebugDumpPrefix
@@ -1323,6 +1327,10 @@ case class GpuParquetPartitionReaderFactory(
     @transient params: Map[String, String])
   extends ShimFilePartitionReaderFactory(params) with Logging {
 
+  // we make sure we mark this as a transient lazy val, so we only materialize it
+  // from a task when we need to create the fileIO instance. This stops a regression
+  // when we materialize the hadoop conf eagerly, see:
+  // https://github.com/NVIDIA/spark-rapids/issues/13353
   @transient private lazy val fileIO = new HadoopFileIO(broadcastedConf.value.value)
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val debugDumpPrefix = rapidsConf.parquetDebugDumpPrefix


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13353

### Description

This fixes a 46% performance regression on NDS @ sf3k in our performance clusters due to this change: https://github.com/NVIDIA/spark-rapids/pull/13252. The culprit was a hadoop configuration that was serialized with the body of the task.

The regression is fixed by accessing the broadcast directly at runtime from the task.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
