### PR TITLE
Add write support for Delta clustered tables

### DIFF
--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -27,12 +27,11 @@ import org.apache.spark.sql.delta.DeltaParquetFileFormat.{IS_ROW_DELETED_COLUMN_
 import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
 import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, OptimizeTableCommand, UpdateCommand}
 import org.apache.spark.sql.delta.rapids.DeltaRuntimeShim
-import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils.PROP_CLUSTERING_COLUMNS
 import org.apache.spark.sql.delta.sources.DeltaDataSource
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, SaveIntoDataSourceCommand}
-import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec, OverwriteByExpressionExecV1}
+import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec}
 import org.apache.spark.sql.execution.datasources.v2.rapids.{GpuAtomicCreateTableAsSelectExec, GpuAtomicReplaceTableAsSelectExec}
 import org.apache.spark.sql.rapids.ExternalSource
 import org.apache.spark.sql.sources.CreatableRelationProvider
@@ -67,15 +66,6 @@ object Delta33xProvider extends DeltaIOProvider {
       case _: DeltaTableV2 => super.tagForGpu(cpuExec, meta)
       case _: GpuDeltaCatalog#GpuStagedDeltaTableV2 =>
       case _ => meta.willNotWorkOnGpu(s"${cpuExec.table} table class not supported on GPU")
-    }
-  }
-
-  override def tagForGpu(cpuExec: OverwriteByExpressionExecV1,
-      meta: OverwriteByExpressionExecV1Meta): Unit = {
-    super.tagForGpu(cpuExec, meta)
-
-    if (cpuExec.table.properties().containsKey(PROP_CLUSTERING_COLUMNS)) {
-      meta.willNotWorkOnGpu("Delta Lake liquid clustering not supported on gpu yet.")
     }
   }
 

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
 import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, OptimizeTableCommand, UpdateCommand}
 import org.apache.spark.sql.delta.rapids.DeltaRuntimeShim
 import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils.PROP_CLUSTERING_COLUMNS
