### PR TITLE
Temporarily disable test_dpp_reuse_broadcast_exchange and mortgage_test given cuDF issue

### DIFF
--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -178,6 +178,7 @@ dpp_fallback_execs=["CollectLimitExec"] if is_databricks_version_or_later(14,3) 
 @ignore_order
 @allow_non_gpu(*dpp_fallback_execs)
 @datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10147")
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13652")
 @pytest.mark.parametrize('store_format', ['parquet', 'orc'], ids=idfn)
 @pytest.mark.parametrize('s_index', list(range(len(_statements))), ids=idfn)
 @pytest.mark.parametrize('aqe_enabled', [

--- a/integration_tests/src/main/python/mortgage_test.py
+++ b/integration_tests/src/main/python/mortgage_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ from marks import approximate_float, incompat, ignore_order, allow_non_gpu, limi
 @limit
 @ignore_order
 @allow_non_gpu(any=True)
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13652")
 def test_mortgage(mortgage):
   assert_gpu_and_cpu_are_equal_iterator(
           lambda spark : mortgage.do_test_query(spark))


### PR DESCRIPTION
Workaround for https://github.com/NVIDIA/spark-rapids/issues/13652

### Description

A recent change in cuDF with aggregates is causing some CPU vs GPU mismatches. https://github.com/NVIDIA/spark-rapids/issues/13652.

We filed an issue in cuDF after triaging things to a specific cuDF change: https://github.com/rapidsai/cudf/pull/19764 and filed this in cuDF to further investigate with them https://github.com/rapidsai/cudf/issues/20361.

For now we are going to disable the tests that @jihoonson and others reported (a dpp_test and mortgage_test) to hopefully unblock CI.

### Checklists

- [x] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
