### PR TITLE
Add in the proper output ordering and partitioning to GpuWindowLimitExec

### DIFF
--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuWindowGroupLimitExec.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuWindowGroupLimitExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This Fixes https://github.com/NVIDIA/spark-rapids/issues/14160

### Description
We missed these when we created the code and it ended up causing us to have an extra sort in the plan. In practice this sort usually had little impact to the overall run time, but it was far from non-zero and it is a simple fix.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.


There is no need for more tests, documentation or performance testing. We were doing extra work before and now we are doing less of it. If the code still works that is great.