### PR TITLE
Fix ArrayIndexOutOfBounds in iceberg reader.

### DIFF
--- a/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
+++ b/iceberg/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
@@ -199,9 +199,8 @@ trait GpuIcebergParquetReader extends Iterator[ColumnarBatch] with AutoCloseable
       val fileSchema = reader.getFileMetaData.getSchema
 
       val rowGroupFirstRowIndices = new Array[Long](reader.getRowGroups.size())
-      rowGroupFirstRowIndices(0) = 0
-      var accumulatedRowCount = reader.getRowGroups.get(0).getRowCount
-      for (i <- 1 until reader.getRowGroups.size()) {
+      var accumulatedRowCount = 0L
+      for (i <- 0 until reader.getRowGroups.size()) {
         rowGroupFirstRowIndices(i) = accumulatedRowCount
         accumulatedRowCount += reader.getRowGroups.get(i).getRowCount
       }


### PR DESCRIPTION

Closes #13824 .

### Description

A minor fix of iceberg parquet reader, which could support empty row group parquet file.

### Checklists


- [x] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
