### PR TITLE
Fix wrong usage of GpuWriteJobStatsTracker in iceberg write

### DIFF
--- a/iceberg/src/main/scala/org/apache/iceberg/spark/source/GpuSparkFileWriterFactory.scala
+++ b/iceberg/src/main/scala/org/apache/iceberg/spark/source/GpuSparkFileWriterFactory.scala
@@ -26,7 +26,7 @@ import org.apache.iceberg.encryption.EncryptedOutputFile
 import org.apache.iceberg.io.{DataWriter, FileWriterFactory}
 
 import org.apache.spark.sql.execution.datasources.GpuWriteFiles
-import org.apache.spark.sql.rapids.GpuWriteJobStatsTracker
+import org.apache.spark.sql.rapids.ColumnarWriteTaskStatsTracker
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -36,6 +36,7 @@ class GpuSparkFileWriterFactory(val table: Table,
   val dataSortOrder: SortOrder,
   val deleteFileFormat: FileFormat,
   val columnarOutputWriterFactory: ColumnarOutputWriterFactory,
+  val taskStatsTracker: ColumnarWriteTaskStatsTracker,
   val hadoopConf: SerializableConfiguration,
 ) extends FileWriterFactory[SpillableColumnarBatch] {
   require(dataFileFormat == FileFormat.PARQUET,
@@ -43,9 +44,6 @@ class GpuSparkFileWriterFactory(val table: Table,
   require(deleteFileFormat == FileFormat.PARQUET,
     s"GpuSparkFileWriterFactory only supports PARQUET file format, but got $deleteFileFormat")
 
-  private val statsTracker = new GpuWriteJobStatsTracker(hadoopConf,
-    GpuWriteJobStatsTracker.basicMetrics,
-    GpuWriteJobStatsTracker.taskMetrics)
 
   private lazy val taskAttemptContext: TaskAttemptContext = GpuWriteFiles
     .calcHadoopTaskAttemptContext(hadoopConf.value)
@@ -79,7 +77,7 @@ class GpuSparkFileWriterFactory(val table: Table,
       path = path,
       dataSchema = dataSparkType,
       context = taskAttemptContext,
-      statsTrackers = Seq(statsTracker.newTaskInstance()),
+      statsTrackers = Seq(taskStatsTracker),
       debugOutputPath = None
     ).asInstanceOf[GpuParquetWriter]
 


### PR DESCRIPTION

Fixes #13505.

### Description

The constructor of `GpuWriteJobStatsTracker` requires to be executed in spark driver side, but currently we construct it in task execution, which leads to an error of trying to fetch `SparkContext`.

This fix is covered by existing tests.

### Checklists


- [x] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
