### PR TITLE
Use wildcard mark to import all Rapids test suites migrated from Apache Spark Suites

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -19,38 +19,8 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.utils
 
-import org.apache.spark.sql.rapids.suites.RapidsCastSuite
-import org.apache.spark.sql.rapids.suites.RapidsDataFrameAggregateSuite
-import org.apache.spark.sql.rapids.suites.RapidsDataFramePivotSuite
-import org.apache.spark.sql.rapids.suites.RapidsJsonExpressionsSuite
-import org.apache.spark.sql.rapids.suites.RapidsJsonFunctionsSuite
-import org.apache.spark.sql.rapids.suites.RapidsJsonSuite
-import org.apache.spark.sql.rapids.suites.RapidsMathExpressionsSuite
-import org.apache.spark.sql.rapids.suites.RapidsMathFunctionsSuite
-import org.apache.spark.sql.rapids.suites.RapidsMiscFunctionsSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetAvroCompatibilitySuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetColumnIndexSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetCompressionCodecPrecedenceSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetDeltaByteArrayEncodingSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetDeltaEncodingInteger
-import org.apache.spark.sql.rapids.suites.RapidsParquetDeltaEncodingLong
-import org.apache.spark.sql.rapids.suites.RapidsParquetDeltaLengthByteArrayEncodingSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetEncodingSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetFieldIdIOSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetFieldIdSchemaSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetFileFormatSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetInteroperabilitySuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetPartitionDiscoverySuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetProtobufCompatibilitySuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetQuerySuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetRebaseDatetimeSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetSchemaPruningSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetSchemaSuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetThriftCompatibilitySuite
-import org.apache.spark.sql.rapids.suites.RapidsParquetVectorizedSuite
-import org.apache.spark.sql.rapids.suites.RapidsRegexpExpressionsSuite
-import org.apache.spark.sql.rapids.suites.RapidsStringExpressionsSuite
-import org.apache.spark.sql.rapids.suites.RapidsStringFunctionsSuite
+// Import all Rapids test suites to avoid merge conflicts when multiple people add new suites
+import org.apache.spark.sql.rapids.suites._
 
 
 // Some settings' line length exceeds 100


### PR DESCRIPTION
Fixes #13789 

## Description

### Problem
When multiple developers simultaneously add new test suites to the Spark-RAPIDS test framework, they often encounter merge conflicts in the `RapidsTestSettings.scala` file, specifically in the import section. With 30+ explicit imports for test suites, every new suite addition requires modifying the same file region, leading to frequent conflicts and slowing down the development workflow.

### Solution
This PR refactors the import section in `RapidsTestSettings.scala` by replacing 30 explicit imports with a single wildcard import:

// Before (30 lines)
import org.apache.spark.sql.rapids.suites.RapidsCastSuite
import org.apache.spark.sql.rapids.suites.RapidsDataFrameAggregateSuite
// ... 28 more imports

// After (2 lines)
// Import all Rapids test suites to avoid merge conflicts when multiple people add new suites
import org.apache.spark.sql.rapids.suites._### Benefits
- **Reduces merge conflicts**: When adding new test suites, developers only need to modify the `enableSuite` configuration section, not the import section
- **Simplifies maintenance**: No need to update imports when adding new test suites
- **Cleaner code**: Reduces code from 30 lines to 2 lines (including comment)
- **No behavioral changes**: All existing functionality remains unchanged

### User Experience
After this change, when developers add new test suites:
1. Create the test suite class in `org.apache.spark.sql.rapids.suites` package
2. Add the `enableSuite[YourNewSuite]` configuration (no import statement needed)
3. Reduced likelihood of merge conflicts during PR review

### Checklists
- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
