### PR TITLE
Accelerate DeltaDynamicPartitionOverwriteCommand

### DIFF
--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.catalog.SupportsWrite
-import org.apache.spark.sql.delta.{DeltaLog, DeltaParquetFileFormat}
+import org.apache.spark.sql.delta.{DeltaDynamicPartitionOverwriteCommand, DeltaLog, DeltaParquetFileFormat}
 import org.apache.spark.sql.delta.DeltaParquetFileFormat.IS_ROW_DELETED_COLUMN_NAME
 import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
 import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, OptimizeTableCommand, UpdateCommand}
@@ -93,7 +93,10 @@ object Delta33xProvider extends DeltaIOProvider {
           (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r)),
       GpuOverrides.runnableCmd[OptimizeTableCommand](
           "Optimize a Delta Lake table",
-          (a, conf, p, r) => new OptimizeTableCommandMeta(a, conf, p, r))
+          (a, conf, p, r) => new OptimizeTableCommandMeta(a, conf, p, r)),
+      GpuOverrides.runnableCmd[DeltaDynamicPartitionOverwriteCommand](
+        "Dynamic partition overwrite to a Delta Lake table",
+        (a, conf, p, r) => new DeltaDynamicPartitionOverwriteCommandMeta(a, conf, p, r))
     ).map(r => (r.getClassFor.asSubclass(classOf[RunnableCommand]), r)).toMap
   }
 

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/DeltaDynamicPartitionOverwriteCommandMeta.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/DeltaDynamicPartitionOverwriteCommandMeta.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta33x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
+
+import org.apache.spark.sql.GpuDeltaDynamicPartitionOverwriteCommand
+import org.apache.spark.sql.delta.DeltaDynamicPartitionOverwriteCommand
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class DeltaDynamicPartitionOverwriteCommandMeta(
+    overwriteCommand: DeltaDynamicPartitionOverwriteCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends RunnableCommandMeta[DeltaDynamicPartitionOverwriteCommand](overwriteCommand, conf,
+    parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+        s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+
+    val dvFeatureEnabled = DeletionVectorUtils.deletionVectorsWritable(
+      overwriteCommand.deltaTable.deltaLog.unsafeVolatileSnapshot)
+
+    if (dvFeatureEnabled && overwriteCommand.conf.getConf(
+      DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS)) {
+      // https://github.com/NVIDIA/spark-rapids/issues/8554
+      willNotWorkOnGpu("Writes with deletion vectors are not supported on GPU")
+    }
+
+    RapidsDeltaUtils.tagForDeltaWrite(this, overwriteCommand.table.schema,
+      Some(overwriteCommand.deltaTable.deltaLog),
+      Map.empty, overwriteCommand.deltaTable.spark)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuDeltaDynamicPartitionOverwriteCommand(
+      new GpuDeltaLog(overwriteCommand.deltaTable.deltaLog, conf),
+      overwriteCommand.table,
+      overwriteCommand.deltaTable,
+      overwriteCommand.query,
+      overwriteCommand.writeOptions,
+      overwriteCommand.isByName,
+      overwriteCommand.analyzedQuery,
+    )
+  }
+}

