### PR TITLE
Update archive.apache usage in dockerfile [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -53,7 +53,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     openjdk-8-jdk openjdk-11-jdk openjdk-17-jdk tzdata git wget
 
 # Install maven 3.8+ to be compatible with JDK17 on Ubuntu
-# maintain also specific version in the internal artifactory to accelarate the build
+# maintain also specific version in the internal artifactory to accelerate the build
 ARG MAVEN_VERSION=3.8.4
 ARG MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3
 


### PR DESCRIPTION
archive.apache file server is quite unstable recently and could slow down/fail our image building.

This change is trying to add capability to use different source to accelerate the process. This has been verified internally