### PR TITLE
Add Spark Connect smoke test in nightly integration tests

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -376,6 +376,14 @@ if [[ $TEST_MODE == "DEFAULT" ]]; then
   EXPLAIN_ONLY_CPU_SMOKE_TEST=1 \
     ./run_pyspark_from_build.sh
 
+  # Spark Connect smoke test (available in Spark 3.5.6+)
+  MAJOR=$(echo "$SPARK_VER" | cut -d. -f1)
+  MINOR=$(echo "$SPARK_VER" | cut -d. -f2)
+  if (( MAJOR > 3 || (MAJOR == 3 && MINOR >= 6) )); then
+    SPARK_CONNECT_SMOKE_TEST=1 \
+      ./run_pyspark_from_build.sh
+  fi
+
   # As '--packages' only works on the default cuda12 jar, it does not support classifiers
   # refer to issue : https://issues.apache.org/jira/browse/SPARK-20075
   # "$CLASSIFIER" == ''" is usally for the case running by developers,


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/9375.

### Description
A new Spark Connect smoke test is added in this PR to validate RAPIDS plugin functionality through Spark Connect. This test runs with Spark versions 3.5.6 and above.

**Smoke Test Implementation:**
- **Server startup**: Uses `start-connect-server.sh` with:
  - `--packages org.apache.spark:spark-connect_${SCALA_VERSION}:${VERSION_STRING}` for Connect runtime
  - `--jars` for RAPIDS plugin jars
  - `--master local-cluster[1,2,1024]` for pseudo-distributed testing
  - `--conf spark.plugins=com.nvidia.spark.SQLPlugin` to enable RAPIDS

For client validation -  Uses standalone Python client to avoid JVM dependencies. 

**Test Validation:**
- **Functional correctness**: Verifies `spark.range(100).selectExpr('sum(id)')` returns 4950
- **GPU acceleration**: Checks physical plan contains `GpuRange` operator

**CI Integration (`jenkins/spark-tests.sh`):**
- Added to DEFAULT test mode for Spark-3.5.6+

**Usage:**
```bash
# Manual execution
SPARK_CONNECT_SMOKE_TEST=1 ./integration_tests/run_pyspark_from_build.sh
```

### Checklists

<!-- 
Check the items below by putting "x" in the brackets for what is done.
Not all of these items may be relevant to every PR, so please check only those that apply.
-->

- [ ] This PR has added documentation for new or modified features or behaviors.
- [X] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
