### PR TITLE
Fix index out of bound bug in iceberg parquet reader.

### DIFF
--- a/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
+++ b/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
@@ -175,17 +175,9 @@ trait GpuIcebergParquetReader extends Iterator[ColumnarBatch] with AutoCloseable
         conf.caseSensitive)
 
       blocks.filter { case (rowGroup, _) =>
-          val beforeOrdinal = rowGroup.getOrdinal
-          val filterResult = statsFilter.shouldRead(typeWithIds, rowGroup) &&
+          statsFilter.shouldRead(typeWithIds, rowGroup) &&
             dictFilter.shouldRead(typeWithIds, rowGroup, reader.getDictionaryReader(rowGroup)) &&
             bloomFilter.shouldRead(typeWithIds, rowGroup, reader.getBloomFilterDataReader(rowGroup))
-
-          val afterOrdinal = rowGroup.getOrdinal
-          if (beforeOrdinal != afterOrdinal) {
-            throw new IllegalStateException(s"Parquet row group ordinal changed from " +
-              s"$beforeOrdinal to $afterOrdinal after filter, this should never happen!")
-          }
-          filterResult
       }
     }.getOrElse(blocks)
       .toSeq


### PR DESCRIPTION

Fixes #13361 

### Description

In iceberg parquet reader we used row group metadata's ordinal field to get row group's position in parquet file. However this field seems unreliable and our customer runs into issues. This pr removed its usage. 

Since it's a small refactor, existing tests should already cover it.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
