### PR TITLE
Align with CPU behavior for the null handling in GpuInSet [databricks]

### DIFF
--- a/integration_tests/src/main/python/inset_test.py
+++ b/integration_tests/src/main/python/inset_test.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from pyspark.sql.functions import col
+from pyspark.sql.types import IntegerType
+
+from asserts import assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_are_equal_collect
+from data_gen import unary_op_df, float_gen, IntegerGen, SetValuesGen
+from marks import ignore_order
+
+
+# This test suite can not run into the empty list sub-path due to the "In" optimization
+# in Spark which can not be disabled as below:
+#   object OptimizeIn extends Rule[LogicalPlan] {
+#     def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(...) {
+#       case q: LogicalPlan => q.transformExpressionsDownWithPruning(_...) {
+#         case In(v, list) if list.isEmpty =>
+#           if (!SQLConf.get.getConf(SQLConf.LEGACY_NULL_IN_EMPTY_LIST_BEHAVIOR)) {
+#             FalseLiteral
+#           } else {
+#             If(IsNotNull(v), FalseLiteral, Literal(null, BooleanType))
+#           }
+#       ...
+# But we keep it here in case if any change in the future.
+@ignore_order(local=True)
+@pytest.mark.parametrize('is_null_in_empty', ["true", "false"],
+                         ids=["Legacy_Null", "False_for_Null"])
+def test_inset_null_value_in_empty_list(is_null_in_empty):
+    def test_fn(spark):
+        test_df = unary_op_df(spark, SetValuesGen(IntegerType(), [None, 1]))
+        return test_df.select(col('a').isin([]))
+
+    assert_gpu_and_cpu_are_equal_collect(
+        test_fn,
+        conf={"spark.sql.legacy.nullInEmptyListBehavior": is_null_in_empty}
+    )
+
+
+@ignore_order(local=True)
+@pytest.mark.parametrize(
+    'set_values',
+    ["1.0, 0.0",
+     "null, 1.0, 0.0",
+     "1.0, 0.0, cast('NaN' as float)",
+     "1.0, 0.0, cast('NaN' as float), null"],
+    ids=["No_Null_NaN", "With_Null", "With_NaN", "With_Null_NaN"])
+def test_inset_with_check_nan(set_values):
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: unary_op_df(spark, float_gen),
+        "inset_test_tbl",
+        f"SELECT * FROM inset_test_tbl WHERE a IN ({set_values})"
+    )
+
+
+@ignore_order(local=True)
+@pytest.mark.parametrize('set_values', ["1,2", "null,1,2"], ids=["No_Null", "With_Null"])
+def test_inset_without_check_nan(set_values):
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: unary_op_df(spark, IntegerGen(min_val=0, max_val=30)),
+        "inset_test_tbl",
+        f"SELECT * FROM inset_test_tbl WHERE a IN ({set_values})"
+    )

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -399,7 +399,6 @@ def test_broadcast_join_right_table(data_gen, join_type, kudo_enabled):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('rows', ['(1)', '(1), (null)', '()'], ids=['no_nulls', 'has_nulls', 'empty'])
-@allow_non_gpu(*non_utc_allow)
 def test_broadcast_join_null_aware_anti(rows):
     sub_condition = ''
     if rows == '()':

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,12 @@ object GpuCanonicalize {
     case GpuNot(GpuLessThanOrEqual(l, r)) => GpuGreaterThan(l, r)
 
     // order the list in the In operator
-    case GpuInSet(value, list) if list.length > 1 => GpuInSet(value, list.sortBy(_.hashCode()))
+    case GpuInSet(value, list) if list.length > 1 =>
+      val orderedList = list.sortBy {
+        case null => 0
+        case nonNull => nonNull.hashCode()
+      }
+      GpuInSet(value, orderedList)
 
     case g: GpuGreatest =>
       val newChildren = orderCommutative(g, { case GpuGreatest(children) => children })

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2074,16 +2074,6 @@ object GpuOverrides extends Logging {
           (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128).withAllLit(),
           TypeSig.comparable))),
       (in, conf, p, r) => new ExprMeta[In](in, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          val unaliased = in.list.map(extractLit)
-          val hasNullLiteral = unaliased.exists {
-            case Some(l) => l.value == null
-            case _ => false
-          }
-          if (hasNullLiteral) {
-            willNotWorkOnGpu("nulls are not supported")
-          }
-        }
         override def convertToGpu(): GpuExpression =
           GpuInSet(childExprs.head.convertToGpu(), in.list.asInstanceOf[Seq[Literal]].map(_.value))
       }),
@@ -2092,11 +2082,6 @@ object GpuOverrides extends Logging {
       ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128, TypeSig.comparable),
       (in, conf, p, r) => new ExprMeta[InSet](in, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          if (in.hset.contains(null)) {
-            willNotWorkOnGpu("nulls are not supported")
-          }
-        }
         override def convertToGpu(): GpuExpression =
           GpuInSet(childExprs.head.convertToGpu(), in.hset.toSeq)
       }),


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/13708

This PR enables the support of nulls existing in the "list" argument for `GpuInSet`, to align with the CPU behavior. It also adds in some tests for this feature. 

With this PR, the following case will be fixed.
Given a row `1` and a `list [2, 3, null]`, CPU will output a `null` for this row `1`, while GPU will produce a `false`.

Personally this PR is a short solution, and it is better to support this in the GPU kernel to get better performance.
Since this nulls handling is Spark-specific, we probably need a new kernel in JNI for `ColumnView.contains`, instead of asking for some change in the cuDF kernel.
