### PR TITLE
Fallback gracefully if libprofiler cannot be loaded

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/profiler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/profiler.scala
@@ -414,7 +414,7 @@ object ProfilerOnDriver extends Logging {
       if (profilerErrored) {
         logDebug(s"Profiling: Error starting profiler from $executorId: $msg")
       } else {
-        logError(s"Profiling: Error starting profiler from $executorId: $msg. Supressing others.")
+        logError(s"Profiling: Error starting profiler from $executorId: $msg. Suppressing others.")
       }
       profilerErrored = true
       null


### PR DESCRIPTION
Fixes #13562.

### Description

This is a must have bug fix for 25.10 cuda13 because spark-rapids-jni cuda13 does not contain libprofiler.so. This is due to https://github.com/NVIDIA/spark-rapids-jni/issues/3627 which is still unresolved. In the future, we will either build libprofiler.so dynamically linking against libcupti.so or some other approach.

With this patch, the output in cuda13 says we failed to load, and then you can continue using the spark session. It is a bit verbose, but way better than executors failing silently. I am happy to adjust this if reviewers feel it's too much info:

```
scala> 25/10/02 07:02:06 WARN ProfilerOnDriver: Profiling: Executor 0 initialized profiler, writing to /tmp/rapids-profile-app-20251002070203-0042-0.bin.zstd
25/10/02 07:02:06 ERROR ProfilerOnDriver: Profiling: Error starting profiler from 0: error launching profiler: java.lang.RuntimeException: Error loading profiler library. Supressing others.
25/10/02 07:02:06 WARN ProfilerOnDriver: Profiling: Executor 0 ended profiling, profile written to /tmp/rapids-profile-app-20251002070203-0042-0.bin.zstd
```

I've tested this manually by loading up a shell with cuda13. I didn't add automatic tests as I think it's harder to test.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
