### PR TITLE
Add an executor cache class

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ExecutorCache.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ExecutorCache.scala
@@ -32,7 +32,7 @@ object ExecutorCache {
    * and will not change during the lifetime of the executor.
    * Should be called on executor side.
    */
-  lazy val getCurrentDeviceComputeMode: CudaComputeMode = Cuda.getComputeMode()
+  private[rapids] lazy val getCurrentDeviceComputeMode: CudaComputeMode = Cuda.getComputeMode()
 
   /**
    * Cache the current device UUID for current executor.
@@ -40,12 +40,12 @@ object ExecutorCache {
    * and will not change during the lifetime of the executor.
    * Should be called on executor side.
    */
-  lazy val getCurrentDeviceUuid: Array[Byte] = Cuda.getGpuUuid()
+  private[rapids] lazy val getCurrentDeviceUuid: Array[Byte] = Cuda.getGpuUuid()
 
   /**
    * Cache the current process name for current executor.
    * Should be called on executor side.
    */
-  lazy val getProcessName: String = ManagementFactory.getRuntimeMXBean.getName
+  private[rapids] lazy val getProcessName: String = ManagementFactory.getRuntimeMXBean.getName
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ExecutorCache.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ExecutorCache.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import java.lang.management.ManagementFactory;
+import java.lang.management.ManagementFactory
 
 import ai.rapids.cudf.{Cuda, CudaComputeMode}
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ExecutorCache.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ExecutorCache.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.lang.management.ManagementFactory;
+
+import ai.rapids.cudf.{Cuda, CudaComputeMode}
+
+/**
+ * A singleton object to cache executor related information.
+ * Uses lazy mode to ensure the values are only computed once per executor.
+ */
+object ExecutorCache {
+
+  /**
+   * Cache the current device compute mode for current executor.
+   * It's based on the assumption that executor has been assigned to a single device,
+   * and will not change during the lifetime of the executor.
+   * Should be called on executor side.
+   */
+  lazy val getCurrentDeviceComputeMode: CudaComputeMode = Cuda.getComputeMode()
+
+  /**
+   * Cache the current device UUID for current executor.
+   * It's based on the assumption that executor has been assigned to a single device,
+   * and will not change during the lifetime of the executor.
+   * Should be called on executor side.
+   */
+  lazy val getCurrentDeviceUuid: Array[Byte] = Cuda.getGpuUuid()
+
+  /**
+   * Cache the current process name for current executor.
+   * Should be called on executor side.
+   */
+  lazy val getProcessName: String = ManagementFactory.getRuntimeMXBean.getName
+}
+

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/misc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/misc.scala
@@ -70,7 +70,7 @@ case class GpuUuid() extends GpuExpression with ShimExpression {
 }
 
 object GpuUuid {
-  // Stores the sequence ID of calling generate UUIDs.
+  // Stores the sequence ID for generating UUIDs.
   private val sequence = new AtomicLong(0L)
 
   private def getSequenceId: Long = sequence.incrementAndGet

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/misc.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/misc.scala
@@ -18,6 +18,8 @@ package com.nvidia.spark.rapids
 
 import com.nvidia.spark.rapids.jni.StringUtils
 import com.nvidia.spark.rapids.shims.ShimExpression
+import java.util
+import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Uuid}
 import org.apache.spark.sql.types._
@@ -42,9 +44,36 @@ case class GpuUuid() extends GpuExpression with ShimExpression {
 
   override def children: Seq[Expression] = Nil
 
-  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
-    GpuColumnVector.from(StringUtils.randomUUIDs(batch.numRows), dataType)
+  /**
+   * Generate a seed for UUID generation.
+   * The seed is generated based on the current time in nanoseconds, the process
+   * name, the GPU UUID, and a sequence ID that increments with each call to
+   * this method. This method ensures (do best effort) that the seed is unique
+   * across different runs, including different Spark jobs, different executions
+   * of the same job, set backward of the clock, etc.
+   *
+   * @return A seed for UUID generation.
+   */
+  private def randomSeed: Long = {
+    var seed = System.nanoTime
+    val processName = ExecutorCache.getProcessName
+    val gpuUUID = ExecutorCache.getCurrentDeviceUuid
+    seed = seed * 37 + processName.hashCode
+    seed = seed * 37 + util.Arrays.hashCode(gpuUUID)
+    seed = seed * 37 + GpuUuid.getSequenceId
+    seed
   }
+
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    GpuColumnVector.from(StringUtils.randomUUIDsWithSeed(batch.numRows, randomSeed), dataType)
+  }
+}
+
+object GpuUuid {
+  // Stores the sequence ID of calling generate UUIDs.
+  private val sequence = new AtomicLong(0L)
+
+  private def getSequenceId: Long = sequence.incrementAndGet
 }
 
 class GpuUuidMeta(


### PR DESCRIPTION
Fixes #13324

### Description
Cache `Cuda.getGpuUuid()` for Spark executor.

### Depends on
* https://github.com/NVIDIA/spark-rapids-jni/pull/3677

### Changes:
Move jni.StringUtils.randomSeed to Spark-Rapids repo.
Cache `Cuda.getGpuUuid()`
Call randomUUIDsWithSeed instead of randomUUIDs(int rowCount)


### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
       No need to add documentation, this is a refactor PR.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      Existing test case can cover.
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
      No need to do Performance testing
