### PR TITLE
[DOC] fix dead link in testing page [skip ci]

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -5,5 +5,5 @@ nav_order: 2
 parent: Developer Overview
 ---
 An overview of testing can be found within the repository at:
-* [Unit tests](../../tests/README.md)
-* [Integration testing](../../integration_tests/README.md)
+* [Unit tests](https://github.com/NVIDIA/spark-rapids/tree/main/tests#readme)
+* [Integration testing](https://github.com/NVIDIA/spark-rapids/tree/main/integration_tests#readme)


### PR DESCRIPTION
Only doc related file can be refer in https://nvidia.github.io/spark-rapids/docs/dev/testing.html
These two files belong to code, so update to absolute link.
The gh-page will update in 2602
fix #13928 