### PR TITLE
Fix read option name for change data feed for Delta [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_low_shuffle_merge_test.py
+++ b/integration_tests/src/main/python/delta_lake_low_shuffle_merge_test.py
@@ -93,7 +93,7 @@ def test_delta_merge_not_match_insert_only(spark_tmp_path, spark_tmp_table_facto
                                           (range(5), range(5)),  # full delete of target
                                           (range(10), range(20, 30))  # no-op delete
                                           ], ids=idfn)
-@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("use_cdf", [pytest.param(True, marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/13552")), False], ids=idfn)
 @pytest.mark.parametrize("partition_columns", [None, ["a"], ["b"], ["a", "b"]], ids=idfn)
 @pytest.mark.parametrize("num_slices", num_slices_to_test, ids=idfn)
 def test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, table_ranges,
@@ -111,7 +111,7 @@ def test_delta_merge_match_delete_only(spark_tmp_path, spark_tmp_table_factory, 
                          (not is_databricks_runtime() and spark_version().startswith("3.4"))),
                     reason="Delta Lake Low Shuffle Merge only supports Databricks 13.3 or OSS "
                            "delta 2.4")
-@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("use_cdf", [pytest.param(True, marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/13552")), False], ids=idfn)
 @pytest.mark.parametrize("num_slices", num_slices_to_test, ids=idfn)
 def test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, use_cdf, num_slices):
     do_test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, use_cdf, False,
@@ -126,7 +126,7 @@ def test_delta_merge_standard_upsert(spark_tmp_path, spark_tmp_table_factory, us
                          (not is_databricks_runtime() and spark_version().startswith("3.4"))),
                     reason="Delta Lake Low Shuffle Merge only supports Databricks 13.3 or OSS "
                            "delta 2.4")
-@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("use_cdf", [pytest.param(True, marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/13552")), False], ids=idfn)
 @pytest.mark.parametrize("merge_sql", [
     "MERGE INTO {dest_table} d USING {src_table} s ON d.a == s.a" \
     " WHEN MATCHED AND s.b > 'q' THEN UPDATE SET d.a = s.a / 2, d.b = s.b" \
@@ -173,7 +173,7 @@ def test_delta_merge_upsert_with_unmatchable_match_condition(spark_tmp_path, spa
                          (not is_databricks_runtime() and spark_version().startswith("3.4"))),
                     reason="Delta Lake Low Shuffle Merge only supports Databricks 13.3 or OSS "
                            "delta 2.4")
-@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("use_cdf", [pytest.param(True, marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/13552")), False], ids=idfn)
 def test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_factory, use_cdf):
     do_test_delta_merge_update_with_aggregation(spark_tmp_path, spark_tmp_table_factory, use_cdf, False,
                                                 delta_merge_enabled_conf)

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -488,7 +488,7 @@ def test_delta_write_round_trip_cdf_write_opt(spark_tmp_path, enable_deletion_ve
             .option("delta.enableChangeDataFeed", "true")
             .save(path),
         lambda spark, path: spark.read.format("delta")
-            .option("readChangeDataFeed", "true")
+            .option("readChangeFeed", "true")
             .option("startingVersion", 0)
             .load(path)
             .drop("_commit_timestamp"),
@@ -500,7 +500,7 @@ def test_delta_write_round_trip_cdf_write_opt(spark_tmp_path, enable_deletion_ve
             .mode("overwrite")
             .save(path),
         lambda spark, path: spark.read.format("delta")
-            .option("readChangeDataFeed", "true")
+            .option("readChangeFeed", "true")
             .option("startingVersion", 0)
             .load(path)
             .drop("_commit_timestamp"),
@@ -529,7 +529,7 @@ def test_delta_write_round_trip_cdf_table_prop(spark_tmp_path):
             .option("delta.enableChangeDataFeed", "true")
             .save(path),
         lambda spark, path: spark.read.format("delta")
-            .option("readChangeDataFeed", "true")
+            .option("readChangeFeed", "true")
             .option("startingVersion", 0)
             .load(path)
             .drop("_commit_timestamp"),
@@ -540,7 +540,7 @@ def test_delta_write_round_trip_cdf_table_prop(spark_tmp_path):
             .mode("overwrite")
             .save(path),
         lambda spark, path: spark.read.format("delta")
-            .option("readChangeDataFeed", "true")
+            .option("readChangeFeed", "true")
             .option("startingVersion", 0)
             .load(path)
             .drop("_commit_timestamp"),

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -487,11 +487,7 @@ def test_delta_write_round_trip_cdf_write_opt(spark_tmp_path, enable_deletion_ve
             gen_df(spark, gen_list).coalesce(1).write.format("delta"), enable_deletion_vectors)
             .option("delta.enableChangeDataFeed", "true")
             .save(path),
-        lambda spark, path: spark.read.format("delta")
-            .option("readChangeFeed", "true")
-            .option("startingVersion", 0)
-            .load(path)
-            .drop("_commit_timestamp"),
+        read_delta_path_with_cdf,
         data_path,
         conf=confs)
     assert_gpu_and_cpu_writes_are_equal_collect(
@@ -499,11 +495,7 @@ def test_delta_write_round_trip_cdf_write_opt(spark_tmp_path, enable_deletion_ve
             gen_df(spark, gen_list).coalesce(1).write.format("delta"), enable_deletion_vectors)
             .mode("overwrite")
             .save(path),
-        lambda spark, path: spark.read.format("delta")
-            .option("readChangeFeed", "true")
-            .option("startingVersion", 0)
-            .load(path)
-            .drop("_commit_timestamp"),
+        read_delta_path_with_cdf,
         data_path,
         conf=confs)
 
@@ -528,22 +520,14 @@ def test_delta_write_round_trip_cdf_table_prop(spark_tmp_path):
             .mode("append")
             .option("delta.enableChangeDataFeed", "true")
             .save(path),
-        lambda spark, path: spark.read.format("delta")
-            .option("readChangeFeed", "true")
-            .option("startingVersion", 0)
-            .load(path)
-            .drop("_commit_timestamp"),
+        read_delta_path_with_cdf,
         data_path,
         conf=confs)
     assert_gpu_and_cpu_writes_are_equal_collect(
         lambda spark, path: gen_df(spark, gen_list).coalesce(1).write.format("delta")
             .mode("overwrite")
             .save(path),
-        lambda spark, path: spark.read.format("delta")
-            .option("readChangeFeed", "true")
-            .option("startingVersion", 0)
-            .load(path)
-            .drop("_commit_timestamp"),
+        read_delta_path_with_cdf,
         data_path,
         conf=confs)
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))


### PR DESCRIPTION
Fixes #12796

### Description

We are currently using "readChangeDataFeed" as a read option name to read a table with change data feed in our tests. However, this option name is invalid. We should use "readChangeFeed" instead. This PR fixes the option name and adds asserts to validate the schema of the data read.

I manually ran `delta_lake_delete_test.py`, `delta_lake_update_test.py`, and `delta_lake_merge_test.py`, which are impacted by this change. `delta_lake_low_shuffle_merge_test.py` is also impacted as well, but it does not run with Delta 3.3. I used Spark 3.5.5 and Delta 3.3.0 for my testing.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
