### PR TITLE
support withRetry with split for GPU shuffle coalesce

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/13951 (along with https://github.com/NVIDIA/spark-rapids/pull/13975)

### Description

Use `AutoCloseableTargetSize` to create a split policy which would halve the target size of an incoming batch when doing a split retry.

Performance testing so far shows no significant change for low memory scenarios in NDS. I'll continue with perf testing while the PR is under review.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
