### PR TITLE
 [DOC]Add user doc for RAPIDS UDAF [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-udfs.md
+++ b/docs/additional-functionality/rapids-udfs.md
@@ -143,7 +143,7 @@ type `DECIMAL64(scale=-2)`.
 Source code for examples of RAPIDS accelerated UDFs is provided in the [udf-examples](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/UDF-Examples/RAPIDS-accelerated-UDFs) project.
 
 ## RAPIDS Accelerated User-Defined Aggregate Functions (UDAFs)
-The RAPIDS also supports an accelerated version of UDAFs via the `RapidsUDAF` interface.
+RAPIDS also supports an accelerated version of UDAFs via the `RapidsUDAF` interface.
 Users can choose to implement its APIs as below to get the GPU acceleration.
 
 - ```java


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/13467

This is a doc only PR to add in the users guide on how to implement their own GPU-accelerated UDAFs.

The 3 links of the UDAF examples in this PR will work after https://github.com/NVIDIA/spark-rapids/pull/13450 is merged.