### PR TITLE
Delete support for clustered tables [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/DeleteCommandMetaBase.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/DeleteCommandMetaBase.scala
@@ -21,7 +21,6 @@ import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.commands.{DeleteCommand, DeletionVectorUtils}
-import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 abstract class DeleteCommandMetaBase(
@@ -42,12 +41,6 @@ abstract class DeleteCommandMetaBase(
         DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS)) {
       // https://github.com/NVIDIA/spark-rapids/issues/8554
       willNotWorkOnGpu("Deletion vectors are not supported on GPU")
-    }
-
-    val isClusteredTable = ClusteredTableUtils.getClusterBySpecOptional(
-      deleteCmd.deltaLog.unsafeVolatileSnapshot).isDefined
-    if (isClusteredTable) {
-      willNotWorkOnGpu("Liquid clustering is not supported on GPU")
     }
 
     RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, Some(deleteCmd.deltaLog),

--- a/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
+++ b/integration_tests/src/main/python/delta_lake_liquid_clustering_test.py
@@ -272,8 +272,7 @@ def test_delta_insert_overwrite_replace_where_sql_liquid_clustering(spark_tmp_pa
 def do_test_delta_dml_sql_liquid_clustering(spark_tmp_path,
                                                      spark_tmp_table_factory,
                                                      conf: Dict[str, str],
-                                                     sql_func: Callable[[str], str],
-                                                     expect_fallback):
+                                                     sql_func: Callable[[str], str]):
 
     base_data_path = spark_tmp_path + "/DELTA_LIQUID_CLUSTER"
     cpu_data_path = f"{base_data_path}/CPU"
@@ -292,34 +291,24 @@ def do_test_delta_dml_sql_liquid_clustering(spark_tmp_path,
         table_name = cpu_table_name if path == cpu_data_path else gpu_table_name
         spark.sql(sql_func(table_name))
 
-    if expect_fallback:
-        assert_gpu_fallback_write(modify_table,
-                                  lambda spark, path: spark.read.format("delta").load(path),
-                                  base_data_path,
-                                  "ExecutedCommandExec",
-                                  conf=conf)
-    else:
-        assert_gpu_and_cpu_writes_are_equal_collect(
-            modify_table,
-            lambda spark, path: spark.read.format("delta").load(path),
-            base_data_path,
-            conf=conf)
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        modify_table,
+        lambda spark, path: spark.read.format("delta").load(path),
+        base_data_path,
+        conf=conf)
 
-@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
-               "AppendDataExecV1")
+@allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow)
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks133_or_later(),
                     reason="Delta Lake liquid clustering is only supported on Databricks 13.3+")
 @pytest.mark.skipif(not is_spark_353_or_later(),
                     reason="Create table with cluster by is only supported on delta 3.1+")
-def test_delta_delete_sql_liquid_clustering_fallback(spark_tmp_path,
-                                                     spark_tmp_table_factory):
+def test_delta_delete_sql_liquid_clustering(spark_tmp_path, spark_tmp_table_factory):
 
     do_test_delta_dml_sql_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory, delta_delete_enabled_conf,
-        lambda table_name: f"DELETE FROM {table_name} WHERE a > 0",
-        expect_fallback=True)
+        lambda table_name: f"DELETE FROM {table_name} WHERE a > 0")
 
 @allow_non_gpu(*delta_meta_allow, delta_write_fallback_allow, "CreateTableExec",
                "AppendDataExecV1")
@@ -335,8 +324,7 @@ def test_delta_update_sql_liquid_clustering(spark_tmp_path,
 
     do_test_delta_dml_sql_liquid_clustering(
         spark_tmp_path, spark_tmp_table_factory, delta_update_enabled_conf,
-        lambda table_name: f"UPDATE {table_name} SET e = e+1 WHERE a > 0",
-        expect_fallback=False)
+        lambda table_name: f"UPDATE {table_name} SET e = e+1 WHERE a > 0")
 
 
 @allow_non_gpu(*delta_meta_allow)


### PR DESCRIPTION
Fixes #13548 

### Description

This PR adds support for deletion for Delta clustered tables.

I ran some test on my workstation to compare the performance of the delete operation between CPU and GPU. The selectivity of the match condition in the query was about 10%.

```sql
CREATE TABLE store_sales_clone SHALLOW CLONE delta.`/path/to/data/tpcds/sf=100/delta_clustered/store_sales`;

DELETE FROM store_sales_clone WHERE ss_store_sk <= 20;
```

The query speedup was:

```
Means = 48289.666666666664, 13413.666666666666
Time diff = 34876.0
Speedup = 3.600034790387913
T-Test (test statistic, p value, df) = 37.879083114921045, 2.9009365781834482e-06, 4.0
T-Test Confidence Interval = 32319.673618099394, 37432.3263819006
ALERT: significant change has been detected (p-value < 0.05)
```

GPU configs:

```
export SPARK_CONF=("--master" "local[16]"
                   "--conf" "spark.driver.maxResultSize=2GB"
                   "--conf" "spark.driver.memory=16G"
                   "--conf" "spark.sql.files.maxPartitionBytes=2gb"
                   "--conf" "spark.plugins=com.nvidia.spark.SQLPlugin"
                   "--conf" "spark.rapids.memory.host.spillStorageSize=16G"
                   "--conf" "spark.rapids.memory.pinnedPool.size=8g"
                   "--conf" "spark.rapids.sql.concurrentGpuTasks=6"
                   "--conf" "spark.sql.adaptive.coalescePartitions.minPartitionSize=32mb"
                   "--conf" "spark.sql.adaptive.advisoryPartitionSizeInBytes=160mb"
                   "--conf" "spark.shuffle.manager=com.nvidia.spark.rapids.spark356.RapidsShuffleManager"
                   "--conf" "spark.rapids.shuffle.multiThreaded.writer.threads=64"
                   "--conf" "spark.rapids.shuffle.multiThreaded.reader.threads=64"
                   "--conf" "spark.rapids.sql.multiThreadedRead.numThreads=64"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                   "--conf" "spark.driver.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR"
                   "--conf" "spark.executor.extraClassPath=$SPARK_RAPIDS_PLUGIN_JAR")
```

CPU configs:

```
export SPARK_CONF=("--master" "local[32]"
                   "--conf" "spark.rapids.sql.enabled=false"
                   "--conf" "spark.driver.memory=16G"
                   "--conf" "spark.scheduler.minRegisteredResourcesRatio=1.0"
                   "--conf" "spark.driver.extraClassPath=$NDS_LISTENER_JAR"
                   "--conf" "spark.executor.extraClassPath=$NDS_LISTENER_JAR"
                   "--packages" "io.delta:delta-spark_2.12:3.3.1"
                   "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                   "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog")
```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
