### PR TITLE
Support update for Delta clustered tables [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/UpdateCommandMetaBase.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/UpdateCommandMetaBase.scala
@@ -20,7 +20,6 @@ import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta,
 import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
 
 import org.apache.spark.sql.delta.commands.{DeletionVectorUtils, UpdateCommand}
-import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 abstract class UpdateCommandMetaBase(
@@ -43,12 +42,6 @@ abstract class UpdateCommandMetaBase(
       DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS)) {
       // https://github.com/NVIDIA/spark-rapids/issues/8554
       willNotWorkOnGpu("Deletion vectors are not supported on GPU")
-    }
-
-    val isClusteredTable = ClusteredTableUtils.getClusterBySpecOptional(
-      updateCmd.tahoeFileIndex.deltaLog.unsafeVolatileSnapshot).isDefined
-    if (isClusteredTable) {
-      willNotWorkOnGpu("Liquid clustering is not supported on GPU")
     }
 
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,

--- a/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
@@ -266,10 +266,11 @@ def test_delta_insert_overwrite_replace_where_sql_liquid_clustering(spark_tmp_pa
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
 
 
-def do_test_delta_dml_sql_liquid_clustering_fallback(spark_tmp_path,
+def do_test_delta_dml_sql_liquid_clustering(spark_tmp_path,
                                                      spark_tmp_table_factory,
                                                      conf: Dict[str, str],
-                                                     sql_func: Callable[[str], str]):
+                                                     sql_func: Callable[[str], str],
+                                                     expect_fallback):
 
     base_data_path = spark_tmp_path + "/DELTA_LIQUID_CLUSTER"
     cpu_data_path = f"{base_data_path}/CPU"
@@ -288,11 +289,18 @@ def do_test_delta_dml_sql_liquid_clustering_fallback(spark_tmp_path,
         table_name = cpu_table_name if path == cpu_data_path else gpu_table_name
         spark.sql(sql_func(table_name))
 
-    assert_gpu_fallback_write(modify_table,
-                              lambda spark, path: spark.read.format("delta").load(path),
-                              base_data_path,
-                              "ExecutedCommandExec",
-                              conf=conf)
+    if expect_fallback:
+        assert_gpu_fallback_write(modify_table,
+                                  lambda spark, path: spark.read.format("delta").load(path),
+                                  base_data_path,
+                                  "ExecutedCommandExec",
+                                  conf=conf)
+    else:
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            modify_table,
+            lambda spark, path: spark.read.format("delta").load(path),
+            base_data_path,
+            conf=conf)
 
 
 @allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
@@ -306,9 +314,10 @@ def do_test_delta_dml_sql_liquid_clustering_fallback(spark_tmp_path,
 def test_delta_delete_sql_liquid_clustering_fallback(spark_tmp_path,
                                                      spark_tmp_table_factory):
 
-    do_test_delta_dml_sql_liquid_clustering_fallback(
+    do_test_delta_dml_sql_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory, delta_delete_enabled_conf,
-        lambda table_name: f"DELETE FROM {table_name} WHERE a > 0")
+        lambda table_name: f"DELETE FROM {table_name} WHERE a > 0",
+        expect_fallback=True)
 
 @allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
                "AppendDataExecV1")
@@ -319,12 +328,13 @@ def test_delta_delete_sql_liquid_clustering_fallback(spark_tmp_path,
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
 @disable_ansi_mode
-def test_delta_update_sql_liquid_clustering_fallback(spark_tmp_path,
-                                                     spark_tmp_table_factory):
+def test_delta_update_sql_liquid_clustering(spark_tmp_path,
+                                            spark_tmp_table_factory):
 
-    do_test_delta_dml_sql_liquid_clustering_fallback(
+    do_test_delta_dml_sql_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory, delta_update_enabled_conf,
-        lambda table_name: f"UPDATE {table_name} SET e = e+1 WHERE a > 0")
+        lambda table_name: f"UPDATE {table_name} SET e = e+1 WHERE a > 0",
+        expect_fallback=False)
 
 @allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
                "AppendDataExecV1")


### PR DESCRIPTION
Fixes #13547 

### Description

This PR adds support for updating clustered tables for Delta.

I ran some test on my workstation to compare the performance of the update operation between CPU and GPU. The selectivity of the match condition in the query was about 10%.

```sql
CREATE TABLE store_sales_clone SHALLOW CLONE delta.`/path/to/sf=100/delta_clustered/store_sales`;

UPDATE store_sales_clone SET
    ss_wholesale_cost = ss_wholesale_cost * 2,
    ss_list_price = ss_list_price * 2,
    ss_sales_price = ss_sales_price * 2,
    ss_ext_sales_price = ss_ext_sales_price * 2,
    ss_ext_wholesale_cost = ss_ext_wholesale_cost * 2,
    ss_ext_list_price = ss_ext_list_price * 2,
    ss_ext_discount_amt = ss_ext_discount_amt * 2
WHERE ss_store_sk <= 20;
```

The query speedup was:

```
Means = 46820.0, 35492.666666666664
Time diff = 11327.333333333336
Speedup = 1.3191457390259023
T-Test (test statistic, p value, df) = 7.280031124055662, 0.0018917865950277067, 4.0
T-Test Confidence Interval = 7007.335430528114, 15647.331236138558
ALERT: significant change has been detected (p-value < 0.05)
```

GPU configs:

```
export SPARK_CONF=("--master" "local[16]"
                   "--conf" "spark.driver.maxResultSize=2GB"
                   "--conf" "spark.driver.memory=16G"
                   "--conf" "spark.sql.files.maxPartitionBytes=2gb"
                   "--conf" "spark.plugins=com.nvidia.spark.SQLPlugin"
                   "--conf" "spark.rapids.memory.host.spillStorageSize=16G"
                   "--conf" "spark.rapids.memory.pinnedPool.size=8g"
                   "--conf" "spark.rapids.sql.concurrentGpuTasks=6"
                   "--conf" "spark.sql.adaptive.coalescePartitions.minPartitionSize=32mb"
                   "--conf" "spark.sql.adaptive.advisoryPartitionSizeInBytes=160mb"
                   "--conf" "spark.shuffle.manager=com.nvidia.spark.rapids.spark356.RapidsShuffleManager"
                   "--conf" "spark.rapids.shuffle.multiThreaded.writer.threads=64"
                   "--conf" "spark.rapids.shuffle.multiThreaded.reader.threads=64"
                   "--conf" "spark.rapids.sql.multiThreadedRead.numThreads=64"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                   "--conf" "spark.driver.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR"
                   "--conf" "spark.executor.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR")
```

CPU configs:

```
export SPARK_CONF=("--master" "local[32]"
                   "--conf" "spark.rapids.sql.enabled=false"
                   "--conf" "spark.driver.memory=16G"
                   "--conf" "spark.scheduler.minRegisteredResourcesRatio=1.0"
                   "--conf" "spark.driver.extraClassPath=$NDS_LISTENER_JAR"
                   "--conf" "spark.executor.extraClassPath=$NDS_LISTENER_JAR"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog")
```


### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
