### PR TITLE
Disable predicate pushdown filters in MULTITHREADED Delta Scan when reading Deletion Vectors

### DIFF
--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/GpuDelta33xParquetFileFormat.scala
@@ -232,7 +232,7 @@ case class GpuDelta33xParquetFileFormat(
       prepareSchema(fileScan.relation.dataSchema),
       prepareSchema(fileScan.requiredSchema),
       prepareSchema(fileScan.readPartitionSchema),
-      pushedFilters,
+      prepareFiltersForRead(pushedFilters).toArray,
       fileScan.rapidsConf,
       fileScan.allMetrics,
       useMetadataRowIndex = false,

--- a/integration_tests/src/main/python/delta_lake_delete_test.py
+++ b/integration_tests/src/main/python/delta_lake_delete_test.py
@@ -18,6 +18,9 @@ from asserts import assert_equal, assert_gpu_and_cpu_writes_are_equal_collect, a
 from data_gen import *
 from delta_lake_utils import *
 from marks import *
+import os
+import glob
+import pyarrow.parquet as pq
 from spark_session import is_before_spark_320, is_databricks_runtime, supports_delta_lake_deletion_vectors, \
     with_cpu_session, with_gpu_session, is_before_spark_353, is_spark_353_or_later
 
@@ -167,6 +170,21 @@ def test_delta_deletion_vector_read_fallback(spark_tmp_path, reader_type):
 
     assert_gpu_fallback_collect(read_parquet_sql(data_path), "FileSourceScanExec", conf={"spark.rapids.sql.format.parquet.reader.type": reader_type})
 
+'''
+This test is specifically designed to setup a parquet file with multiple row groups and we 
+select a value from the last row group so the first ones get dropped to cause a misalignment 
+between the deletion vectors and the parquet file when reading 
+
+Example: only the first two values (-3268, -3267) are deleted 
+    <-- Row group 1 -->|<-- Row group 2 -->|<-- Row group 3 -->
+   |  -3268, -3267,...|.... 0  ,   1,......|...  3266, 3267  |
+dv:|   true, true,....|...false, false,....|... false, false | 
+
+After dropping Row group 1 and 2, we have a misalignment and now it shows 3266 and 3267 as deleted
+    <-- Row group 3 -->
+   |...  3266, 3267   |
+dv:|   true, true,....|...false, false,....|... false, false | 
+'''
 @allow_non_gpu("SerializeFromObjectExec", "DeserializeToObjectExec",
                "FilterExec", "MapElementsExec", "ProjectExec")
 @delta_lake
@@ -174,34 +192,47 @@ def test_delta_deletion_vector_read_fallback(spark_tmp_path, reader_type):
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors() or is_before_spark_353(), \
                     reason="Deletion vectors new in Delta Lake 2.4 / Apache Spark 3.4")
 @pytest.mark.parametrize("reader_type", ["PERFILE", "COALESCING", "MULTITHREADED"])
-@pytest.mark.parametrize("condition", ["where a > 23455 "])
-def test_delta_deletion_vector_read_drop_row_group(spark_tmp_path, reader_type, condition):
+def test_delta_deletion_vector_read_drop_row_group(spark_tmp_path, reader_type):
     data_path = spark_tmp_path + "/DELTA_DATA"
     def setup_tables(spark):
         setup_delta_dest_table(spark, data_path,
-                               dest_table_func=lambda spark: two_col_df(spark, int_gen, IntegerGen(nullable=False, min_val=1, max_val=2, special_cases=[]), seed=12345).sort("a").repartition("b").coalesce(1),
-                               # dest_table_func=lambda spark: binary_op_df(spark, IntegerGen(min_val=-3268, max_val=3267, special_cases=[0,1,-1]), seed=12345).sort("a").repartition(1),
-                               use_cdf=False, enable_deletion_vectors=True)
+                               # create records -3268 .... 3267 in sorted order so we can have predictable row groups
+                               # coalesce the partitions to have a single file with multiple row groups
+                               dest_table_func=lambda spark: unary_op_df(spark, IntegerGen(nullable=False, min_val=-3268, max_val=3267, special_cases=[]), seed=12345).sort("a").coalesce(1),
+                               # limiting the block size to make sure we have more than one row group
+                               use_cdf=False, enable_deletion_vectors=True, options={"parquet.block.size": "4096"})
     def write_func(path):
-        delete_sql=f"DELETE FROM delta.`{path}` {condition}"
+        # choose -3000 to make sure the deleted indices are towards the top of the file
+        delete_sql=f"DELETE FROM delta.`{path}` where a < -3000"
         def delete_func(spark):
             count = spark.sql(delete_sql).collect()[0][0]
-            if condition != "where a = ''":
-                assert(count > 0)
-            else:
-                assert(count == 0)
+            assert(count > 0)
         return delete_func
 
-    def read_parquet_sql(data_path):
-        return lambda spark : spark.sql(f"select * from delta.`{data_path}` where b = 1")
+    def read_parquet_sql(data_path, last_rg_value):
+        # selecting a number from the last row group to make sure the first row groups are dropped
+        return lambda spark : spark.sql(f"select * from delta.`{data_path}` where a = {last_rg_value}")
 
     enable_conf = copy_and_update(delta_delete_enabled_conf,
                                   {"spark.databricks.delta.delete.deletionVectors.persistent": "true"})
 
     with_cpu_session(setup_tables, conf=enable_conf)
