### PR TITLE
Make the GPU UDF has different name than the CPU one

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,11 @@ case class GpuScalaUDF(
     udfName: Option[String],
     nullable: Boolean,
     udfDeterministic: Boolean) extends GpuUserDefinedFunction {
-  override def toString: String = s"${udfName.getOrElse("UDF")}(${children.mkString(", ")})"
+  override def toString: String = s"${name}(${children.mkString(", ")})"
 
   /** name of the UDF function */
-  override val name: String = udfName.getOrElse("???")
+  override val name: String = udfName.map(cpuName => s"gpu_$cpuName")
+    .getOrElse(this.getClass.getSimpleName)
 }
 
 object GpuScalaUDFMeta {
@@ -151,7 +152,8 @@ case class GpuRowBasedScalaUDF(
   override def toString: String = s"$name(${children.mkString(", ")})"
 
   /** name of the UDF function */
-  override val name: String = udfName.getOrElse(this.getClass.getSimpleName)
+  override val name: String = udfName.map(cpuName => s"gpu_row_based_$cpuName")
+    .getOrElse(this.getClass.getSimpleName)
 
   /** The input `row` consists of only child columns. */
   override final protected def evaluateRow(childrenRow: InternalRow): Any =


### PR DESCRIPTION
This PR adds the GPU specific prefix to the UDF name to make it differ from the CPU one.

Some customers want to know if the [GpuRowBasedUDF](https://github.com/NVIDIA/spark-rapids/blob/main/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala#L94) is applied from the physical plan in the eventlog other than the explain log in the driver. But the GPU UDF has the same name as the CPU, so it is not easy to achieve this for their tools. This PR will add this type of support.