### PR TITLE
Support ChangeLog for the new branch model [skip ci]

### DIFF
--- a/scripts/generate-changelog
+++ b/scripts/generate-changelog
@@ -326,6 +326,7 @@ def process_pr(releases: set, token: str):
     current_ver_float = float(current_ver)
     based_rel = float(FROM_RELEASE)
 
+    # Note: only the last 2 releases are supported/included in the changelog
     # Both releases are after {FROM_RELEASE}
     if current_ver_float > based_rel:
         ver_commits = get_commits(releases)


### PR DESCRIPTION
1, Retrieve commit hashes for a release after enabling the new branch model.

2, Create a query to fetch pull request (PR) information from GitHub using commit hashes.

3, Support retrieving PR ChangeLogs for both the old and new branch models.