### PR TITLE
Fix metric display for data sizes exceeding TB (#14078)

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -66,7 +66,7 @@ case class SizeInBytes(value: jl.Long) {
 }
 
 private object SizeInBytes {
-  private val SizeUnitNames: Array[String] = Array("B", "KB", "MB", "GB", "TB")
+  private val SizeUnitNames: Array[String] = Array("B", "KB", "MB", "GB", "TB", "PB", "EB")
 }
 
 class NanoSecondAccumulator extends AccumulatorV2[jl.Long, NanoTime] {


### PR DESCRIPTION
Add PB (Petabyte) and EB (Exabyte) units to SizeInBytes.SizeUnitNames to correctly format very large data sizes in metrics.

Previously, data sizes over 1TB would display with large TB values (e.g., 1024.00TB) instead of proper larger units (e.g., 1.00PB).

Fixes #14078