### PR TITLE
Revert "Temporarily disable test_dpp_reuse_broadcast_exchange and mortgage_test given cuDF issue"

### DIFF
--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -178,7 +178,6 @@ dpp_fallback_execs=["CollectLimitExec"] if is_databricks_version_or_later(14,3) 
 @ignore_order
 @allow_non_gpu(*dpp_fallback_execs)
 @datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10147")
-@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13652")
 @pytest.mark.parametrize('store_format', ['parquet', 'orc'], ids=idfn)
 @pytest.mark.parametrize('s_index', list(range(len(_statements))), ids=idfn)
 @pytest.mark.parametrize('aqe_enabled', [

--- a/integration_tests/src/main/python/mortgage_test.py
+++ b/integration_tests/src/main/python/mortgage_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ from marks import approximate_float, incompat, ignore_order, allow_non_gpu, limi
 @limit
 @ignore_order
 @allow_non_gpu(any=True)
-@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13652")
 def test_mortgage(mortgage):
   assert_gpu_and_cpu_are_equal_iterator(
           lambda spark : mortgage.do_test_query(spark))


### PR DESCRIPTION
Reverts NVIDIA/spark-rapids#13655
Closes https://github.com/NVIDIA/spark-rapids/issues/13652


Now that the cuDF issue https://github.com/rapidsai/cudf/pull/20370 has been merged, this reverts me disabling some tests that were failing consistently.