### PR TITLE
Fix the unstable unit test case: ResourceBoundedExecutorSuite

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ResourceBoundedExecutorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ResourceBoundedExecutorSuite.scala
@@ -40,7 +40,7 @@ class ResourceBoundedExecutorSuite extends AnyFunSuite with RmmSparkRetrySuiteBa
    * Builds a dummy function that simulates the CPU task, which returns the timestamp of the
    * completion of the task.
    */
-  def buildDummyFn(startBlk: Lock): () => Long = {
+  private def buildDummyFn(startBlk: Lock): () => Long = {
     () => {
       // Block the start of task execution until the lock is released.
       startBlk.lock()


### PR DESCRIPTION
Fixes #13788

This PR stabilizes a flaky unit test whose output was nondeterministic due to runtime fluctuations by introducing a startup lock to enforce a deterministic execution order.