### PR TITLE
Avoid throwing ClassNotFoundExceptions when checking isSupportedFormat with Delta Lake versions < 2.0.1

### DIFF
--- a/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/DeltaIOProvider.scala
+++ b/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/DeltaIOProvider.scala
@@ -47,7 +47,17 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 abstract class DeltaIOProvider extends DeltaProviderImplBase {
 
   override def isSupportedFormat(format: Class[_ <: FileFormat]): Boolean = {
-    format == classOf[DeltaParquetFileFormat]
+    // We need to check if the DeltaParquetFileFormat class is loadable
+    // because we can run into a case where a customer runs with an
+    // untested version of Delta Lake. A similar case happened in our
+    // benchmarks, for details check
+    // https://github.com/NVIDIA/spark-rapids/issues/13519
+    val deltaFormat = "org.apache.spark.sql.delta.DeltaParquetFileFormat"
+    if (Try(ShimReflectionUtils.loadClass(deltaFormat)).isSuccess) {
+      format == classOf[DeltaParquetFileFormat]
+    } else {
+      return false
+    }
   }
 
   override def isSupportedWrite(write: Class[_ <: SupportsWrite]): Boolean = {


### PR DESCRIPTION
Fixes #13519 

### Description

We recently encountered an issue when running the plugin with Delta Lake < 1.1.0, which resulted in a crash. Although we don't officially support Delta Lake versions < 2.0.1, this regression is unacceptable; this PR addresses it and reverts to the old behavior.

The PR was tested by running the NDS benchmark against Delta Lake 1.1.0 and 1.2.0 with Spark 3.2.0

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
