### PR TITLE
Ensure that task threads are the only ones registered as dedicated

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -754,7 +754,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
     // Make sure that the thread/task is registered before we try and block
     // For the task main thread, we want to make sure that it's registered in the OOM state
     // machine throughout the task lifecycle.
-    TaskRegistryTracker.registerThreadForRetry()
+    TaskRegistryTracker.registerDedicatedThreadForRetry()
   }
 
   override def onTaskSucceeded(): Unit = {


### PR DESCRIPTION
This is a cherry-pick of https://github.com/NVIDIA/spark-rapids/pull/13775 for 25.10.

### Description

The PR is a clean cherry-pick of a commit we are adding in 25.12 to circumvent an exception in the state machine. See https://github.com/NVIDIA/spark-rapids/issues/13774 for more info.

### Checklists

- [x] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
