### PR TITLE
Remove legacy spacy pkg [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -52,7 +52,6 @@ RUN conda init && conda install -n base -c conda-forge mamba
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
         cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
-    mamba install -y spacy && python -m spacy download en_core_web_sm && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \
     mamba clean -ay

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -73,7 +73,6 @@ RUN conda init && conda install -n base -c conda-forge mamba
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
         cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
-    mamba install -y spacy && python -m spacy download en_core_web_sm && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \
     mamba clean -ay


### PR DESCRIPTION
fix #13455 

As typer upgrade (last Friday) caused wide `Secondary flag is not valid for non-boolean flag`, since we have no deps on spacy/typer any more. lets remove this legacy pkgs from our CI dockerfiles to avoid blocking nightly image build

This has been verified internally