### PR TITLE
Update dependency version JNI, private, hybrid to 26.02.0-SNAPSHOT [skip ci]

### DIFF
--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -20,8 +20,7 @@
 
 set -ex
 
-# TODO: https://github.com/NVIDIA/spark-rapids/issues/13794
-CUDF_VER=${CUDF_VER:-25.12}
+CUDF_VER=${CUDF_VER:-26.02}
 CUDA_VER=${CUDA_VER:-12.9}
 
 # Need to explicitly add conda into PATH environment, to activate conda environment.

--- a/pom.xml
+++ b/pom.xml
@@ -932,10 +932,9 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda12</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <!-- TODO: https://github.com/NVIDIA/spark-rapids/issues/13794 -->
-        <spark-rapids-jni.version>25.12.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>25.12.0-SNAPSHOT</spark-rapids-private.version>
-        <spark-rapids-hybrid.version>25.12.0-SNAPSHOT</spark-rapids-hybrid.version>
+        <spark-rapids-jni.version>26.02.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>26.02.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-hybrid.version>26.02.0-SNAPSHOT</spark-rapids-hybrid.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.12.15</scala.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -932,10 +932,9 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda12</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <!-- TODO: https://github.com/NVIDIA/spark-rapids/issues/13794 -->
-        <spark-rapids-jni.version>25.12.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>25.12.0-SNAPSHOT</spark-rapids-private.version>
-        <spark-rapids-hybrid.version>25.12.0-SNAPSHOT</spark-rapids-hybrid.version>
+        <spark-rapids-jni.version>26.02.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>26.02.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-hybrid.version>26.02.0-SNAPSHOT</spark-rapids-hybrid.version>
         <scala.binary.version>2.13</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.13.14</scala.version>


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids/issues/13794

Wait for the pre-merge CI job to SUCCEED