--- a/delta-lake/delta-33x/src/main/scala/org/apache/spark/sql/GpuDeltaDynamicPartitionOverwriteCommand.scala
+++ b/delta-lake/delta-33x/src/main/scala/org/apache/spark/sql/GpuDeltaDynamicPartitionOverwriteCommand.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.analysis.NamedRelation
+import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan, V2WriteCommand}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.delta.DeltaOptions
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.WriteIntoDelta
+import org.apache.spark.sql.delta.rapids.{GpuDeltaLog, GpuWriteIntoDelta}
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+case class GpuDeltaDynamicPartitionOverwriteCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    table: NamedRelation,
+    deltaTable: DeltaTableV2,
+    query: LogicalPlan,
+    writeOptions: Map[String, String],
+    isByName: Boolean,
+    analyzedQuery: Option[LogicalPlan] = None) extends RunnableCommand with V2WriteCommand {
+
+  override def child: LogicalPlan = query
+
+  override def withNewQuery(newQuery: LogicalPlan): V2WriteCommand = {
+    copy(query = newQuery)
+  }
+
+  override def withNewTable(newTable: NamedRelation): V2WriteCommand = {
+    copy(table = newTable)
+  }
+
+  override def storeAnalyzedQuery(): Command = copy(analyzedQuery = Some(query))
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = {
+    copy(query = newChild)
+  }
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val deltaOptions = new DeltaOptions(
+      CaseInsensitiveMap[String](
+        deltaTable.options ++
+          writeOptions ++
+          Seq(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION ->
+            DeltaOptions.PARTITION_OVERWRITE_MODE_DYNAMIC)),
+      sparkSession.sessionState.conf)
+
+    GpuWriteIntoDelta(
+      gpuDeltaLog,
+      WriteIntoDelta(
+        gpuDeltaLog.deltaLog,
+        SaveMode.Overwrite,
+        deltaOptions,
+        partitionColumns = Nil,
+        deltaTable.deltaLog.unsafeVolatileSnapshot.metadata.configuration,
+        Dataset.ofRows(sparkSession, query),
+        deltaTable.catalogTable
+      )
+    ).run(sparkSession)
+  }
+}


### PR DESCRIPTION
Fixes #13110.

### Description

The insert overwrite queries with the `dynamic` partitionOverwriteMode to clustered tables currently fall back to CPU because of the lack of the GPU version of `DeltaDynamicPartitionOverwriteCommand`. This PR adds the missing classes to support it.

One thing to note is that we already have test cases for this query, which are `test_delta_insert_overwrite_dynamic_sql_liquid_clustering` and `test_delta_insert_overwrite_df_liquid_clustering` in `delta_lake_liquid_clustering_test.py`. These tests run some insert overwrite query and then verify whether it runs on GPU. These tests have been passing the CI because of #13059 even though the write falls back. These tests should cover the change in this PR. 

Here is performance test result.

I used the query below against the TPC-H lineitem table at sf=100.

```sql
insert overwrite lineitem_inserted select * from parquet.`/parquet/lineitem` where mod(l_suppkey, 5) = 0;
```

I ran the query above on CPU and GPU, and compared their results. The means in the below snippet are the CPU runtime and the GPU runtime, respectively.

```
Means = 28439.0, 15296.0
Time diff = 13143.0
Speedup = 1.8592442468619246
T-Test (test statistic, p value, df) = 4.3441882924511575, 0.012212682511672469, 4.0
T-Test Confidence Interval = 4743.083707001302, 21542.9162929987
ALERT: significant change has been detected (p-value < 0.05)
```

Configs used:

```
GPU configs

export SPARK_CONF=("--master" "local[16]"
                   "--conf" "spark.driver.maxResultSize=2GB"
                   "--conf" "spark.driver.memory=16G"
                   "--conf" "spark.sql.files.maxPartitionBytes=2gb"
                   "--conf" "spark.plugins=com.nvidia.spark.SQLPlugin"
                   "--conf" "spark.rapids.memory.host.spillStorageSize=16G"
                   "--conf" "spark.rapids.memory.pinnedPool.size=8g"
                   "--conf" "spark.rapids.sql.concurrentGpuTasks=6"
                   "--conf" "spark.sql.sources.partitionOverwriteMode=DYNAMIC"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                   "--conf" "spark.driver.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR"
                   "--conf" "spark.executor.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR")
```

```
CPU configs

export SPARK_CONF=("--master" "local[64]"
                   "--conf" "spark.driver.memory=16G"
                   "--conf" "spark.scheduler.minRegisteredResourcesRatio=1.0"
                   "--conf" "spark.sql.adaptive.enabled=true"
                   "--conf" "spark.sql.broadcastTimeout=1200"
                   "--conf" "spark.dynamicAllocation.enabled=false"
                   "--conf" "spark.sql.sources.partitionOverwriteMode=DYNAMIC"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog")
```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
