### PR TITLE
Add a missing allow-non-gpu tag for CreateTableExec for test_delta_rtas_sql_liquid_clustering

### DIFF
--- a/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
@@ -107,7 +107,7 @@ def setup_clustered_table_sql(spark, path, table_name, view_name):
         """)
 
 
-@allow_non_gpu(*delta_meta_allow)
+@allow_non_gpu(*delta_meta_allow, "CreateTableExec")
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks133_or_later(),


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13457.

### Description

The test in question has been failing in the CI after it was modified https://github.com/NVIDIA/spark-rapids/pull/13417. The reason is the missing allow-non-gpu tag for `CreateTableExec`. I manually confirmed the fix against Spark 3.5.5 and Delta 3.3.0 as [the premerge CI doesn't run delta tests](https://github.com/NVIDIA/spark-rapids/issues/13457#issuecomment-3320373928) per @razajafri.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
