### PR TITLE
Avoid host-vector access under TableCache by replacing CPU ColumnarToRow with GPU variant [databricks]

### DIFF
--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -420,3 +420,30 @@ def test_persist_with_groupby_join_version_specific(enable_vectorized_conf):
         return ee.join(minNbrs1, "src")
 
     assert_gpu_and_cpu_are_equal_collect(do_it, conf=enable_vectorized_conf)
+
+@ignore_order(local=True)
+# Ensure base allow list is a tuple to satisfy pytest hook concatenation
+@allow_non_gpu("ColumnarToRowExec") #, "HashAggregateExec")
+@pytest.mark.parametrize('enable_vectorized_conf', enable_vectorized_confs, ids=idfn)
+@allow_non_gpu_conditional(is_spark_350_or_351(), "InMemoryTableScanExec")
+def test_cached_groupby_sum_version_specific(enable_vectorized_conf):
+    """
+    Validate aggregation on a cached query works without errors across Spark versions.
+    Expected behavior:
+    - Spark 3.5.0-3.5.1: InMemoryTableScan falls back to CPU by default
+    - Spark 3.5.2+: InMemoryTableScan works on GPU
+    """
+
+    def do_it(spark):
+        spark.sql(
+            """
+            SELECT id, value FROM VALUES (1, 10.0), (2, 20.0) AS t(id, value)
+            """).createOrReplaceTempView("t_simple")
+
+        df = spark.sql("""SELECT SUM(value) AS s FROM t_simple GROUP BY id""").cache()
+
+        # Populate the cache
+        df.count()
+        return df
+
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf=enable_vectorized_conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -174,6 +174,10 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       // We wrap custom shuffle readers with a coalesce batches operator here.
       addPostShuffleCoalesce(e.copy(child = optimizeAdaptiveTransitions(e.child, Some(e))))
 
+    // Leave TableCacheQueryStage wrapper intact and let shims decide behavior.
+    case p if SparkShimImpl.getTableCacheNonQueryStagePlan(p).nonEmpty =>
+      p.withNewChildren(p.children.map(c => optimizeAdaptiveTransitions(c, Some(p))))
+
     case c2re: ColumnarToRowExec if
         SparkShimImpl.checkCToRWithExecBroadcastAQECoalPart(c2re, parent) =>
       val shuffle = SparkShimImpl.getShuffleFromCToRWithExecBroadcastAQECoalPart(c2re)
@@ -199,6 +203,11 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
     case ColumnarToRowExec(e: ShuffleQueryStageExec) =>
       val c2r = GpuColumnarToRowExec(optimizeAdaptiveTransitions(e, Some(plan)))
       SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, e)
+
+    // If Spark wrapped a TableCache query stage with a CPU ColumnarToRow, replace it with
+    // a GPU ColumnarToRow to avoid CPU accessing GPU vectors.
+    case ColumnarToRowExec(e) if SparkShimImpl.getTableCacheNonQueryStagePlan(e).nonEmpty =>
+      GpuColumnarToRowExec(optimizeAdaptiveTransitions(e, Some(plan)))
 
     case ColumnarToRowExec(e: BroadcastQueryStageExec) =>
       // In Spark an AdaptiveSparkPlanExec when doing a broadcast expects to only ever see
@@ -234,10 +243,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       p.withNewChildren(Array(newChild))
 
     case p =>
-      SparkShimImpl.handleTableCacheInOptimizeAdaptiveTransitions(p, parent) match {
-        case Some(handledPlan) => handledPlan
-        case None => p.withNewChildren(p.children.map(c => optimizeAdaptiveTransitions(c, Some(p))))
-      }
+      p.withNewChildren(p.children.map(c => optimizeAdaptiveTransitions(c, Some(p))))
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -197,12 +197,6 @@ trait SparkShims {
    */
   def reproduceEmptyStringBug: Boolean
 
-  /**
-   * Handle TableCacheQueryStageExec for optimizeAdaptiveTransitions.
-   * Returns the original plan for versions where TableCacheQueryStageExec doesn't exist.
-   */
-  def handleTableCacheInOptimizeAdaptiveTransitions(plan: SparkPlan,
-      parent: Option[SparkPlan]): Option[SparkPlan] = None
 
   /**
    * Handle TableCacheQueryStageExec for getNonQueryStagePlan.

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/Spark350PlusNonDBShims.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/Spark350PlusNonDBShims.scala
@@ -169,14 +169,6 @@ trait Spark350PlusNonDBShims extends Spark340PlusNonDBShims {
     super.getExecs ++ shimExecs
   }
 
-  override def handleTableCacheInOptimizeAdaptiveTransitions(plan: SparkPlan,
-      parent: Option[SparkPlan]): Option[SparkPlan] = {
-    plan match {
-      case tcqs: TableCacheQueryStageExec => Some(tcqs)
-      case _ => None
-    }
-  }
-
   override def getTableCacheNonQueryStagePlan(plan: SparkPlan): Option[SparkPlan] = {
     plan match {
       case tcqs: TableCacheQueryStageExec => Some(tcqs.plan)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13578

### Description
Fixes “DATA ACCESS MUST BE ON A HOST VECTOR” failures when caching an aggregated query that ends in a `TableCacheQueryStage`

When an aggregated DataFrame is cached and later collected with AQE enabled, Spark can wrap the cached scan in a `TableCacheQueryStageExec`. If Spark inserts a CPU `ColumnarToRowExec` directly above this wrapper while the underlying plan produces GPU columnar batches, generated CPU code attempts to access GPU device column vectors, causing the IllegalStateException.

- In `GpuTransitionOverrides.optimizeAdaptiveTransitions`, we added the fix:
    - When we see a CPU `ColumnarToRowExec` whose child is a `TableCacheQueryStage` (detected via shim’s `getTableCacheNonQueryStagePlan`), replace it with `GpuColumnarToRowExec` after optimizing the child.
    - This ensures rows are materialized on the GPU before control returns to the CPU, so CPU codegen never touches device vectors.
  - Keep `TableCacheQueryStage` itself on CPU (as intended). We do not convert `TableCacheQueryStage` to GPU, we just ensure the transition boundary above it is GPU-safe.
  - Removed the no-op shim hook `handleTableCacheInOptimizeAdaptiveTransitions`;  the default recursion is sufficient.
    
Afte the fix the final plan would have GpuColumnarToRow

```
== Physical Plan ==
AdaptiveSparkPlan (19)
+- == Final Plan ==
   ResultQueryStage (17), Statistics(sizeInBytes=8.0 EiB)
   +- GpuColumnarToRow (16)
      +- TableCacheQueryStage (15)
         +- GpuInMemoryTableScan (1)
               +- InMemoryRelation (2)
                     +- AdaptiveSparkPlan (14)
                     +- == Final Plan ==
``` 

### Testing
- New test  `test_cached_groupby_sum_version_specific` added in cache_test.py which validates cache->aggregate->collect. 

### Checklists

<!-- 
Check the items below by putting "x" in the brackets for what is done.
Not all of these items may be relevant to every PR, so please check only those that apply.
-->

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
