### PR TITLE
Optimize table to trigger liquid clustering before test [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_clustered_reads_test.py
+++ b/integration_tests/src/main/python/delta_lake_clustered_reads_test.py
@@ -60,6 +60,9 @@ def setup_clustered_table(spark, path, table_name, enable_dv):
     df = gen_df(spark, gen_list)
     df.write.format("delta").mode("append").saveAsTable(table_name)
 
+    # Optimize the table to trigger clustering
+    spark.sql(f"optimize {table_name}")
+
     desc = spark.sql(f"DESCRIBE DETAIL {table_name}").collect()
     # Ensure the table is clustered as expected
     assert desc[0].clusteringColumns == ["a", "d"]


### PR DESCRIPTION
Fixes #13370.

### Description

For Delta IO, enabling liquid clustering for a table does not automatically trigger clustering as data is appended. [The table should be optimized to do that](https://docs.delta.io/delta-clustering/#how-to-trigger-clustering). Currently, our tests for liquid clustering in `delta_lake_clustered_reads_test.py` create a table with liquid clustering enabled, but do not trigger the clustering. As for databricks delta, we have the same issue even though [Databricks delta can automatically trigger the clustering if it satisfies certain condition](https://docs.databricks.com/gcp/en/delta/clustering#write-data-to-a-clustered-table), because our test data doesn't seem to satisfy that condition. This PR adds an optimize command after data is appended to the test table.

The tests in `delta_lake_liquid_clustereing_test.py` are fine as they test only fallbacks.

Performance test result will be posted in #13370.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
