### PR TITLE
Remove nested quotes and double quotes

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -259,12 +259,12 @@ org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
         PYSP_TEST_spark_jars_repositories=${PROJECT_REPO} \
           PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
           PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
-          env 'PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl="org.apache.iceberg.rest.RESTCatalog"' \
-          PYSP_TEST_spark_sql_catalog_spark__catalog_uri="${ICEBERG_REST_CATALOG_URI:-'http://localhost:8181/catalog/'}" \
+          env 'PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl=org.apache.iceberg.rest.RESTCatalog' \
+          PYSP_TEST_spark_sql_catalog_spark__catalog_uri="${ICEBERG_REST_CATALOG_URI:-http://localhost:8181/catalog/}" \
           PYSP_TEST_spark_sql_catalog_spark__catalog_credential="${ICEBERG_REST_CREDENTIAL}" \
-          PYSP_TEST_spark_sql_catalog_spark__catalog_oauth2-server-uri="${ICEBERG_REST_OAUTH2_SERVER_URI:-'http://localhost:8080/realms/iceberg/protocol/openid-connect/token'}" \
-          PYSP_TEST_spark_sql_catalog_spark__catalog_scope="${ICEBERG_REST_SCOPE:-'lakekeeper'}" \
-          PYSP_TEST_spark_sql_catalog_spark__catalog_warehouse="${ICEBERG_REST_WAREHOUSE:-'demo'}" \
+          env 'PYSP_TEST_spark_sql_catalog_spark__catalog_oauth2-server-uri=${ICEBERG_REST_OAUTH2_SERVER_URI:-http://localhost:8080/realms/iceberg/protocol/openid-connect/token}' \
+          PYSP_TEST_spark_sql_catalog_spark__catalog_scope="${ICEBERG_REST_SCOPE:-lakekeeper}" \
+          PYSP_TEST_spark_sql_catalog_spark__catalog_warehouse="${ICEBERG_REST_WAREHOUSE:-demo}" \
           ./run_pyspark_from_build.sh -m iceberg --iceberg
   elif [[ "$test_type" == "s3tables" ]]; then
     echo "!!! Running iceberg tests with s3tables"
@@ -299,7 +299,7 @@ com.amazonaws:aws-java-sdk-bundle:${AWS_SDK_BUNDLE_VERSION}"
         PYSP_TEST_spark_jars_repositories=${PROJECT_REPO} \
         PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
         PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
-        env 'PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl="software.amazon.s3tables.iceberg.S3TablesCatalog"' \
+        env 'PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl=software.amazon.s3tables.iceberg.S3TablesCatalog' \
         PYSP_TEST_spark_sql_catalog_spark__catalog_warehouse="$S3TABLES_BUCKET_ARN" \
         ./run_pyspark_from_build.sh -s -m iceberg --iceberg
   fi


### PR DESCRIPTION
Fixes #13554 

### Description

The test script for iceberg tests have some bugs in it as it has unnecessary quotes and double quotes in other quotes or double quotes. They are syntactically incorrect and causing test failures. Two patterns are fixed.

- For the config prefixed with `env`, the config value should not be double quoted as the whole config key-value is quoted.
- The default value should not be quoted or double quoted.

I tested this fix manually on my workstation. The classNotFound error is gone with the fix, but the tests did not pass successfully. The error seems because of some missing settings for the rest catalog server, but I'm not sure what I'm missing unfortunately.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
