### PR TITLE
Fix failed cases due to Spark 41x changed the default mode from unsafe to safe

### DIFF
--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -52,6 +52,12 @@ arrow_udf_conf = {
     'spark.rapids.sql.exec.FlatMapCoGroupsInPandasExec': 'true'
 }
 
+# From Spark 41x, Spark uses stricter checker by default,
+# this is a workaround solution to pass some cases,
+# e.g.: Int64 + Int64 can cause overflow, and thus fail when use stricter checker on Spark 411
+arrow_udf_conf_unsafe = copy_and_update(arrow_udf_conf,
+                                        {'spark.sql.execution.pandas.convertToArrowArraySafely': 'false'})
+
 data_gens_nested_for_udf = arrow_array_gens + arrow_struct_gens
 
 ####################################################################
@@ -70,7 +76,9 @@ def test_pandas_math_udf(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen, num_slices=4).select(
                 my_udf(f.col('a'), f.col('b'))),
-            conf=arrow_udf_conf)
+            # use unsafe mode to avoid overflow
+            # int64 + int64 can overflow when return type is long type
+            conf=arrow_udf_conf_unsafe)
 
 
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
@@ -83,7 +91,9 @@ def test_iterator_math_udf(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen, num_slices=4).select(
                 my_udf(f.col('a'), f.col('b'))),
-            conf=arrow_udf_conf)
+            # use unsafe mode to avoid overflow
+            # int64 + int64 can overflow when return type is long type
+            conf=arrow_udf_conf_unsafe)
 
 
 @pytest.mark.parametrize('data_gen', data_gens_nested_for_udf, ids=idfn)
@@ -201,7 +211,8 @@ def test_window_aggregate_udf(data_gen, window):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: binary_op_df(spark, data_gen).select(
             pandas_sum(f.col('b')).over(window)),
-        conf=arrow_udf_conf)
+        # use unsafe mode to avoid overflow
+        conf=arrow_udf_conf_unsafe)
 
 
 @ignore_order
@@ -270,7 +281,8 @@ def test_group_apply_udf(data_gen):
             lambda spark : binary_op_df(spark, data_gen)\
                     .groupBy('a')\
                     .applyInPandas(pandas_add, schema="a long, b long"),
-            conf=arrow_udf_conf)
+            # use unsafe mode to avoid overflow
+            conf=arrow_udf_conf_unsafe)
 
 
 @ignore_order(local=True)
@@ -297,7 +309,8 @@ def test_map_apply_udf(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen, num_slices=4)\
                     .mapInPandas(pandas_filter, schema="a long, b long"),
-            conf=arrow_udf_conf)
+            # use unsafe mode to avoid overflow
+            conf=arrow_udf_conf_unsafe)
 
 
 @ignore_order(local=True)
@@ -504,4 +517,4 @@ def test_pandas_math_udf_with_rand():
         # Ensure there is only one partition to make the output comparable.
         lambda spark: unary_op_df(spark, int_gen, length=10, num_slices=1).select(
             my_udf(f.rand(42))),
-        conf=arrow_udf_conf)
+        conf=arrow_udf_conf_unsafe)


### PR DESCRIPTION
Contributes to #14135

### Description
From Spark 41x, it changes the default mode from unsafe to safe, so some cases failed.
This PR set disable `spark.sql.execution.pandas.convertToArrowArraySafely` to pass the ITs.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
