### PR TITLE
Fix a GBK test failure on DB 143+[databricks]

### DIFF
--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -708,8 +708,8 @@ def test_read_case_col_name(spark_tmp_path, spark_tmp_table_factory, read_func, 
 def test_csv_read_gbk_encoded_data(std_input_path):
     # Conf does not work before 4.0.0, so verify even setting to false it should still work.
     legacy_charset = "false"
-    if is_spark_400_or_later() or is_databricks_runtime():
-        # true from Spark 4.0.0 or DB runtimes to pass the test for GBK.
+    if is_spark_400_or_later() or is_databricks143_or_later():
+        # true from Spark 4.0.0 or DB 143 to pass the test for GBK.
         # We can not test the "GBK-with-false" case because Spark will fail the
         # current app before running into the GPU world.
         legacy_charset = "true"

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -63,7 +63,7 @@ object GpuCSVScan extends Logging {
     }
   }
 
-  private def legacyCharsetEnabled: Boolean = {
+  private def legacyCharsetEnabled(): Boolean = {
     try {
       // Use reflection to determine if this conf is defined to avoid the
       // complicated shim things due to only a boolean diff in CSV read.
@@ -82,10 +82,10 @@ object GpuCSVScan extends Logging {
     StandardCharsets.US_ASCII)
 
   // May have more in the future
-  private lazy val supportedCharsets: Set[Charset] = {
+  private def supportedCharsets(): Set[Charset] = {
     // Spark restricts charsets in CSV from 4.0.0.
     // See https://issues.apache.org/jira/browse/SPARK-48857
-    if (legacyCharsetEnabled) {
+    if (legacyCharsetEnabled()) {
       utf8Charsets ++ tryLoadCharset("GBK")
     } else {
       utf8Charsets
@@ -94,7 +94,7 @@ object GpuCSVScan extends Logging {
 
   private def isSupportedCharset(name: String): Boolean = {
     try {
-      name != null && supportedCharsets.contains(Charset.forName(name))
+      name != null && supportedCharsets().contains(Charset.forName(name))
     } catch {
       case _: IllegalArgumentException => false
     }
@@ -168,7 +168,7 @@ object GpuCSVScan extends Logging {
 
     if (!isSupportedCharset(parsedOptions.charset)) {
       meta.willNotWorkOnGpu(s"GpuCSVScan only supports " +
-        s"${supportedCharsets.mkString("[", ", ", "]")} encoded data")
+        s"${supportedCharsets().mkString("[", ", ", "]")} encoded data")
     }
 
     // TODO parsedOptions.ignoreLeadingWhiteSpaceInRead cudf always does this, but not for strings


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/13800

The root cause is missing the check for DB runtimes when specifying the legacy charset config for the CSV read, and should not cache the supported charset list, instead build it each time overriding the plan according to the current config.
