### PR TITLE
[Backport to 25.12] add missing spark 357 to GpuWriteFilesUnsupportedVersions

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/lore/GpuLore.scala
@@ -366,6 +366,7 @@ object GpuLore {
       SparkShimVersion(3, 5, 4),
       SparkShimVersion(3, 5, 5),
       SparkShimVersion(3, 5, 6),
+      SparkShimVersion(3, 5, 7),
       SparkShimVersion(4, 0, 0),
       SparkShimVersion(4, 0, 1),
       // Databricks versions


### PR DESCRIPTION
Backport https://github.com/NVIDIA/spark-rapids/pull/13819 to release 25.12

Fixes https://github.com/NVIDIA/spark-rapids/issues/13798.

### Description

This change was missing in my previous PR #13742. 

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.