+
+    # Find all parquet files in the directory
+    files = glob.glob(os.path.join(data_path, "*.parquet"))
+    assert(len(files) == 1)
+    parquet_file = pq.ParquetFile(files[0])
+    # We should have more than one row group so we can drop the first ones
+    assert(parquet_file.num_row_groups > 1)
+
+    last_rg_index = parquet_file.num_row_groups - 1
+    rg_meta = parquet_file.metadata.row_group(last_rg_index)
+    stats = rg_meta.column(0).statistics
+    lrg_min_value = stats.min
+
     with_cpu_session(write_func(data_path), conf=enable_conf)
 
-    assert_gpu_and_cpu_are_equal_collect(read_parquet_sql(data_path), conf={"spark.rapids.sql.format.parquet.reader.type": reader_type,
+    assert_gpu_and_cpu_are_equal_collect(read_parquet_sql(data_path, lrg_min_value), conf={"spark.rapids.sql.format.parquet.reader.type": reader_type,
                                                                             # we need to set the useMetadataRowIndex = false as there are other
                                                                             # hidden metadata columns that we don't support on the GPU
                                                                             "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "false"})

--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -191,7 +191,7 @@ def read_delta_path_with_cdf(spark, path):
 def schema_to_ddl(spark, schema):
     return spark.sparkContext._jvm.org.apache.spark.sql.types.DataType.fromJson(schema.json()).toDDL()
 
-def setup_delta_dest_table(spark, path, dest_table_func, use_cdf, partition_columns=None, enable_deletion_vectors=False):
+def setup_delta_dest_table(spark, path, dest_table_func, use_cdf, partition_columns=None, enable_deletion_vectors=False, options=None):
     dest_df = dest_table_func(spark)
     # append to SQL-created table
     writer = dest_df.write.format("delta").mode("append")
@@ -207,7 +207,8 @@ def setup_delta_dest_table(spark, path, dest_table_func, use_cdf, partition_colu
         writer = writer.partitionBy(*partition_columns)
     properties = ', '.join(key + ' = ' + value for key, value in table_properties.items())
     sql_text += " TBLPROPERTIES ({})".format(properties)
-    sql_text += " OPTIONS (parquet.block.size=4096)"
+    options_str = ', '.join(key + ' = ' + value for key, value in options.items())
+    sql_text += f" OPTIONS ({options_str}) "
     spark.sql(sql_text)
     writer.save(path)
 

--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -207,6 +207,7 @@ def setup_delta_dest_table(spark, path, dest_table_func, use_cdf, partition_colu
         writer = writer.partitionBy(*partition_columns)
     properties = ', '.join(key + ' = ' + value for key, value in table_properties.items())
     sql_text += " TBLPROPERTIES ({})".format(properties)
+    sql_text += " OPTIONS (parquet.block.size=4096)"
     spark.sql(sql_text)
     writer.save(path)
 

--- a/integration_tests/src/main/python/delta_lake_utils.py
+++ b/integration_tests/src/main/python/delta_lake_utils.py
@@ -207,8 +207,9 @@ def setup_delta_dest_table(spark, path, dest_table_func, use_cdf, partition_colu
         writer = writer.partitionBy(*partition_columns)
     properties = ', '.join(key + ' = ' + value for key, value in table_properties.items())
     sql_text += " TBLPROPERTIES ({})".format(properties)
-    options_str = ', '.join(key + ' = ' + value for key, value in options.items())
-    sql_text += f" OPTIONS ({options_str}) "
+    if options:
+        options_str = ', '.join(key + ' = ' + value for key, value in options.items())
+        sql_text += f" OPTIONS ({options_str}) "
     spark.sql(sql_text)
     writer.save(path)
 


### PR DESCRIPTION
Fixes #13513 

### Description

- When we added support for reading Deletion Vectors on Delta Lake 3.3.0 we didn't disable the predicate pushdown which caused a misalignment while reading the Delta Table. This PR fixes the data corruption that would happen if the predicates were pushed down and row groups were dropped. 
- A new integration test has been added 

Example: Assume only the first two values (-3268, -3267) are deleted 
<table>
  <tr>
    <th colspan="1"></th>
    <th colspan="2">Row group 1</th>
    <th colspan="2">Row group 2</th>
    <th colspan="2">Row group 3</th>
  </tr>
  <tr>
    <td/>
    <td>-3268</td>
    <td>-3267</td>
    <td>0</td>
    <td>1</td>
    <td>3266</td>
    <td>3267</td>
  </tr>
  <tr> 
    <td>dv</td>
    <td>true</td>
    <td>true</td>
    <td>false</td>
    <td>false</td>
    <td>false</td>
    <td>false</td>     
</table>

After dropping Row group 1 and 2, we have a misalignment and now it shows 3266 and 3267 as deleted
<table>
  <tr>
    <th colspan="1"></th>
    <th colspan="2">Row group 3</th>
  </tr>
  <tr>
    <td/>
    <td>3266</td>
    <td>3267</td>
  </tr>
  <tr> 
    <td>dv</td>
    <td>true</td>
    <td>true</td>
    <td>false</td>
    <td>false</td>
    <td>false</td>
    <td>false</td>     
</table>

#### Performance 
Performance runs against NDS SF100 dataset on workstation

  | Baseline - commit id 5d88f6a | DV MULTITHREADED READER |  
-- | -- | -- | --
  | Average | Average | Speedup
5% | 40327.2 | 29165.2 | 1.38
10% | 39161.4 | 29577 | 1.32
25% | 39043.8 | 29784.6 | 1.31
50% | 37682.4 | 28661 | 1.31
75% | 37800 | 28600 | 1.32
50% small files | 36465.2 | 28084.8 | 1.30

Query used 

```
select *
from store_sales
order by rand(12324) 
limit 1000000
```


### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
