### PR TITLE
Add two metrics for the sized join

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMetrics.scala
@@ -111,6 +111,8 @@ object GpuMetric extends Logging {
   val DELETION_VECTOR_SIZE = "deletionVectorSize"
   val COPY_TO_HOST_TIME = "d2hMemCopyTime"
   val READ_THROTTLING_TIME = "readThrottlingTime"
+  val SMALL_JOIN_COUNT = "sizedSmallJoin"
+  val BIG_JOIN_COUNT = "sizedBigJoin"
   val SYNC_READ_TIME = "shuffleSyncReadTime"
   val ASYNC_READ_TIME = "shuffleAsyncReadTime"
 
@@ -157,6 +159,9 @@ object GpuMetric extends Logging {
   val DESCRIPTION_DELETION_VECTOR_SIZE = "deletion vector size"
   val DESCRIPTION_COPY_TO_HOST_TIME = "deviceToHost memory copy time"
   val DESCRIPTION_READ_THROTTLING_TIME = "read throttling time"
+
+  val DESCRIPTION_SMALL_JOIN_COUNT = "small joins"
+  val DESCRIPTION_BIG_JOIN_COUNT = "big joins"
   val DESCRIPTION_SYNC_READ_TIME = "sync read time"
   val DESCRIPTION_ASYNC_READ_TIME = "async read time"
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -352,11 +352,6 @@ object GpuShuffledSizedHashJoinExec {
           opTime, joinTime)
     }
   }
-
-  val SMALL_JOIN_COUNT = "_sizedSmallJoin"
-  val SMALL_JOIN_COUNT_DESC = "small joins"
-  val BIG_JOIN_COUNT = "_sizedBigJoin"
-  val BIG_JOIN_COUNT_DESC = "big joins"
 }
 
 abstract class GpuShuffledSizedHashJoinExec[HOST_BATCH_TYPE <: AutoCloseable] extends GpuJoinExec {
@@ -386,8 +381,8 @@ abstract class GpuShuffledSizedHashJoinExec[HOST_BATCH_TYPE <: AutoCloseable] ex
     BUILD_DATA_SIZE -> createSizeMetric(ESSENTIAL_LEVEL, DESCRIPTION_BUILD_DATA_SIZE),
     BUILD_TIME -> createNanoTimingMetric(ESSENTIAL_LEVEL, DESCRIPTION_BUILD_TIME),
     STREAM_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_STREAM_TIME),
-    SMALL_JOIN_COUNT -> createMetric(DEBUG_LEVEL, SMALL_JOIN_COUNT_DESC),
-    BIG_JOIN_COUNT -> createMetric(DEBUG_LEVEL, BIG_JOIN_COUNT_DESC),
+    SMALL_JOIN_COUNT -> createMetric(DEBUG_LEVEL, DESCRIPTION_SMALL_JOIN_COUNT),
+    BIG_JOIN_COUNT -> createMetric(DEBUG_LEVEL, DESCRIPTION_BIG_JOIN_COUNT),
     JOIN_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_JOIN_TIME))
 
   override def requiredChildDistribution: Seq[Distribution] =


### PR DESCRIPTION
This PR adds in two metrics of debug level in the sized join to show the numbers of the internal join types (big or small) separately for better performance analysis.