### PR TITLE
Return true when comparing 2 variables if both  isNaN in Unit Test

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestsTrait.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestsTrait.scala
@@ -223,7 +223,9 @@ trait RapidsTestsTrait extends RapidsTestsCommonTrait {
           ArrayType(vt, vcn),
           exprNullable = false)
       case (result: Double, expected: Double) =>
-        if (
+        if (result.isNaN && expected.isNaN) {
+          true
+        } else if (
           (isNaNOrInf(result) || isNaNOrInf(expected))
             || (result == -0.0) || (expected == -0.0)
         ) {


### PR DESCRIPTION
Since NaN has different bit mode, we can't compare 2 NaN by the bits.

The issue was that we did a doubleToRawLongBits on 2 NaN variables, then compared their bits.
According to https://en.wikipedia.org/wiki/NaN, 2 NaN variables shouldn't be compared directly.
So we return equal by checking both variables are NaN.

Interesting thing is this issue only happened on GPUs with cuda13 driver, not cuda12. Might be the NaN representation on cuda13 has some difference, I guess.

Close https://github.com/NVIDIA/spark-rapids/issues/13771