### PR TITLE
fix db GpuBroadcastHashJoinExec CollectTimeIterator args

### DIFF
--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -176,7 +176,7 @@ case class GpuBroadcastHashJoinExec(
           buildRelation,
           localBuildSchema,
           localBuildOutput,
-          new CollectTimeIterator("executor broadcast join stream", it, streamTime),
+          new CollectTimeIterator(NvtxRegistry.BROADCAST_JOIN_STREAM, it, streamTime),
           allMetrics)
       // builtBatch will be closed in doJoin
       doJoin(builtBatch, streamIter, targetSize, numOutputRows, numOutputBatches, opTime, joinTime)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13607

### Description

Fixes the 330db shim call of CollectTimeIterator to use the new `NvtxId` based api

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
