### PR TITLE
Fix compile error in `HashFunctions.scala`

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
@@ -134,7 +134,7 @@ case class GpuSha2(left: Expression, right: Expression)
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
-    withResource(GpuColumnVector.from(lhs, numRows, lhs.dataType)) {
+    withResource(GpuColumnVector.from(lhs, numRows)) {
       doColumnar(_, rhs)
     }
   }


### PR DESCRIPTION
This commit fixes a compile error in `HashFunctions.scala`.

The error was introduced in #14038 (which introduced SHA2 support in `HashFunctions`).  It was caused by a change in the signature of `GpuColumnVector.from(GpuScalar, int...)` introduced in #14086.

The changes in #14086 were merged in the time between:
1. The CI build (passing) for #14038, and
2. The time #14038 was merged.

This commit uses the improved function signature.  No functionality has been modified.  None of the tests need be changed here.
