### PR TITLE
Set JDK 17 as the default for nightly builds across both scala2.12 and scala2.13

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -23,11 +23,10 @@ export MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentC
 . jenkins/version-def.sh
 
 # Set JDK 17 as the default for nightly builds across both:
-# scala2.12 (with maven.compiler.source as 1.8)
-# and scala2.13
+# scala2.12 and scala2.13 (with maven.compiler.source as 1.8)
 export JAVA_HOME=$(echo /usr/lib/jvm/java-1.17.0-*)
 update-java-alternatives --set $JAVA_HOME
-java -version
+mvn -version
 
 DIST_PL="dist"
 DIST_PATH="$DIST_PL" # The path of the dist module is used only outside of the mvn cmd


### PR DESCRIPTION
Update nightly build to use 17 as default JDK version and keep 
`maven.compiler.source` as 1.8 and `java.major.version` as 8 for scala build,
```
<plugin>
  <groupId>net.alchim31.maven</groupId>
  <artifactId>scala-maven-plugin</artifactId>
  <version>${scala.plugin.version}</version>
  <configuration>
  <release>${java.major.version}</release>
  </configuration>
</plugin>
```

NOTE: Databricks runtimes require forcing APT cache cleanup to avoid mismatched available JDK packages with remote Ubuntu repositories.