### PR TITLE
Support merging clustered tables for Delta IO [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/MergeIntoCommandMetaBase.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/MergeIntoCommandMetaBase.scala
@@ -22,7 +22,6 @@ import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.commands.{DeletionVectorUtils, MergeIntoCommand}
-import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 abstract class MergeIntoCommandMetaBase(
@@ -49,12 +48,6 @@ abstract class MergeIntoCommandMetaBase(
       DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS)) {
       // https://github.com/NVIDIA/spark-rapids/issues/8654
       willNotWorkOnGpu("Deletion vectors are not supported on GPU")
-    }
-
-    val isClusteredTable = ClusteredTableUtils.getClusterBySpecOptional(
-      mergeCmd.targetFileIndex.deltaLog.unsafeVolatileSnapshot).isDefined
-    if (isClusteredTable) {
-      willNotWorkOnGpu("Liquid clustering is not supported on GPU")
     }
 
     val targetSchema = mergeCmd.migratedSchema.getOrElse(mergeCmd.target.schema)

--- a/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
@@ -266,10 +266,11 @@ def test_delta_insert_overwrite_replace_where_sql_liquid_clustering(spark_tmp_pa
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
-def do_test_delta_dml_sql_liquid_clustering_fallback(spark_tmp_path,
-                                                     spark_tmp_table_factory,
-                                                     conf: Dict[str, str],
-                                                     sql_func: Callable[[str], str]):
+def do_test_delta_dml_sql_liquid_clustering(spark_tmp_path,
+                                            spark_tmp_table_factory,
+                                            conf: Dict[str, str],
+                                            sql_func: Callable[[str], str],
+                                            expect_fallback):
 
     base_data_path = spark_tmp_path + "/DELTA_LIQUID_CLUSTER"
     cpu_data_path = f"{base_data_path}/CPU"
@@ -288,12 +289,18 @@ def do_test_delta_dml_sql_liquid_clustering_fallback(spark_tmp_path,
         table_name = cpu_table_name if path == cpu_data_path else gpu_table_name
         spark.sql(sql_func(table_name))
 
-    assert_gpu_fallback_write(modify_table,
-                              lambda spark, path: spark.read.format("delta").load(path),
-                              base_data_path,
-                              "ExecutedCommandExec",
-                              conf=conf)
-
+    if expect_fallback:
+        assert_gpu_fallback_write(modify_table,
+                                  lambda spark, path: spark.read.format("delta").load(path),
+                                  base_data_path,
+                                  "ExecutedCommandExec",
+                                  conf=conf)
+    else:
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            modify_table,
+            lambda spark, path: spark.read.format("delta").load(path),
+            base_data_path,
+            conf=conf)
 
 @allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
                "AppendDataExecV1")
@@ -306,9 +313,10 @@ def do_test_delta_dml_sql_liquid_clustering_fallback(spark_tmp_path,
 def test_delta_delete_sql_liquid_clustering_fallback(spark_tmp_path,
                                                      spark_tmp_table_factory):
 
-    do_test_delta_dml_sql_liquid_clustering_fallback(
+    do_test_delta_dml_sql_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory, delta_delete_enabled_conf,
-        lambda table_name: f"DELETE FROM {table_name} WHERE a > 0")
+        lambda table_name: f"DELETE FROM {table_name} WHERE a > 0",
+        expect_fallback=True)
 
 @allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
                "AppendDataExecV1")
@@ -321,27 +329,28 @@ def test_delta_delete_sql_liquid_clustering_fallback(spark_tmp_path,
 def test_delta_update_sql_liquid_clustering_fallback(spark_tmp_path,
                                                      spark_tmp_table_factory):
 
-    do_test_delta_dml_sql_liquid_clustering_fallback(
+    do_test_delta_dml_sql_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory, delta_update_enabled_conf,
-        lambda table_name: f"UPDATE {table_name} SET e = e+1 WHERE a > 0")
+        lambda table_name: f"UPDATE {table_name} SET e = e+1 WHERE a > 0",
+        expect_fallback=True)
 
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
-               "AppendDataExecV1")
+@allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks133_or_later(),
                     reason="Delta Lake liquid clustering is only supported on Databricks 13.3+")
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
-def test_delta_merge_sql_liquid_clustering_fallback(spark_tmp_path,
+def test_delta_merge_sql_liquid_clustering(spark_tmp_path,
                                                      spark_tmp_table_factory):
 
-    do_test_delta_dml_sql_liquid_clustering_fallback(
+    do_test_delta_dml_sql_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory, delta_merge_enabled_conf,
         lambda table_name: f"MERGE INTO {table_name} "
                            f"USING {table_name} as src_table "
                            f"ON {table_name}.a == src_table.a "
-                           f"WHEN NOT MATCHED THEN INSERT *")
+                           f"WHEN NOT MATCHED THEN INSERT *",
+        expect_fallback=False)
 
 
 


### PR DESCRIPTION
Fixes #13546

### Description

This PR adds support for merging clustered tables for Delta IO.

I ran some test on my workstation to compare the performance of the merge operation between CPU and GPU. The selectivity of the match condition in the query was about 10%.

```sql
CREATE TABLE store_sales_clone SHALLOW CLONE delta.`/path/to/tpcds/sf=100/delta_clustered/store_sales`;

MERGE INTO store_sales_clone AS target
USING store_sales AS source
  ON target.ss_ticket_number = source.ss_ticket_number
    AND target.ss_item_sk = source.ss_item_sk
    AND (source.ss_ticket_number * source.ss_item_sk) % 1000 < 100
WHEN MATCHED THEN
  UPDATE SET target.ss_coupon_amt = source.ss_coupon_amt;
```

The query speedup was:

```
Means = 191026.33333333334, 98566.33333333333
Time diff = 92460.00000000001
Speedup = 1.9380484884967486
T-Test (test statistic, p value, df) = 17.21877560175701, 6.674817518471436e-05, 4.0
T-Test Confidence Interval = 77551.26779023746, 107368.73220976257
ALERT: significant change has been detected (p-value < 0.05)
```

GPU configs:

```
export SPARK_CONF=("--master" "local[16]"
                   "--conf" "spark.driver.maxResultSize=2GB"
                   "--conf" "spark.driver.memory=16G"
                   "--conf" "spark.sql.files.maxPartitionBytes=2gb"
                   "--conf" "spark.plugins=com.nvidia.spark.SQLPlugin"
                   "--conf" "spark.rapids.memory.host.spillStorageSize=16G"
                   "--conf" "spark.rapids.memory.pinnedPool.size=8g"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                   "--conf" "spark.driver.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR
                   "--conf" "spark.executor.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR)
```

CPU configs:

```
export SPARK_CONF=("--master" "local[64]"
                   "--conf" "spark.rapids.sql.enabled=false"
                   "--conf" "spark.driver.memory=16G"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog")
```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
