### PR TITLE
avoid using Noop as default excludeMetric

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -600,7 +600,7 @@ abstract class AbstractGpuCoalesceIterator(
    * @return The coalesced batch
    */
   override def next(): ColumnarBatch = withResource(
-    new MetricRange(Seq(opTime), excludeMetric = streamTime)) { _ =>
+    new MetricRange(Seq(opTime), excludeMetric = Seq(streamTime))) { _ =>
     if (coalesceBatchIterator.hasNext) {
       val batch = coalesceBatchIterator.next()
       if (wasLastBatch) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
@@ -32,41 +32,41 @@ object NvtxWithMetrics {
  *  by the amount of time spent in the range
  */
 class NvtxWithMetrics(name: String, color: NvtxColor, val metrics: Seq[GpuMetric],
-    excludeMetric: GpuMetric = NoopMetric)
+    excludeMetric: Seq[GpuMetric] = Seq.empty)
   extends NvtxRange(name, color) {
 
   // add a convenient constructor
   def this(name: String, color: NvtxColor, metrics: GpuMetric*) =
-    this(name, color, metrics.toSeq, NoopMetric)
+    this(name, color, metrics.toSeq)
 
-  val needTracks = metrics.map(_.tryActivateTimer(Seq(excludeMetric)))
+  val needTracks = metrics.map(_.tryActivateTimer(excludeMetric))
   private val start = System.nanoTime()
 
   override def close(): Unit = {
     val time = System.nanoTime() - start
     metrics.toSeq.zip(needTracks).foreach { pair =>
       if (pair._2) {
-        pair._1.deactivateTimer(time, Seq(excludeMetric))
+        pair._1.deactivateTimer(time, excludeMetric)
       }
     }
     super.close()
   }
 }
 
-class MetricRange(val metrics: Seq[GpuMetric], val excludeMetric: GpuMetric = NoopMetric)
+class MetricRange(val metrics: Seq[GpuMetric], val excludeMetric: Seq[GpuMetric] = Seq.empty)
   extends AutoCloseable {
 
   // add a convenient constructor
-  def this(metrics: GpuMetric*) = this(metrics.toSeq, NoopMetric)
+  def this(metrics: GpuMetric*) = this(metrics.toSeq)
 
-  val needTracks = metrics.map(_.tryActivateTimer(Seq(excludeMetric)))
+  val needTracks = metrics.map(_.tryActivateTimer(excludeMetric))
   private val start = System.nanoTime()
 
   override def close(): Unit = {
     val time = System.nanoTime() - start
     metrics.toSeq.zip(needTracks).foreach { pair =>
       if (pair._2) {
-        pair._1.deactivateTimer(time, Seq(excludeMetric))
+        pair._1.deactivateTimer(time, excludeMetric)
       }
     }
   }


### PR DESCRIPTION
This is a follow up fix for https://github.com/NVIDIA/spark-rapids/pull/13429
The existing code mistakenly use Noop as default exclude metrics ( in new op time framework), which can cause issues like:

```
25/09/24 16:29:17 ERROR Executor: Exception in task 433.0 in stage 9.0 (TID 5556)
java.lang.IllegalStateException: the excludeMetrics size 1 does not match excludeMetricsWhenActivated size 0
	at com.nvidia.spark.rapids.GpuMetric.deactivateTimer(GpuMetrics.scala:335)
	at com.nvidia.spark.rapids.NvtxWithMetrics.$anonfun$close$1(NvtxWithMetrics.scala:49)
	at com.nvidia.spark.rapids.NvtxWithMetrics.$anonfun$close$1$adapted(NvtxWithMetrics.scala:47)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at com.nvidia.spark.rapids.NvtxWithMetrics.close(NvtxWithMetrics.scala:47)
	at com.nvidia.spark.rapids.RapidsPluginImplicits$AutoCloseableColumn.safeClose(implicits.scala:60)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:32)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalOnCpuAndClose(GpuPartitioning.scala:135)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalOnCpuAndClose$(GpuPartitioning.scala:123)
	at com.nvidia.spark.rapids.GpuSinglePartitioning$.sliceInternalOnCpuAndClose(GpuSinglePartitioning.scala:28)
	at com.nvidia.spark.rapids.GpuPartitioning.$anonfun$sliceInternalGpuOrCpuAndClose$1(GpuPartitioning.scala:278)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:30)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalGpuOrCpuAndClose(GpuPartitioning.scala:273)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalGpuOrCpuAndClose$(GpuPartitioning.scala:260)
	at com.nvidia.spark.rapids.GpuSinglePartitioning$.sliceInternalGpuOrCpuAndClose(GpuSinglePartitioning.scala:28)
	at com.nvidia.spark.rapids.GpuSinglePartitioning$.columnarEvalAny(GpuSinglePartitioning.scala:50)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$.$anonfun$prepareBatchShuffleDependency$4(GpuShuffleExchangeExecBase.scala:395)
	at com.nvidia.spark.rapids.GpuMetric.ns(GpuMetrics.scala:358)
	at com.nvidia.spark.rapids.GpuMetric.ns(GpuMetrics.scala:351)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$.$anonfun$prepareBatchShuffleDependency$3(GpuShuffleExchangeExecBase.scala:395)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$$anon$1.partNextBatch(GpuShuffleExchangeExecBase.scala:420)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$$anon$1.hasNext(GpuShuffleExchangeExecBase.scala:434)
	at com.nvidia.spark.rapids.GpuOpTimeTrackingRDD$$anon$1.$anonfun$hasNext$1(GpuExec.scala:68)
	at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
	at com.nvidia.spark.rapids.GpuMetric.ns(GpuMetrics.scala:358)
	at com.nvidia.spark.rapids.GpuOpTimeTrackingRDD$$anon$1.hasNext(GpuExec.scala:68)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:140)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1462)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
25/09/24 16:29:17 WARN TaskSetManager: Lost task 433.0 in stage 9.0 (TID 5556) (10.19.57.134 executor driver): java.lang.IllegalStateException: the excludeMetrics size 1 does not match excludeMetricsWhenActivated size 0
	at com.nvidia.spark.rapids.GpuMetric.deactivateTimer(GpuMetrics.scala:335)
	at com.nvidia.spark.rapids.NvtxWithMetrics.$anonfun$close$1(NvtxWithMetrics.scala:49)
	at com.nvidia.spark.rapids.NvtxWithMetrics.$anonfun$close$1$adapted(NvtxWithMetrics.scala:47)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at com.nvidia.spark.rapids.NvtxWithMetrics.close(NvtxWithMetrics.scala:47)
	at com.nvidia.spark.rapids.RapidsPluginImplicits$AutoCloseableColumn.safeClose(implicits.scala:60)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:32)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalOnCpuAndClose(GpuPartitioning.scala:135)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalOnCpuAndClose$(GpuPartitioning.scala:123)
	at com.nvidia.spark.rapids.GpuSinglePartitioning$.sliceInternalOnCpuAndClose(GpuSinglePartitioning.scala:28)
	at com.nvidia.spark.rapids.GpuPartitioning.$anonfun$sliceInternalGpuOrCpuAndClose$1(GpuPartitioning.scala:278)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:30)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalGpuOrCpuAndClose(GpuPartitioning.scala:273)
	at com.nvidia.spark.rapids.GpuPartitioning.sliceInternalGpuOrCpuAndClose$(GpuPartitioning.scala:260)
	at com.nvidia.spark.rapids.GpuSinglePartitioning$.sliceInternalGpuOrCpuAndClose(GpuSinglePartitioning.scala:28)
	at com.nvidia.spark.rapids.GpuSinglePartitioning$.columnarEvalAny(GpuSinglePartitioning.scala:50)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$.$anonfun$prepareBatchShuffleDependency$4(GpuShuffleExchangeExecBase.scala:395)
	at com.nvidia.spark.rapids.GpuMetric.ns(GpuMetrics.scala:358)
	at com.nvidia.spark.rapids.GpuMetric.ns(GpuMetrics.scala:351)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$.$anonfun$prepareBatchShuffleDependency$3(GpuShuffleExchangeExecBase.scala:395)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$$anon$1.partNextBatch(GpuShuffleExchangeExecBase.scala:420)
	at org.apache.spark.sql.rapids.execution.GpuShuffleExchangeExecBase$$anon$1.hasNext(GpuShuffleExchangeExecBase.scala:434)
	at com.nvidia.spark.rapids.GpuOpTimeTrackingRDD$$anon$1.$anonfun$hasNext$1(GpuExec.scala:68)
	at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
	at com.nvidia.spark.rapids.GpuMetric.ns(GpuMetrics.scala:358)
	at com.nvidia.spark.rapids.GpuOpTimeTrackingRDD$$anon$1.hasNext(GpuExec.scala:68)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:140)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1462)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

steps to reproduce:

```
import pyspark.sql.functions as f

spark.conf.set("spark.rapids.sql.enabled", True)
spark.conf.set("spark.sql.adaptive.enabled", False)
spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)

# Create two small DataFrames
# First DataFrame
df1 = spark.range(1, 100000, 2).selectExpr("id as id1", "id * 10 as value1")
# Second DataFrame  
df2 = spark.range(1000, 30000, 3).selectExpr("id as id2", "id * 100 as value2")

# Force a Cartesian product by joining without a condition
# This will trigger CartesianProductExec
df = df1.crossJoin(df2)
result = df.agg(f.max(f.col('value1')), f.max(f.col('value2')))
result.explain(True)
result.collect()
```