### PR TITLE
define usesKudoGPUSlicing override got GpuSinglePartitioning

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
@@ -59,6 +59,9 @@ case object GpuSinglePartitioning extends GpuExpression with ShimExpression
   override def usesMultiThreadedShuffle: Boolean =
     GpuShuffleEnv.useMultiThreadedShuffle(new RapidsConf(SQLConf.get))
 
+  override def usesKudoGPUSlicing: Boolean =
+    new RapidsConf(SQLConf.get).shuffleKudoGpuSerializerEnabled
+
   override def nullable: Boolean = false
 
   override def dataType: DataType = IntegerType


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13664

### Description

Adds an override to `GpuSinglePartitioning` for `usesKudoGPUSlicing`. This is needed, like the other similar overrides, because it is a static class and the setting can be changed dynamically between test runs.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
