### PR TITLE
Use strict priority in conda process [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -46,11 +46,11 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
-RUN conda init
+RUN conda init && conda config --set channel_priority strict
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
+    conda install -y -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
         cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
     conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -73,11 +73,11 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
-RUN conda init
+RUN conda init && conda config --set channel_priority strict
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
+    conda install -y -c rapidsai-nightly -c nvidia -c conda-forge -c defaults \
         cudf=${CUDF_VER} python=3.10 cuda-version=${CUDA_VER} && \
     conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \


### PR DESCRIPTION
Part of #13892, target 26.02

### Description

Use strict channel priority to try to mitigate some unexpected dep issues.

NOTE: This has been verified internally.