### PR TITLE
Fix the flaky test in `TrafficControllerSuite`

### DIFF
--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/TrafficControllerSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/TrafficControllerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ class TrafficControllerSuite extends AnyFunSuite with BeforeAndAfterEach with Ti
     while (controller.numScheduledTasks == 0) {
       Thread.sleep(100)
     }
-    assert(futures(0).isDone)
+    futures(0).get(1, TimeUnit.SECONDS)
     assertResult(1)(controller.numScheduledTasks)
     assertResult(throttle.tasksScheduled.head)(tasks(0))
 
@@ -129,7 +129,7 @@ class TrafficControllerSuite extends AnyFunSuite with BeforeAndAfterEach with Ti
     while (controller.numScheduledTasks == 0) {
       Thread.sleep(100)
     }
-    assert(futures(1).isDone)
+    futures(1).get(1, TimeUnit.SECONDS)
     assertResult(1)(controller.numScheduledTasks)
     assertResult(throttle.tasksScheduled(1))(tasks(1))
 
@@ -139,7 +139,7 @@ class TrafficControllerSuite extends AnyFunSuite with BeforeAndAfterEach with Ti
     while (controller.numScheduledTasks == 0) {
       Thread.sleep(100)
     }
-    assert(futures(2).isDone)
+    futures(2).get(1, TimeUnit.SECONDS)
     assertResult(1)(controller.numScheduledTasks)
     assertResult(throttle.tasksScheduled(2))(tasks(2))
 


### PR DESCRIPTION
Fixes #13198.

### Description

```scala
      val f: Future[_] = executor.submit(new Runnable {
        override def run(): Unit = controller.blockUntilRunnable(t)
      })
```

It was reported in https://github.com/NVIDIA/spark-rapids/issues/13198 that the test `all tasks are bigger than the total memory limit` fails intermittently. This test tests a case where all tasks are bigger than the total host memory limit. In this case, only one task can be executed at a time. To test this case, this test submits all tasks at the beginning of the test, completes the tasks one at a time, and verifies whether the next task is scheduled. The tasks are executed asynchronously using a different thread from the main as depicted in the above. As such, there can be some time gap between when `controller.blockUntilRunnable(t)` returns and the status of the future `f` is updated. Currently, the test in question is calling `assert(future.isDone)` to verify the future status. This can if `blockUntilRunnable()` has returned but the future status hasn't been updated yet. This PR fixes this issue by waiting until the future is done instead of directly checking the future status.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
