### PR TITLE
Add common infrastructure and Spark 4.0 compatibility for Delta Lake 4.0.0 support

### DIFF
--- a/delta-lake/common/src/main/delta-20x-24x/scala/com/nvidia/spark/rapids/delta/shims/StatsExprShim.scala
+++ b/delta-lake/common/src/main/delta-20x-24x/scala/com/nvidia/spark/rapids/delta/shims/StatsExprShim.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.shims
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+/**
+ * Delta 2.0.x-2.4.x shim: no-op unwrap. RuntimeReplaceable replacement not needed.
+ */
+object StatsExprShim {
+  def unwrapRuntimeReplaceable(expr: Expression): Expression = expr
+}
+

--- a/delta-lake/common/src/main/delta-20x-24x/scala/org/apache/spark/sql/delta/rapids/ShimDeltaInvariantCheckerExec.scala
+++ b/delta-lake/common/src/main/delta-20x-24x/scala/org/apache/spark/sql/delta/rapids/ShimDeltaInvariantCheckerExec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids
+
+import org.apache.spark.sql.delta.constraints.{CheckDeltaInvariant, Constraint, DeltaInvariantCheckerExec}
+import org.apache.spark.sql.execution.SparkPlan
+
+/**
+ * Per-version shim for constructing the CPU Delta invariant checker exec.
+ *
+ * Delta 2.0.x-2.4.x expects constraints, not pre-built invariants.
+ */
+object ShimDeltaInvariantCheckerExec {
+  def apply(
+      plan: SparkPlan,
+      constraints: Seq[Constraint],
+      invariants: Seq[CheckDeltaInvariant]): SparkPlan = {
+    DeltaInvariantCheckerExec(plan, constraints)
+  }
+}
+

--- a/delta-lake/common/src/main/delta-33x-40x/scala/org/apache/spark/sql/delta/rapids/DeltaRuntimeShimBase.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/org/apache/spark/sql/delta/rapids/DeltaRuntimeShimBase.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids
+
+import com.nvidia.spark.rapids.RapidsConf
+import com.nvidia.spark.rapids.delta.{AcceptAllConfigChecker, DeltaConfigChecker, DeltaProvider}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
+import org.apache.spark.sql.delta.{DeltaLog, DeltaUDF, Snapshot, TransactionExecutionObserver}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.util.Clock
+
+/**
+ * Shared base for 3.3.x and 4.0.x runtime shims.
+ * Version-specific shims override provider, catalog, and transaction construction.
+ */
+abstract class DeltaRuntimeShimBase extends DeltaRuntimeShim {
+  override def getDeltaConfigChecker: DeltaConfigChecker = AcceptAllConfigChecker
+
+  // Provider is version-specific
+  override def getDeltaProvider: DeltaProvider
+
+  // Default behavior shared across versions
+  override def unsafeVolatileSnapshotFromLog(deltaLog: DeltaLog): Snapshot =
+    deltaLog.unsafeVolatileSnapshot
+
+  override def fileFormatFromLog(deltaLog: DeltaLog): FileFormat =
+    deltaLog.fileFormat(deltaLog.unsafeVolatileSnapshot.protocol,
+      deltaLog.unsafeVolatileSnapshot.metadata)
+
+  override def getTightBoundColumnOnFileInitDisabled(spark: SparkSession): Boolean = false
+
+  // Catalog is version-specific (GpuDeltaCatalog differs by version)
+  override def getGpuDeltaCatalog(cpuCatalog: DeltaCatalog,
+      rapidsConf: RapidsConf): StagingTableCatalog
+
+  // Transaction construction is version-specific
+  protected def constructOptimisticTransaction(arg: StartTransactionArg):
+      GpuOptimisticTransactionBase
+
+  override def startTransaction(log: DeltaLog, conf: RapidsConf, clock: Clock):
+      GpuOptimisticTransactionBase = {
+    startTransaction(StartTransactionArg(log, conf, clock))
+  }
+
+  override def startTransaction(arg: StartTransactionArg): GpuOptimisticTransactionBase = {
+    TransactionExecutionObserver.getObserver.startingTransaction {
+      constructOptimisticTransaction(arg)
+    }.asInstanceOf[GpuOptimisticTransactionBase]
+  }
+
+  override def stringFromStringUdf(f: String => String): UserDefinedFunction =
+    DeltaUDF.stringFromString(f)
+}

