### PR TITLE
Skip test_delta_filter_out_metadata_col on [databricks] 

### DIFF
--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -178,9 +178,7 @@ def test_delta_filter_out_metadata_col(spark_tmp_path):
 
     def read_table(spark):
         df = spark.sql(f"SELECT * FROM delta.`{data_path}`")
-        explain_string = df._sc._jvm.PythonSQLUtils.explainString(df._jdf.queryExecution(), "extended")
-        assert "__delta_internal_is_row_deleted" in explain_string or \
-            "_databricks_internal_edge_computed_column_skip_row" in explain_string
+        assert "__delta_internal_is_row_deleted" in df._sc._jvm.PythonSQLUtils.explainString(df._jdf.queryExecution(), "extended")
         return df
 
     with_cpu_session(create_delta)


### PR DESCRIPTION
### Description

A recently introduced test in #13991 is irrelevant for DBR as we currently don't support Deletion Vectors on DBR. This PR skips the test on DBR and for versions of Spark that don't support Deletion Vectors

### Checklists


- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
