### PR TITLE
log if maxMem is called twice in a task

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -207,7 +207,7 @@ class AvgLongAccumulator extends AccumulatorV2[jl.Long, jl.Double] {
   } else 0;
 }
 
-class GpuTaskMetrics extends Serializable {
+class GpuTaskMetrics extends Serializable with Logging {
   private val semaphoreHoldingTime = new NanoSecondAccumulator
   private val semWaitTimeNs = new NanoSecondAccumulator
   private val retryCount = new LongAccumulator
@@ -403,6 +403,9 @@ class GpuTaskMetrics extends Serializable {
       // once on task completion, whereas the actual logic tracking of the max value during memory
       // allocations lives in the JNI. Therefore, we can stick the convention here of calling the
       // add method instead of adding a dedicated max method to the accumulator.
+      if (maxDeviceMemoryBytes.value.value > 0) {
+        logError(s"updateMaxMemory called twice for task $taskAttemptId with maxMem $maxMem")
+      }
       maxDeviceMemoryBytes.add(maxMem)
     }
     if (maxHostBytesAllocated > 0) {


### PR DESCRIPTION
### Description
This change adds an error log line for if `GpuTaskMetrics.updateMaxMemory` gets called more than once for a given task. This will help to debug https://github.com/NVIDIA/spark-rapids/issues/13336

### Checklists
No behavioral change.


- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