--- a/delta-lake/common/src/main/delta-33x-40x/scala/org/apache/spark/sql/delta/rapids/common/GpuDeltaFileFormatWriterBase.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/org/apache/spark/sql/delta/rapids/common/GpuDeltaFileFormatWriterBase.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.common
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.{TaskAttemptContext, TaskAttemptID}
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+
+import org.apache.spark.sql.delta.files.DeltaFileFormatWriter.PartitionedTaskAttemptContextImpl
+import org.apache.spark.sql.rapids.GpuWriteJobDescription
+
+object GpuDeltaFileFormatWriterBase {
+  def createTaskAttemptContext(
+      description: GpuWriteJobDescription,
+      hadoopConf: Configuration,
+      taskAttemptId: TaskAttemptID): TaskAttemptContext = {
+    if (description.partitionColumns.isEmpty) {
+      new TaskAttemptContextImpl(hadoopConf, taskAttemptId)
+    } else {
+      val partitionColumnToDataType = description.partitionColumns
+        .map(attr => (attr.name, attr.dataType)).toMap
+      new PartitionedTaskAttemptContextImpl(hadoopConf, taskAttemptId, partitionColumnToDataType)
+    }
+  }
+}

--- a/delta-lake/common/src/main/delta-33x/scala/com/nvidia/spark/rapids/delta/shims/StatsExprShim.scala
+++ b/delta-lake/common/src/main/delta-33x/scala/com/nvidia/spark/rapids/delta/shims/StatsExprShim.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.shims
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+/**
+ * Spark 3.3.x shim: no-op unwrap. RuntimeReplaceable replacement not needed here.
+ */
+object StatsExprShim {
+  def unwrapRuntimeReplaceable(expr: Expression): Expression = expr
+}

--- a/delta-lake/common/src/main/delta-33x/scala/org/apache/spark/sql/delta/rapids/ShimDeltaInvariantCheckerExec.scala
+++ b/delta-lake/common/src/main/delta-33x/scala/org/apache/spark/sql/delta/rapids/ShimDeltaInvariantCheckerExec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids
+
+import org.apache.spark.sql.delta.constraints.{CheckDeltaInvariant, Constraint, DeltaInvariantCheckerExec}
+import org.apache.spark.sql.execution.SparkPlan
+
+/**
+ * Per-version shim for constructing the CPU Delta invariant checker exec.
+ *
+ * Spark 3.3.x-3.5.x Delta expects constraints, not pre-built invariants.
+ */
+object ShimDeltaInvariantCheckerExec {
+  def apply(
+      plan: SparkPlan,
+      constraints: Seq[Constraint],
+      invariants: Seq[CheckDeltaInvariant]): SparkPlan = {
+    DeltaInvariantCheckerExec(plan, constraints)
+  }
+}

