### PR TITLE
insert coalesce after join because join can cause row reductions

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -1062,6 +1062,8 @@ trait GpuJoinExec extends ShimBinaryExecNode with GpuExec {
   def leftKeys: Seq[Expression]
   def rightKeys: Seq[Expression]
   def isSkewJoin: Boolean = false
+
+  override def coalesceAfter: Boolean = true
 }
 
 trait GpuHashJoin extends GpuJoinExec {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashSortOptimizeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashSortOptimizeSuite.scala
@@ -60,7 +60,9 @@ class HashSortOptimizeSuite extends SparkQueryCompareTestSuite with FunSuiteWith
     assert(gse.children.length == 1)
     assert(!gse.global)
     assert(gse.sortType == SortEachBatch)
-    val sortChild = gse.children.head
+    val coalesce = gse.children.head
+    assert(coalesce.isInstanceOf[GpuCoalesceBatches])
+    val sortChild = coalesce.children.head
     assertResult(joinNode) { sortChild }
   }
 


### PR DESCRIPTION
This issue relates to Item 1 of https://github.com/NVIDIA/spark-rapids/pull/13427#issuecomment-3292553617.

# Performance Evaluation

for NDS power test: https://gist.github.com/binmahone/f8f8e77dba0f0af99a576ad7ffb6a295, no regression and no improvement, seems the NDS workload is not sensitive to this optimization

for local contrived test case (https://gist.github.com/binmahone/6a9dbea608906db8d91c90a92dc3420f, same as in https://github.com/NVIDIA/spark-rapids/pull/13427#issue-3392279775) the improvement is same as https://github.com/NVIDIA/spark-rapids/pull/13427

<img width="1440" height="77" alt="image" src="https://github.com/user-attachments/assets/7c80517a-b473-4db0-b4da-bb8902706e8e" />


