### PR TITLE
Optimization for unit test: Reduce TimeZonePerfSuite test time

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZonePerfSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZonePerfSuite.scala
@@ -68,13 +68,19 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
    */
   override def beforeAll(): Unit = {
     super.beforeAll()
-    withCpuSparkSession(
-      spark => createDF(spark).write.mode("overwrite").parquet(path))
+    if (enablePerfTest) {
+      // create a parquet file for testing
+      withCpuSparkSession(
+        spark => createDF(spark).write.mode("overwrite").parquet(path))
+    }
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    FileUtils.deleteRecursively(new File(path))
+    if (enablePerfTest) {
+      // delete the parquet file
+      FileUtils.deleteRecursively(new File(path))
+    }
   }
 
   val year1980 = Instant.parse("1980-01-01T00:00:00Z").getEpochSecond * 1000L * 1000L


### PR DESCRIPTION

Fixes #13458

### Description
If the `TimeZonePerfSuite` is not enabled, skip generating the Parquet file.

- [x] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
