### PR TITLE
Fix a GBK test failure on DB runtimes[databricks]

### DIFF
--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -708,8 +708,8 @@ def test_read_case_col_name(spark_tmp_path, spark_tmp_table_factory, read_func, 
 def test_csv_read_gbk_encoded_data(std_input_path):
     # Conf does not work before 4.0.0, so verify even setting to false it should still work.
     legacy_charset = "false"
-    if is_spark_400_or_later():
-        # true from Spark 4.0.0 to pass the test for GBK.
+    if is_spark_400_or_later() or is_databricks_runtime():
+        # true from Spark 4.0.0 or DB runtimes to pass the test for GBK.
         # We can not test the "GBK-with-false" case because Spark will fail the
         # current app before running into the GPU world.
         legacy_charset = "true"


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/13800

The root cause is missing the check for DB runtimes when specifying the legacy charset config for the CSV read.