### PR TITLE
Kudo supports schema check when serializing batches [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -408,13 +408,11 @@ private class KudoSerializerInstance(
         // the kudo serializer. But if they become different in some cases unintentionally,
         // the kudo shuffle can easily run into errors. e.g. the negative "numRows" error.
         // Then enable this to figure out if the error is caused by mismatched batches.
-        closeOnExcept(batch) { _ =>
-          val actualTypes = GpuColumnVector.extractTypes(batch)
-          if (!dataTypes.sameElements(actualTypes)) {
-            throw new IllegalStateException(s"Kudo writer got a mismatched batch, types: " +
-              s"[${actualTypes.mkString("; ")}], but expected types: " +
-              s"[${dataTypes.mkString("; ")}].")
-          }
+        val actualTypes = GpuColumnVector.extractTypes(batch)
+        if (!dataTypes.sameElements(actualTypes)) {
+          throw new IllegalStateException(s"Kudo writer got a mismatched batch, types: " +
+            s"[${actualTypes.mkString("; ")}], but expected types: " +
+            s"[${dataTypes.mkString("; ")}].")
         }
       }
       val numColumns = batch.numCols()


### PR DESCRIPTION
This PR adds in the schema check support to Kudo serializer when serializing batches.

This behavior is for kudo shuffle debugging and disabled by default for performance, but can be enabled by setting the Java property `ai.rapids.kudo.debug.ser.checkSchema` to 'true'.

This is to ensure the written batch has the same schema with the given one used to create the kudo serializer. and these two schemas should be always the same. But if they become different in some cases unintentionally, the kudo shuffle can easily run into errors. e.g. the negative `numRows` error as below.
```
  Cause: java.lang.IllegalArgumentException: numRows must be >= 0, but was -159
  at com.nvidia.spark.rapids.jni.kudo.SlicedValidityBufferInfo.calc(SlicedValidityBufferInfo.java:57)
  at com.nvidia.spark.rapids.jni.kudo.SliceInfo.<init>(SliceInfo.java:27)
  at com.nvidia.spark.rapids.jni.kudo.MergedInfoCalc$SingleTableVisitor.preVisitList(MergedInfoCalc.java:251)
  at com.nvidia.spark.rapids.jni.schema.Visitors.visitSchemaInner(Visitors.java:76)
  at com.nvidia.spark.rapids.jni.schema.Visitors.visitSchema(Visitors.java:61)
  at com.nvidia.spark.rapids.jni.kudo.MergedInfoCalc.doCalc(MergedInfoCalc.java:60)
```
Then we can leverage this feature to figure out if it is caused by mismatched batches being serialized for Shuffle.