### PR TITLE
Add missing javadocs in delta-33x-40x refactored code [skip ci]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-40x/scala/org/apache/spark/sql/delta/rapids/GpuCreateDeltaTableCommandBase.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/org/apache/spark/sql/delta/rapids/GpuCreateDeltaTableCommandBase.scala
@@ -52,8 +52,19 @@ import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
 import org.apache.spark.sql.types.StructType
 
 /**
- * Base class for GPU version of CreateDeltaTableCommand with common logic.
- * Version-specific differences are abstracted into protected methods.
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name. Version-specific differences are abstracted into protected methods.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ * @param protocol This is used to create a table with specific protocol version
+ * @param createTableFunc If specified, call this function to create the table, instead of
+ *                        Spark `SessionCatalog#createTable` which is backed by Hive Metastore.
  */
 abstract class GpuCreateDeltaTableCommandBase(
     table: CatalogTable,


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/13339

### Description
 
Missed copying the javadocs from delta-33x files when we refactored it to delta-33x-40x directory in these PR's 
https://github.com/NVIDIA/spark-rapids/pull/13642
https://github.com/NVIDIA/spark-rapids/pull/13644

Compared and added the missing javadocs. 

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
