### PR TITLE
Use pyspark-client only for Spark 4.x [skip ci]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -536,12 +536,22 @@ else
             exit 1
         fi
 
-        # Create a venv and install only pyspark-client to ensure a pure Python client
-        # See: https://spark.apache.org/docs/latest/api/python/getting_started/install.html#python-spark-connect-client
+        case $VERSION_STRING in
+          3.5.*)
+            CONNECT_PIP_PACKAGE="pyspark[connect]"
+            ;;
+          
+          4.*)
+            # Create a venv and install only pyspark-client to ensure a pure Python client
+            # See: https://spark.apache.org/docs/latest/api/python/getting_started/install.html#python-spark-connect-client
+            CONNECT_PIP_PACKAGE="pyspark-client"
+            ;;
+        esac
+
         CONNECT_CLIENT_VENV="${RUN_DIR}/connect_client_venv"
         python -m venv "$CONNECT_CLIENT_VENV"
         "$CONNECT_CLIENT_VENV/bin/python" -m pip install --upgrade pip >/dev/null
-        "$CONNECT_CLIENT_VENV/bin/python" -m pip install --no-cache-dir "pyspark-client==${VERSION_STRING}" > /dev/null
+        "$CONNECT_CLIENT_VENV/bin/python" -m pip install --no-cache-dir "$CONNECT_PIP_PACKAGE==${VERSION_STRING}" > /dev/null
 
         # Run a simple query using the Connect client and assert expected result and GPU operator in the plan
         output=$(CONNECT_URL="$CONNECT_SERVER_URL" \


### PR DESCRIPTION
Fixes #13860 

### Description

pyspark-client is available only for Spark 4.x, use pyspark[connect] for 3.5.6+ tests in the smoke test

### Testing

```bash
$ SPARK_HOME=~/dist/spark-4.0.0-bin-hadoop3  SCALA_VERSION=2.13 \
  SPARK_CONNECT_SMOKE_TEST=1 ./integration_tests/run_pyspark_from_build.sh

$ SPARK_HOME=~/dist/spark-3.5.6-bin-hadoop3  \
  SPARK_CONNECT_SMOKE_TEST=1 ./integration_tests/run_pyspark_from_build.sh 
```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
