### PR TITLE
[SparkUT]Check Java version to decide the expected string in one case of DataFrameAggregateSuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameAggregateSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameAggregateSuite.scala
@@ -82,4 +82,17 @@ class RapidsDataFrameAggregateSuite extends DataFrameAggregateSuite with RapidsS
     checkAnswer(df.select(sort_array(collect_set("a")) cast ArrayType(FloatType, false)),
       Seq(Row(Seq(1.0, 2.0))))
   }
+
+  testRapids("SPARK-24788: RelationalGroupedDataset.toString " +
+    "with unresolved exprs should not fail") {
+    // Checks if these raise no exception
+    val expected = if (getJavaMajorVersion() >= 11) "" else "GroupBy"
+    assert(testData.groupBy($"key").toString.contains(
+      s"[grouping expressions: [key], value: [key: int, value: string], type: ${expected}]"))
+    assert(testData.groupBy(col("key")).toString.contains(
+      s"[grouping expressions: [key], value: [key: int, value: string], type: ${expected}]"))
+    assert(testData.groupBy(current_date()).toString.contains(
+      "grouping expressions: [current_date(None)], value: [key: int, value: string], " +
+        s"type: ${expected}]"))
+  }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -42,7 +42,7 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("collect functions should be able to cast to array type with no null values", ADJUST_UT("order of elements in the array is non-deterministic in collect"))
     .exclude("SPARK-17641: collect functions should not collect null values", ADJUST_UT("order of elements in the array is non-deterministic in collect"))
     .exclude("SPARK-19471: AggregationIterator does not initialize the generated result projection before using it", WONT_FIX_ISSUE("Codegen related UT, not applicable for GPU"))
-    .exclude("SPARK-24788: RelationalGroupedDataset.toString with unresolved exprs should not fail", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10801"), (getJavaMajorVersion() >= 17))
+    .exclude("SPARK-24788: RelationalGroupedDataset.toString with unresolved exprs should not fail", ADJUST_UT("Replaced by testRapids version that considers the difference of JDK version"))
   enableSuite[RapidsDataFrameComplexTypeSuite]
   enableSuite[RapidsDataFrameNaFunctionsSuite]
   enableSuite[RapidsDataFramePivotSuite]

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestsBaseTrait.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestsBaseTrait.scala
@@ -30,4 +30,18 @@ trait RapidsTestsBaseTrait {
   def shouldRun(testName: String): Boolean = {
     BackendTestSettings.shouldRun(getClass.getCanonicalName, testName)
   }
+
+  protected def getJavaMajorVersion(): Int = {
+    val version = System.getProperty("java.version")
+    // Allow these formats:
+    // 1.8.0_72-ea
+    // 9-ea
+    // 9
+    // 11.0.1
+    val versionRegex = """(1\.)?(\d+)([._].+)?""".r
+    version match {
+      case versionRegex(_, major, _) => major.toInt
+      case _ => throw new IllegalStateException(s"Cannot parse java version: $version")
+    }
+  }
 }


### PR DESCRIPTION
JDK11+ return empty on getSimpleName of the nested defined class 'GroupByType'
JDK8 returns correctly.
Related code: https://github.com/apache/spark/blob/v3.3.0/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala#L634-L641

Check the java major version in the test case and decide the expected string at runtime.

Close #13953 