-import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterByTransform
 import org.apache.spark.sql.delta.sources.DeltaDataSource
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
@@ -54,24 +53,6 @@ object Delta33xProvider extends DeltaIOProvider {
 
   override def isSupportedWrite(write: Class[_ <: SupportsWrite]): Boolean = {
     write == classOf[DeltaTableV2] || write == classOf[GpuDeltaCatalog#GpuStagedDeltaTableV2]
-  }
-
-  override def tagForGpu(cpuExec: AtomicCreateTableAsSelectExec,
-      meta: AtomicCreateTableAsSelectExecMeta): Unit = {
-    super.tagForGpu(cpuExec, meta)
-
-    if (cpuExec.partitioning.exists(_.isInstanceOf[ClusterByTransform])) {
-      meta.willNotWorkOnGpu("Delta Lake liquid clustering not supported on gpu yet.")
-    }
-  }
-
-  override def tagForGpu(cpuExec: AtomicReplaceTableAsSelectExec,
-      meta: AtomicReplaceTableAsSelectExecMeta): Unit = {
-    super.tagForGpu(cpuExec, meta)
-
-    if (cpuExec.partitioning.exists(_.isInstanceOf[ClusterByTransform])) {
-      meta.willNotWorkOnGpu("Delta Lake liquid clustering not supported on gpu yet.")
-    }
   }
 
   override def tagForGpu(

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids.delta.delta33x
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.delta.{DeltaIOProvider, GpuDeltaDataSource, RapidsDeltaUtils}
 import org.apache.hadoop.fs.Path
-import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.SupportsWrite
@@ -81,10 +80,6 @@ object Delta33xProvider extends DeltaIOProvider {
     if (!meta.conf.isDeltaWriteEnabled) {
       meta.willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
         s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
-    }
-
-    if (cpuExec.table.properties().containsKey(PROP_CLUSTERING_COLUMNS)) {
-      meta.willNotWorkOnGpu("Delta Lake liquid clustering not supported on gpu yet.")
     }
 
     cpuExec.table match {
@@ -210,11 +205,6 @@ class DeltaCreatableRelationProviderMeta(
       val deltaLog = DeltaLog.forTable(SparkSession.active, new Path(path.get), saveCmd.options)
       RapidsDeltaUtils.tagForDeltaWrite(this, saveCmd.query.schema, Some(deltaLog),
         saveCmd.options, SparkSession.active)
-
-      val table = source.getTable(saveCmd.schema, Array.empty, saveCmd.options.asJava)
-      if (table.properties().containsKey(PROP_CLUSTERING_COLUMNS)) {
-        willNotWorkOnGpu("Delta Lake liquid clustering not supported on gpu yet.")
-      }
     } else {
       willNotWorkOnGpu("no path specified for Delta Lake table")
     }

--- a/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
@@ -185,15 +185,14 @@ def test_delta_append_sql_liquid_clustering(spark_tmp_path, spark_tmp_table_fact
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
-               "OverwriteByExpressionExecV1")
+@allow_non_gpu(*delta_meta_allow, "CreateTableExec")
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks133_or_later(),
                     reason="Delta Lake liquid clustering is only supported on Databricks 13.3+")
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
-def test_delta_insert_overwrite_static_sql_liquid_clustering_fallback(spark_tmp_path,
+def test_delta_insert_overwrite_static_sql_liquid_clustering(spark_tmp_path,
                                                                spark_tmp_table_factory):
     def write_func(spark, path):
         table_name = spark_tmp_table_factory.get()
@@ -210,22 +209,22 @@ def test_delta_insert_overwrite_static_sql_liquid_clustering_fallback(spark_tmp_
     conf = copy_and_update(delta_writes_enabled_conf,
                            {"spark.sql.sources.partitionOverwriteMode": "STATIC"})
 
-    assert_gpu_fallback_write(
+    assert_gpu_and_cpu_writes_are_equal_collect(
         write_func,
         lambda spark, path: spark.read.format("delta").load(path),
         data_path,
-        "OverwriteByExpressionExecV1",
         conf=conf)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec")
+@allow_non_gpu(*delta_meta_allow, "CreateTableExec")
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks133_or_later(),
                     reason="Delta Lake liquid clustering is only supported on Databricks 13.3+")
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
-def test_delta_insert_overwrite_dynamic_sql_liquid_clustering_fallback(spark_tmp_path,
+def test_delta_insert_overwrite_dynamic_sql_liquid_clustering(spark_tmp_path,
                                                                       spark_tmp_table_factory):
     """
     Test to ensure that creating a Delta table with liquid clustering (CLUSTER BY)
@@ -246,23 +245,22 @@ def test_delta_insert_overwrite_dynamic_sql_liquid_clustering_fallback(spark_tmp
     conf = copy_and_update(delta_writes_enabled_conf,
                            {"spark.sql.sources.partitionOverwriteMode": "DYNAMIC"})
 
-    assert_gpu_fallback_write(
+    assert_gpu_and_cpu_writes_are_equal_collect(
         write_func,
         lambda spark, path: spark.read.format("delta").load(path),
         data_path,
-        "ExecutedCommandExec",
         conf=conf)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
-               "OverwriteByExpressionExecV1")
+@allow_non_gpu(*delta_meta_allow, "CreateTableExec")
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks133_or_later(),
                     reason="Delta Lake liquid clustering is only supported on Databricks 13.3+")
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
-def test_delta_insert_overwrite_replace_where_sql_liquid_clustering_fallback(spark_tmp_path,
+def test_delta_insert_overwrite_replace_where_sql_liquid_clustering(spark_tmp_path,
                                                                              spark_tmp_table_factory):
 
     def write_func(spark, path):
@@ -278,12 +276,12 @@ def test_delta_insert_overwrite_replace_where_sql_liquid_clustering_fallback(spa
 
     data_path = spark_tmp_path + "/DELTA_LIQUID_CLUSTER"
 
-    assert_gpu_fallback_write(
+    assert_gpu_and_cpu_writes_are_equal_collect(
         write_func,
         lambda spark, path: spark.read.format("delta").load(path),
         data_path,
-        "OverwriteByExpressionExecV1",
         conf=delta_writes_enabled_conf)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
 def do_test_delta_dml_sql_liquid_clustering_fallback(spark_tmp_path,
@@ -426,7 +424,7 @@ def test_delta_append_df_liquid_clustering(spark_tmp_path, spark_tmp_table_facto
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec")
+@allow_non_gpu(*delta_meta_allow, "CreateTableExec")
 @delta_lake
 @ignore_order
 @pytest.mark.parametrize("overwrite_mode", ["STATIC", "DYNAMIC"],
@@ -435,7 +433,7 @@ def test_delta_append_df_liquid_clustering(spark_tmp_path, spark_tmp_table_facto
                     reason="Delta Lake liquid clustering is only supported on Databricks 13.3+")
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
-def test_delta_insert_overwrite_df_liquid_clustering_fallback(spark_tmp_path,
+def test_delta_insert_overwrite_df_liquid_clustering(spark_tmp_path,
                                                               spark_tmp_table_factory,
                                                               overwrite_mode):
     def write_func(spark, path):
@@ -446,22 +444,22 @@ def test_delta_insert_overwrite_df_liquid_clustering_fallback(spark_tmp_path,
 
     data_path = spark_tmp_path + "/DELTA_LIQUID_CLUSTER"
 
-    assert_gpu_fallback_write(
+    assert_gpu_and_cpu_writes_are_equal_collect(
         write_func,
         lambda spark, path: spark.read.format("delta").load(path),
         data_path,
-        "ExecutedCommandExec",
         conf=delta_writes_enabled_conf)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec")
+@allow_non_gpu(*delta_meta_allow, "CreateTableExec")
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks133_or_later(),
                     reason="Delta Lake liquid clustering is only supported on Databricks 13.3+")
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
-def test_delta_insert_overwrite_replace_where_df_liquid_clustering_fallback(
+def test_delta_insert_overwrite_replace_where_df_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory):
 
     def write_func(spark, path):
@@ -472,9 +470,9 @@ def test_delta_insert_overwrite_replace_where_df_liquid_clustering_fallback(
 
     data_path = spark_tmp_path + "/DELTA_LIQUID_CLUSTER"
 
-    assert_gpu_fallback_write(
+    assert_gpu_and_cpu_writes_are_equal_collect(
         write_func,
         lambda spark, path: spark.read.format("delta").load(path),
         data_path,
-        "ExecutedCommandExec",
         conf=delta_writes_enabled_conf)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))


### PR DESCRIPTION
Fixes #12553.

### Description

This PR adds support for the write for Delta clustered tables. Previously, Spark RAPIDS used to fall back to CPU when data is written to clustered tables. AFAIT, we already have the code implemented to properly write the clustered table as described in https://github.com/delta-io/delta/blob/master/PROTOCOL.md#clustered-table. This PR just removes the fallback route for writes for clustered tables and fixes tests accordingly.

#### Performance test results

I ran some performance test in my workstation that has 64 CPU cores and RTX A5500. I used the TPC-H dataset at sf=100.

##### Query

```sql
create table lineitem_clustered using delta cluster by (l_shipdate) as select * from lineitem;
```

##### Results

  | CPU | GPU
-- | -- | --
Run1 | 80994 | 25692
Run2 | 83983 | 24525
Run3 | 85071 | 25486
Avg | 83349.33333 | 25234.33333

Speedup:

```
Means = 83349.33333333333, 25234.333333333332
Time diff = 58115.0
Speedup = 3.30301309063049
T-Test (test statistic, p value, df) = 45.73193823447923, 1.3673815294797087e-06, 4.0
T-Test Confidence Interval = 54586.76320274746, 61643.23679725254
```

##### Configs

CPU:
```
export SPARK_CONF=("--master" "local[32]"
                   "--deploy-mode" "client"
                   "--conf" "spark.driver.memory=16g"
                   "--conf" "spark.executor.instances=1"
                   "--conf" "spark.executor.memory=32g"
                   "--conf" "spark.sql.shuffle.partitions=200"
                   "--conf" "spark.sql.files.maxPartitionBytes=512mb"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog")
```

GPU:
```
export SPARK_CONF=("--master" "local[16]"
                   "--conf" "spark.driver.maxResultSize=2GB"
                   "--conf" "spark.driver.memory=50G"
                   "--conf" "spark.executor.memory=16G"
                   "--conf" "spark.sql.files.maxPartitionBytes=2gb"
                   "--conf" "spark.sql.adaptive.enabled=true"
                   "--conf" "spark.plugins=com.nvidia.spark.SQLPlugin"
                   "--conf" "spark.rapids.memory.host.spillStorageSize=16G"
                   "--conf" "spark.rapids.memory.pinnedPool.size=8g"
                   "--conf" "spark.rapids.sql.concurrentGpuTasks=3"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                   "--conf" "spark.driver.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR:$NDS_LISTENER_JAR"
                   "--conf" "spark.executor.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR:$NDS_LISTENER_JAR")
```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
