### PR TITLE
Fix a Memory leak introduced as part of adding Deletion Vector support 

### DIFF
--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
@@ -449,8 +449,10 @@ case class GpuDelta33xParquetFileFormat(
           markedRowIndicesCol =>
             rowIndexCol.getBase.contains(markedRowIndicesCol.getBase)
         }
-      withResource(containsMarkedRows.not()) { indicesToDelete =>
-        GpuColumnVector.from(indicesToDelete.castTo(DType.INT8), ByteType)
+      withResource(containsMarkedRows) { containsMarkedRows =>
+        withResource(containsMarkedRows.not()) { indicesToDelete =>
+          GpuColumnVector.from(indicesToDelete.castTo(DType.INT8), ByteType)
+        }
       }
     }
   }
@@ -463,7 +465,9 @@ case class GpuDelta33xParquetFileFormat(
           markedRowIndicesCol =>
             rowIndexCol.getBase.contains(markedRowIndicesCol.getBase)
         }
-      GpuColumnVector.from(containsMarkedRows.castTo(DType.INT8), ByteType)
+      withResource(containsMarkedRows) { containsMarkedRows =>
+        GpuColumnVector.from(containsMarkedRows.castTo(DType.INT8), ByteType)
+      }
     }
   }
 

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
@@ -490,13 +490,17 @@ case class GpuDelta33xParquetFileFormat(
 
   private object RapidsDropAllRowsFilter extends RapidsRowIndexFilter {
     def materializeIntoVector(rowIndexCol: GpuColumnVector): GpuColumnVector = {
-      GpuColumnVector.from(Scalar.fromByte(1.toByte), rowIndexCol.getRowCount.toInt, ByteType)
+      withResource(Scalar.fromByte(1.toByte)) { one =>
+        GpuColumnVector.from(one, rowIndexCol.getRowCount.toInt, ByteType)
+      }
     }
   }
 
   private object RapidsKeepAllRowsFilter extends RapidsRowIndexFilter {
     def materializeIntoVector(rowIndexCol: GpuColumnVector): GpuColumnVector = {
-      GpuColumnVector.from(Scalar.fromByte(0.toByte), rowIndexCol.getRowCount.toInt, ByteType)
+      withResource(Scalar.fromByte(0.toByte)) { zero =>
+        GpuColumnVector.from(zero, rowIndexCol.getRowCount.toInt, ByteType)
+      }
     }
   }
 


### PR DESCRIPTION

### Description

As part of https://github.com/NVIDIA/spark-rapids/pull/13439 we added support for Deletion Vector reads but we introduced a memory leak. 

This PR fixes the memory leak 


### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
