### PR TITLE
[AutoSparkUT]Enable several UT Suites

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsArithmeticExpressionSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsArithmeticExpressionSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.catalyst.expressions.ArithmeticExpressionSuite
+import org.apache.spark.sql.rapids.utils.RapidsTestsTrait
+
+/**
+ * RAPIDS GPU tests for arithmetic expressions.
+ *
+ * This test suite validates arithmetic expression execution on GPU.
+ * It extends the original Spark ArithmeticExpressionSuite to ensure GPU implementation
+ * produces the same results as CPU.
+ *
+ * Original Spark test:
+ *  sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/
+ *    ArithmeticExpressionSuite.scala
+ * Test count: 56 tests
+ *
+ * Migration notes:
+ * - ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper,
+ *   so we use RapidsTestsTrait
+ * - This test suite covers:
+ *   - Basic arithmetic: Add, Subtract, Multiply, Divide, Remainder
+ *   - Unary operations: UnaryMinus, UnaryPositive, Abs
+ *   - Decimal arithmetic with precision and scale handling
+ *   - Interval arithmetic (year-month and day-time intervals)
+ *   - Overflow handling in ANSI mode
+ *   - Special value handling (null, infinity, NaN)
+ *   - Pmod (positive modulo) operation
+ */
+class RapidsArithmeticExpressionSuite
+  extends ArithmeticExpressionSuite
+  with RapidsTestsTrait {
+  // All 56 tests from ArithmeticExpressionSuite will be inherited and run on GPU
+  // The checkEvaluation method is overridden in RapidsTestsTrait to execute on GPU
+  // GPU-specific arithmetic configuration is handled by RapidsTestsTrait
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsComplexTypeSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsComplexTypeSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.catalyst.expressions.ComplexTypeSuite
+import org.apache.spark.sql.rapids.utils.RapidsTestsTrait
+
+/**
+ * RAPIDS GPU tests for complex type expressions.
+ *
+ * This test suite validates complex type expression execution on GPU.
+ * It extends the original Spark ComplexTypeSuite to ensure GPU implementation
+ * produces the same results as CPU.
+ *
+ * Original Spark test:
+ *  sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/
+ *    ComplexTypeSuite.scala
+ * Test count: 19 tests
+ *
+ * Migration notes:
+ * - ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper,
+ *   so we use RapidsTestsTrait
+ * - This test suite covers:
+ *   - Array access: GetArrayItem
+ *   - Map access: GetMapValue
+ *   - Struct field extraction: GetStructField
+ *   - Array/Map/Struct creation
+ *   - Complex type operations with null handling
+ *   - Nested complex types
+ */
+class RapidsComplexTypeSuite
+  extends ComplexTypeSuite
+  with RapidsTestsTrait {
+  // All 19 tests from ComplexTypeSuite will be inherited and run on GPU
+  // The checkEvaluation method is overridden in RapidsTestsTrait to execute on GPU
+  // GPU-specific complex type configuration is handled by RapidsTestsTrait
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsHashExpressionsSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsHashExpressionsSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.catalyst.expressions.HashExpressionsSuite
+import org.apache.spark.sql.rapids.utils.RapidsTestsTrait
+
+/**
+ * RAPIDS GPU tests for hash expressions.
+ *
+ * This test suite validates hash expression execution on GPU.
+ * It extends the original Spark HashExpressionsSuite to ensure GPU implementation
+ * produces the same results as CPU.
+ *
+ * Original Spark test:
+ *  sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/
+ *    HashExpressionsSuite.scala
+ * Test count: 25 tests
+ *
+ * Migration notes:
+ * - HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper,
+ *   so we use RapidsTestsTrait
+ * - This test suite covers:
+ *   - Hash functions: md5, sha1, sha2, crc32
+ *   - Murmur3 hash (32-bit and 128-bit)
+ *   - xxHash64
+ *   - Hive hash
+ *   - Hash consistency across different data types
+ *   - Hash with complex types (arrays, maps, structs)
+ *   - Hash with null values
+ */
+class RapidsHashExpressionsSuite
+  extends HashExpressionsSuite
+  with RapidsTestsTrait {
+  // All 25 tests from HashExpressionsSuite will be inherited and run on GPU
+  // The checkEvaluation method is overridden in RapidsTestsTrait to execute on GPU
+  // GPU-specific hash configuration is handled by RapidsTestsTrait
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsIntervalExpressionsSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsIntervalExpressionsSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.catalyst.expressions.IntervalExpressionsSuite
+import org.apache.spark.sql.rapids.utils.RapidsTestsTrait
+
+/**
+ * RAPIDS GPU tests for interval expressions.
+ *
+ * This test suite validates interval expression execution on GPU.
+ * It extends the original Spark IntervalExpressionsSuite to ensure GPU implementation
+ * produces the same results as CPU.
+ *
+ * Original Spark test:
+ *  sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/
+ *    IntervalExpressionsSuite.scala
+ * Test count: 20 tests
+ *
+ * Migration notes:
+ * - IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper,
+ *   so we use RapidsTestsTrait
+ * - This test suite covers:
+ *   - Extract interval components: years, months, days, hours, minutes, seconds
+ *   - Year-month interval operations
+ *   - Day-time interval operations
+ *   - Interval multiplication and division
+ *   - Make interval functions
+ *   - Interval type conversions and coercion
+ */
+class RapidsIntervalExpressionsSuite
+  extends IntervalExpressionsSuite
+  with RapidsTestsTrait {
+  // All 20 tests from IntervalExpressionsSuite will be inherited and run on GPU
+  // The checkEvaluation method is overridden in RapidsTestsTrait to execute on GPU
+  // GPU-specific interval configuration is handled by RapidsTestsTrait
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPredicateSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsPredicateSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.catalyst.expressions.PredicateSuite
+import org.apache.spark.sql.rapids.utils.RapidsTestsTrait
+
+/**
+ * RAPIDS GPU tests for predicate expressions.
+ *
+ * This test suite validates predicate expression execution on GPU.
+ * It extends the original Spark PredicateSuite to ensure GPU implementation
+ * produces the same results as CPU.
+ *
+ * Original Spark test:
+ *  sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/
+ *    PredicateSuite.scala
+ * Test count: 30 tests
+ *
+ * Migration notes:
+ * - PredicateSuite extends SparkFunSuite with ExpressionEvalHelper,
+ *   so we use RapidsTestsTrait
+ * - This test suite covers:
+ *   - Boolean logic: AND, OR, NOT
+ *   - Three-valued logic (3VL) with NULL handling
+ *   - Comparison operators: =, <>, <, <=, >, >=
+ *   - IN and INSET predicates
+ *   - BETWEEN predicate
+ *   - NULL-safe equality (<=>)
+ *   - Like patterns and regex matching
+ *   - IsNull, IsNotNull, IsNaN predicates
+ */
+class RapidsPredicateSuite
+  extends PredicateSuite
+  with RapidsTestsTrait {
+  // All 30 tests from PredicateSuite will be inherited and run on GPU
+  // The checkEvaluation method is overridden in RapidsTestsTrait to execute on GPU
+  // GPU-specific predicate configuration is handled by RapidsTestsTrait
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -27,6 +27,12 @@ import org.apache.spark.sql.rapids.suites._
 
 class RapidsTestSettings extends BackendTestSettings {
 
+  enableSuite[RapidsArithmeticExpressionSuite]
+  enableSuite[RapidsComplexTypeSuite]
+    .exclude("CreateMap", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14140"))
+  enableSuite[RapidsHashExpressionsSuite]
+  enableSuite[RapidsIntervalExpressionsSuite]
+  enableSuite[RapidsPredicateSuite]
   enableSuite[RapidsCastSuite]
     .exclude("SPARK-35711: cast timestamp without time zone to timestamp with local time zone", WONT_FIX_ISSUE("https://issues.apache.org/jira/browse/SPARK-40851"))
     .exclude("SPARK-35719: cast timestamp with local time zone to timestamp without timezone", WONT_FIX_ISSUE("https://issues.apache.org/jira/browse/SPARK-40851"))


### PR DESCRIPTION
Enable below suites:
- RapidsArithmeticExpressionSuite
- RapidsComplexTypeSuite
- RapidsHashExpressionsSuite
- RapidsIntervalExpressionsSuite
- RapidsPredicateSuite

Only RapidsComplexTypeSuite has a failed case. Filed issue https://github.com/NVIDIA/spark-rapids/issues/14140