### PR TITLE
Change input type for `reductionAggregate` from `ColumnVector` to `ColumnView`

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/GpuApproximatePercentile.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/GpuApproximatePercentile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,8 +180,8 @@ case class ApproxPercentileFromTDigestExpr(
 class CudfTDigestUpdate(accuracyExpression: GpuLiteral)
   extends CudfAggregate {
 
-  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
-    (col: cudf.ColumnVector) =>
+  override lazy val reductionAggregate: cudf.ColumnView => cudf.Scalar =
+    (col: cudf.ColumnView) =>
       col.reduce(ReductionAggregation.createTDigest(CudfTDigest.accuracy(accuracyExpression)),
         DType.STRUCT)
 
@@ -194,8 +194,8 @@ class CudfTDigestUpdate(accuracyExpression: GpuLiteral)
 class CudfTDigestMerge(accuracyExpression: GpuLiteral)
   extends CudfAggregate {
 
-  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
-    (col: cudf.ColumnVector) =>
+  override lazy val reductionAggregate: cudf.ColumnView => cudf.Scalar =
+    (col: cudf.ColumnView) =>
       col.reduce(ReductionAggregation.mergeTDigest(CudfTDigest.accuracy(accuracyExpression)))
 
   override lazy val groupByAggregate: GroupByAggregation =

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/GpuHyperLogLogPlusPlus.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/GpuHyperLogLogPlusPlus.scala
@@ -35,8 +35,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class CudfHLLPP(override val dataType: DataType,
     precision: Int) extends CudfAggregate {
-  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
-    (input: cudf.ColumnVector) => {
+  override lazy val reductionAggregate: cudf.ColumnView => cudf.Scalar =
+    (input: cudf.ColumnView) => {
       if (input.getNullCount == input.getRowCount) {
         // For NullType column or all values are null,
         // return a struct scalar: struct(0L, 0L, ..., 0L)
@@ -61,8 +61,8 @@ case class CudfHLLPP(override val dataType: DataType,
 case class CudfMergeHLLPP(override val dataType: DataType,
     precision: Int)
   extends CudfAggregate {
-  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
-    (input: cudf.ColumnVector) => {
+  override lazy val reductionAggregate: cudf.ColumnView => cudf.Scalar =
+    (input: cudf.ColumnView) => {
       val hll = new HyperLogLogPlusPlusHostUDF(AggregationType.ReductionMerge, precision)
       input.reduce(ReductionAggregation.hostUDF(hll), DType.STRUCT)
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/GpuPercentile.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/GpuPercentile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,16 +35,16 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class CudfHistogram(override val dataType: DataType) extends CudfAggregate {
-  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
-    (input: cudf.ColumnVector) => input.reduce(ReductionAggregation.histogram(), DType.LIST)
+  override lazy val reductionAggregate: cudf.ColumnView => cudf.Scalar =
+    (input: cudf.ColumnView) => input.reduce(ReductionAggregation.histogram(), DType.LIST)
   override lazy val groupByAggregate: GroupByAggregation = GroupByAggregation.histogram()
   override val name: String = "CudfHistogram"
 }
 
 case class CudfMergeHistogram(override val dataType: DataType)
   extends CudfAggregate {
-  override lazy val reductionAggregate: cudf.ColumnVector => cudf.Scalar =
-    (input: cudf.ColumnVector) =>
+  override lazy val reductionAggregate: cudf.ColumnView => cudf.Scalar =
+    (input: cudf.ColumnView) =>
       input.getType match {
         // This is called from updateAggregate in GpuPercentileWithFrequency.
         case DType.STRUCT => input.reduce(ReductionAggregation.mergeHistogram(), DType.LIST)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -282,7 +282,7 @@ case class GpuAggregateExpression(origAggregateFunction: GpuAggregateFunction,
 trait CudfAggregate extends Serializable {
   // we use this to get the ordinal of the bound reference, s.t. we can ask cudf to perform
   // the aggregate on that column
-  val reductionAggregate: cudf.ColumnVector => cudf.Scalar
+  val reductionAggregate: cudf.ColumnView => cudf.Scalar
   val groupByAggregate: GroupByAggregation
   def dataType: DataType
   val name: String


### PR DESCRIPTION
When performing reduction, it is not necessary to use the input as a `ColumnVector`. We can instead use a (read-only data) `ColumnView`. By doing so, the input column view can be created by combining multiple intermediate data columns (`ColumnView`) without any data copy.

Depends on:
 * https://github.com/NVIDIA/spark-rapids-jni/pull/3836