### PR TITLE
Replace `apache.commons.lang3.StringUtils.abbreviate` calls

### DIFF
--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/SparkStringUtilsShims.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/SparkStringUtilsShims.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "400"}
+{"spark": "401"}
+spark-rapids-shim-json-lines ***/
+
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.commons.lang3.{StringUtils => CommonsLang3StringUtils}
+
+/**
+ * Shim for Spark StringUtils functions.
+ */
+object SparkStringUtilsShims {
+  /**
+   * This shim method is in response to the following two Spark JIRAs:
+   *   1. https://issues.apache.org/jira/browse/SPARK-53004
+   *   2. https://issues.apache.org/jira/browse/SPARK-52987
+   * Apache Spark 4.1.x is reducing its dependency on Apache Commons Lang3, in this case replacing
+   * references to StringUtils.abbreviate with its own implementation in SparkStringUtils.
+   * This shim implementation retains the Apache Commons Lang3 implementation.
+   * When Spark RAPIDS adds Apache Spark 4.1.x support, a new shim can be created to
+   * forward to org.apache.spark.util.SparkStringUtils.abbreviate.
+   */
+  def abbreviate(str: String, len: Int): String = CommonsLang3StringUtils.abbreviate(str, len)
+}


### PR DESCRIPTION
This commit replaces calls to
`apache.commons.lang3.StringUtils.abbreviate` with a shim in the plugin.

Apache Spark 4.x is reducing its dependency on Apache commons-lang3, as is evident from the changes made in Apache Spark, in the following JIRAs:
1. https://issues.apache.org/jira/browse/SPARK-53004
2. https://issues.apache.org/jira/browse/SPARK-52987

In this commit, the shim handles Spark versions prior to Spark 4.1 (by forwarding to `commons.lang3.StringUtils`).

When Apache Spark 4.1 support is added to Spark RAPIDS, we can see about a shim to use `org.apache.spark.utils.StringUtils.abbreviate()`.
