### PR TITLE
Adds ignore_order for groupBy agg test that returns multiple rows [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2885,6 +2885,7 @@ def test_avg_long_ansi_groupby_overflow():
 
 
 @approximate_float
+@ignore_order
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_type', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(4,0), DecimalGen(10,0), DecimalGen(12,0), DecimalGen(38,0)], ids=idfn)
 def test_avg_divide_by_zero(data_type, ansi):


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14043

### Description

The test test_avg_divide_by_zero performs a groupBy("k") which returns multiple rows (k=0 and k=1), but it does NOT use @ignore_order, which means that we've been getting lucky in the ordering. That said https://github.com/NVIDIA/spark-rapids/issues/14043 documents a failure where spark 3.3.0 and Databricks is returning a different order. Since the order of the keys isn't deterministic, I added an `@ignore_order`.

The unit test was added here https://github.com/NVIDIA/spark-rapids/pull/13192

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