--- a/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/DeltaIOProvider.scala
+++ b/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/DeltaIOProvider.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.execution.datasources.{FileFormat, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec, OverwriteByExpressionExecV1}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.UnshimmedTrampolineUtil
+import org.apache.spark.sql.rapids.shims.TrampolineConnectShims
 import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -238,7 +239,7 @@ abstract class DeltaIOProvider extends DeltaProviderImplBase {
     override def toInsertableRelation(): InsertableRelation = {
       new InsertableRelation {
         override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-          val session = data.sparkSession
+          val session = TrampolineConnectShims.getActiveSession
           val deltaLog = writeConfig.deltaLog
 
           // TODO: Get the config from WriteIntoDelta's txn.

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/AbstractGpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/AbstractGpuOptimisticTransactionBase.scala
@@ -64,7 +64,8 @@ abstract class AbstractGpuOptimisticTransactionBase(
         GpuDeltaInvariantCheckerExec(gpuPlan, gpuInvariants)
       case None =>
         val cpuPlan = convertToCpu(plan)
-        DeltaInvariantCheckerExec(cpuPlan, constraints)
+        // Delegate to per-version shim because the CPU exec constructor differs across versions
+        ShimDeltaInvariantCheckerExec(cpuPlan, constraints, cpuInvariants)
     }
   }
 

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuCheckDeltaInvariant.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuCheckDeltaInvariant.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from CheckDeltaInvariant.scala in the
  * Delta Lake project at https://github.com/delta-io/delta.
@@ -57,8 +57,8 @@ case class GpuCheckDeltaInvariant(
   def withBoundReferences(input: AttributeSeq): GpuCheckDeltaInvariant = {
     GpuCheckDeltaInvariant(
       GpuBindReferences.bindReference(child, input),
-      columnExtractors.map {
-        case (column, extractor) => column -> BindReferences.bindReference(extractor, input)
+      columnExtractors.map { case (column, extractor) =>
+        column -> BindReferences.bindReference(extractor, input)
       },
       constraint)
   }
@@ -128,7 +128,12 @@ case class GpuCheckDeltaInvariant(
 object GpuCheckDeltaInvariant extends Logging {
   private val exprRule = GpuOverrides.expr[CheckDeltaInvariant](
     "checks a Delta Lake invariant expression",
-    ExprChecks.unaryProject(TypeSig.all, TypeSig.all, TypeSig.all, TypeSig.all),
+    ExprChecks.projectOnly(
+      TypeSig.all,
+      TypeSig.all,
+      paramCheck = Seq(ParamCheck("input", TypeSig.all, TypeSig.all)),
+      repeatingParamCheck = Some(RepeatingParamCheck("extra", TypeSig.all, TypeSig.all))
+    ),
     (c, conf, p, r) => new GpuCheckDeltaInvariantMeta(c, conf, p, r))
 
   def maybeConvertToGpu(
@@ -161,7 +166,7 @@ class GpuCheckDeltaInvariantMeta(
     conf: RapidsConf,
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule)
-    extends UnaryExprMeta[CheckDeltaInvariant](check, conf, parent, rule) {
+    extends ExprMeta[CheckDeltaInvariant](check, conf, parent, rule) {
 
   override def tagExprForGpu(): Unit = {
     wrapped.constraint match {
@@ -170,10 +175,14 @@ class GpuCheckDeltaInvariantMeta(
     }
   }
 
-  override def convertToGpu(child: Expression): GpuExpression = {
+  override def convertToGpu(): GpuExpression = {
+    val child = childExprs.head.convertToGpu()
+    // Delta 4.0 provides columnExtractors as Seq[(String, Expression)] while older
+    // versions provide Map[String, Expression]. Normalize to Map for GPU version.
+    val colExtractorsAsMap: Map[String, Expression] = wrapped.columnExtractors.toMap
     GpuCheckDeltaInvariant(
       child,
-      wrapped.columnExtractors,  // leave these on CPU
+      colExtractorsAsMap,
       wrapped.constraint)
   }
 }

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/rapids/delta/GpuIdentityColumn.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/rapids/delta/GpuIdentityColumn.scala
@@ -23,13 +23,13 @@ package org.apache.spark.sql.rapids.delta
 
 import com.nvidia.spark.rapids.delta.GpuDeltaIdentityColumnStatsTracker
 
-import org.apache.spark.sql.{Column, Dataset, SparkSession}
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
-import org.apache.spark.sql.functions.{array, max, min, to_json}
+import org.apache.spark.sql.functions.{array, col, max, min, to_json}
+import org.apache.spark.sql.rapids.shims.TrampolineConnectShims
+import org.apache.spark.sql.rapids.shims.TrampolineConnectShims.SparkSession
 import org.apache.spark.sql.types.StructType
 
 object GpuIdentityColumn {
@@ -74,13 +74,13 @@ object GpuIdentityColumn {
     // The expression will be: to_json(array(max(id1), min(id2)))
     val aggregates = identityColumnInfo.map {
       case (name, positiveStep) =>
-        val col = Column(UnresolvedAttribute.quoted(name))
-        if (positiveStep) max(col) else min(col)
+        val column = col(name)
+        if (positiveStep) max(column) else min(column)
     }
     val unresolvedExpr = to_json(array(aggregates: _*))
     // Resolve the collection expression by constructing a query to select the expression from a
     // table with the statsSchema and get the analyzed expression.
-    val resolvedExpr = Dataset.ofRows(spark, LocalRelation(statsDataSchema))
+    val resolvedExpr = TrampolineConnectShims.createDataFrame(spark, LocalRelation(statsDataSchema))
       .select(unresolvedExpr).queryExecution.analyzed.expressions.head
     Some(new GpuDeltaIdentityColumnStatsTracker(
       statsDataSchema,

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuStatisticsCollection.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuStatisticsCollection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * This file was derived from StatisticsCollection.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -30,8 +30,7 @@ import com.nvidia.spark.rapids.delta.shims.{ShimDeltaColumnMapping, ShimDeltaUDF
 
 import org.apache.spark.sql.{Column, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.functions.{count, lit, max, min, struct, sum, when}
+import org.apache.spark.sql.functions.{col, count, lit, max, min, struct, sum, when}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -167,7 +166,7 @@ trait GpuStatisticsCollection extends ShimUsesMetadataFields {
       schema.flatMap {
         case f @ StructField(name, s: StructType, _, _) =>
           val column = parent.map(_.getItem(name))
-              .getOrElse(new Column(UnresolvedAttribute.quoted(name)))
+              .getOrElse(col(name))
           val stats = collectStats(s, Some(column), parentFields :+ name, function)
           if (stats.nonEmpty) {
             Some(struct(stats: _*) as ShimDeltaColumnMapping.getPhysicalName(f))
@@ -177,7 +176,7 @@ trait GpuStatisticsCollection extends ShimUsesMetadataFields {
         case f @ StructField(name, _, _, _) =>
           val fieldPath = parentFields :+ name
           val column = parent.map(_.getItem(name))
-              .getOrElse(new Column(UnresolvedAttribute.quoted(name)))
+              .getOrElse(col(name))
           // Note: explodedDataSchema comes from dataSchema. In the read path, dataSchema comes
           // from the table's metadata.dataSchema, which is the same as tableDataSchema. In the
           // write path, dataSchema comes from the DataFrame schema. We then assume


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/13339.

### Description
This PR lays foundation for Delta-4.0.x support. It adds new common infrastructure.

- Add DeltaRuntimeShimBase to abstract shared runtime utilities between Delta versions
- Add GpuDeltaFileFormatWriterBase for shared file writing infrastructure
- Add delta-33x shims for forward compatibility:
  - StatsExprShim: Statistics expression handling
  - ShimDeltaInvariantCheckerExec: Invariant checker shim
- Update existing common files for Spark 4.0 API compatibility:
  - GpuCheckDeltaInvariant: Handle Spark 4.0 ExprChecks API changes
  - GpuIdentityColumn: Use TrampolineConnectShims for Spark 4.0
  - GpuStatisticsCollection: Handle Column constructor changes
  - AbstractGpuOptimisticTransactionBase: Spark 4.0 compatibility
  - DeltaIOProvider: Runtime shim integration
  - GpuDeltaTaskStatisticsTracker: Spark 4.0 compatibility


### Testing :
Delta 3.3.0 (Scala 2.12, Spark 3.5.6): BUILD SUCCESS, Ran delta integration tests locally.
Delta 4.0.0 (Scala 2.13, Spark 4.0.0): BUILD SUCCESS

### Checklists
- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
