### PR TITLE
Fix Iceberg view test failures in CICD

### DIFF
--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -118,6 +118,10 @@ def is_not_utc():
 def is_iceberg_remote_catalog():
     v = os.environ.get('ICEBERG_TEST_REMOTE_CATALOG')
     return v == "1"
+
+def is_iceberg_rest_catalog():
+    v = os.environ.get('ICEBERG_TEST_CATALOG_TYPE')
+    return v == "rest"
 
 # key is time zone, value is recorded boolean value
 _support_info_cache_for_time_zone = {}

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -296,6 +296,7 @@ run_iceberg_tests() {
     ICEBERG_REST_JARS="org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_${SCALA_BINARY_VER}:${ICEBERG_VERSION},\
 org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
         env \
+          ICEBERG_TEST_CATALOG_TYPE="rest" \
           ICEBERG_TEST_REMOTE_CATALOG=1 \
           PYSP_TEST_spark_driver_memory=6G \
           PYSP_TEST_spark_executor_memory=6G \


### PR DESCRIPTION
Fixes #14075.

### Description

#### why pipelines failed

For pipelines: `rapids_it-iceberg-s3tables-dev` and `rapids_it-iceberg-dev`
pipeline 1.6.x passed, but 1.9.x failed.

From Iceberg 1.9.x, using hadoop type with SparkSessionCatalog will fail with:
    "Creating a view is not supported by catalog: spark_catalog"
Iceberg 1.9.x changed the behavior.  

For S3TableCatalog, it also does not support view, tested, trying to create a view in `s3_catalog`.`namespace` also fails with: "Creating a view is not supported by catalog"

#### how to fix
Only test `rest` catalog, skip `hadoop` and `s3table` catalog.
`rest` catalog supports view.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
