### PR TITLE
move validateGpuArch check to after initializeGpuAndMemory

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -543,13 +543,6 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
         AsyncProfilerOnExecutor.init(pluginContext, conf)
       }
 
-      // Checks if the current GPU architecture is supported by the
-      // spark-rapids-jni and cuDF libraries.
-      // Note: We allow this check to be skipped for off-chance cases.
-      if (!conf.skipGpuArchCheck && conf.isSqlExecuteOnGPU) {
-        RapidsPluginUtils.validateGpuArchitecture()
-      }
-
       // Fail if there are multiple plugin jars in the classpath.
       RapidsPluginUtils.detectMultipleJars(conf)
 
@@ -595,6 +588,13 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
             rapidsShuffleHeartbeatEndpoint.registerShuffleHeartbeat()
           }
         }
+      }
+
+      // Checks if the current GPU architecture is supported by the
+      // spark-rapids-jni and cuDF libraries.
+      // Note: We allow this check to be skipped for off-chance cases.
+      if (!conf.skipGpuArchCheck && conf.isSqlExecuteOnGPU) {
+        RapidsPluginUtils.validateGpuArchitecture()
       }
 
       logDebug("Loading extra executor plugins: " +


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13659  #12246

### Description

Delays the arch validation step until after we have acquired the correct device, in order to ensure we are validating the supported arch against the card we intend to actually use.

### Checklists

I tested this manually and it fixed the issue I was having, as described in the GH issue.

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
