### PR TITLE
Reduce the rows number for map Pandas UDF tests with nested types.

### DIFF
--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -333,7 +333,7 @@ def test_pandas_map_udf_nested_type(data_gen):
             })
 
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, data_gen, num_slices=4)\
+        lambda spark: unary_op_df(spark, data_gen, length=800, num_slices=4)\
             .mapInPandas(col_types_udf, schema=udf_out_schema),
         conf=arrow_udf_conf)
 


### PR DESCRIPTION
This is an attempt to try to address https://github.com/NVIDIA/spark-rapids/issues/13939 according to the comment as below from AI.
```
The "Detected deadlock while completing task" error in PySpark with pandas UDFs typically
occurs due to resource contention or parallelism issues during task execution. Here are
common scenarios when this happens:
Primary Causes:
1. Insufficient Executor Memory
...
```
It is a little wierd that Spark detected a dead lock as the error log said
 "**_logWarning - Detected deadlock while completing task 0.0 in stage 13706 (TID 93513): Attempting to kill Python Worker_**"
, since there are no locks used in the `GpuMapInPandasExec` things. And nested type data indeed needs more memory to handle. Then let's try to reduce the memory usage for the tests first.
