### PR TITLE
Calls removeTaskMetrics to remove task metrics in RmmSpark after task completion

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -34,7 +34,7 @@ import com.nvidia.spark.rapids.RapidsPluginUtils.buildInfoEvent
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.filecache.{FileCache, FileCacheLocalityManager, FileCacheLocalityMsg}
 import com.nvidia.spark.rapids.io.async.TrafficController
-import com.nvidia.spark.rapids.jni.{GpuTimeZoneDB, TaskPriority}
+import com.nvidia.spark.rapids.jni.{GpuTimeZoneDB, RmmSpark, TaskPriority}
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import org.apache.commons.lang3.exception.ExceptionUtils
 
@@ -509,13 +509,40 @@ class RapidsDriverPlugin extends DriverPlugin with Logging {
 }
 
 /**
+ * This class wraps an nvtx range, and a call to `removeTaskMetrics` to ensure
+ * we don't leak metrics for this task.
+ *
+ * We store the object in concurrent map where the key is the executor task thread.
+ * It is `AutoCloseable`, so the caller must close it on task success or failure.
+ */
+case class ActiveTaskMetrics(
+    stageId: Int,
+    taskAttemptId: Long,
+    attemptNumber: Int) extends AutoCloseable {
+  private var nvtx = new NvtxRange(
+    s"Stage $stageId Task $taskAttemptId-$attemptNumber", NvtxColor.DARK_GREEN)
+  private var closed = false
+  override def close(): Unit = {
+    if (!closed) {
+      closed = true
+      RmmSpark.removeTaskMetrics(taskAttemptId)
+      if (nvtx != null) {
+        nvtx.close()
+        nvtx = null
+      }
+    }
+  }
+}
+
+/**
  * The Spark executor plugin provided by the RAPIDS Spark plugin.
  */
 class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   var rapidsShuffleHeartbeatEndpoint: RapidsShuffleHeartbeatEndpoint = null
   private lazy val extraExecutorPlugins =
     RapidsPluginUtils.extraPlugins.map(_.executorPlugin()).filterNot(_ == null)
-  private val activeTaskNvtx = new ConcurrentHashMap[Thread, NvtxRange]()
+
+  private val activeTaskInfo = new ConcurrentHashMap[Thread, ActiveTaskMetrics]()
 
   private var isAsyncProfilerEnabled = false
 
@@ -766,14 +793,15 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
     val stageId = taskCtx.stageId()
     val taskAttemptId = taskCtx.taskAttemptId()
     val attemptNumber = taskCtx.attemptNumber()
-    activeTaskNvtx.put(Thread.currentThread(),
-      new NvtxRange(s"Stage $stageId Task $taskAttemptId-$attemptNumber", NvtxColor.DARK_GREEN))
+    activeTaskInfo.put(
+      Thread.currentThread(),
+      ActiveTaskMetrics(stageId, taskAttemptId, attemptNumber))
   }
 
   private def endTaskNvtx(): Unit = {
-    val nvtx = activeTaskNvtx.remove(Thread.currentThread())
-    if (nvtx != null) {
-      nvtx.close()
+    val taskInfo = activeTaskInfo.remove(Thread.currentThread())
+    if (taskInfo != null) {
+      taskInfo.close()
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13732

### Description

This PR addresses a leak of native task metrics we detected during a native leak study. It amounts to ~100B per task, so this can add up over long/many-million-task spark jobs.

### Checklists

- [x] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
