### PR TITLE
[Spark 4.1.1] Fallback BloomFilter operations to CPU when V1/V2 format incompatibility may occur

### DIFF
--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -255,6 +255,9 @@ def is_spark_400_or_later():
 def is_spark_401_or_later():
     return spark_version() >= "4.0.1"
 
+def is_spark_411_or_later():
+    return spark_version() >= "4.1.1"
+
 def is_spark_330():
     return spark_version() == "3.3.0"
 

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterFallbackShim.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterFallbackShim.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "400"}
+{"spark": "401"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids.RapidsConf
+
+/**
+ * BloomFilter fallback check for Spark 3.3.0 - 4.0.1.
+ * These versions use V1 format, so no special fallback is needed.
+ */
+object BloomFilterFallbackShim {
+  
+  /**
+   * Check if BloomFilter operations must fall back to CPU.
+   * For Spark 3.3.0 - 4.0.1, always returns false since they use V1 format
+   * which is compatible with GPU.
+   */
+  def mustFallbackToCpu(conf: RapidsConf): Boolean = false
+  
+  /** Fallback message (not used for pre-4.1.1 versions) */
+  val fallbackMessage: Option[String] = None
+}

--- a/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/BloomFilterFallbackShim.scala
+++ b/sql-plugin/src/main/spark411/scala/com/nvidia/spark/rapids/shims/BloomFilterFallbackShim.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids.RapidsConf
+
+/**
+ * BloomFilter fallback check for Spark 4.1.1.
+ * 
+ * Spark 4.1.1 uses BloomFilter V2 format (SPARK-47547) by default. The GPU implementation
+ * only produces V1 format. This works fine when BOTH build (BloomFilterAggregate) and 
+ * probe (BloomFilterMightContain) are on GPU.
+ * 
+ * However, if partial/final aggregates are split between CPU and GPU:
+ * - GPU partial aggregate produces V1 format
+ * - CPU final aggregate expects V2 format
+ * - Spark throws IncompatibleMergeException: "Cannot merge bloom filter of class BloomFilterImpl"
+ * 
+ * Therefore, when replaceMode is not "all", BOTH BloomFilterAggregate and 
+ * BloomFilterMightContain must fall back to CPU to ensure consistent V2 format.
+ * 
+ * See: https://github.com/NVIDIA/spark-rapids/issues/14148
+ */
+object BloomFilterFallbackShim {
+  
+  /**
+   * Check if BloomFilter operations must run entirely on CPU.
+   * This happens when the partial/final aggregates might be split between CPU and GPU,
+   * which would cause V1/V2 format incompatibility.
+   */
+  def mustFallbackToCpu(conf: RapidsConf): Boolean = {
+    // Check if BloomFilterAggregate is explicitly disabled
+    val bloomFilterAggKey = "spark.rapids.sql.expression.BloomFilterAggregate"
+    val isExplicitlyDisabled = !conf.isOperatorEnabled(bloomFilterAggKey, 
+      incompat = false, isDisabledByDefault = false)
+    
+    // Check if hashAgg.replaceMode is set to partial or final (not "all" which is the default)
+    // This causes partial/final aggregates to be split between CPU and GPU,
+    // leading to V1/V2 format incompatibility
+    val replaceMode = conf.hashAggReplaceMode.toLowerCase
+    val isReplaceModeRestricted = replaceMode != "all"
+    
+    isExplicitlyDisabled || isReplaceModeRestricted
+  }
+  
+  /** Fallback message for Spark 4.1.1 */
+  val fallbackMessage: Option[String] = Some(
+    "BloomFilter operations must run on CPU when " +
+    "spark.rapids.sql.hashAgg.replaceMode is not 'all' or BloomFilterAggregate is disabled, " +
+    "because Spark 4.1.1 uses V2 bloom filter format which is incompatible with GPU's V1 format.")
+}


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/14135 and 

### Description
This PR adds conditional CPU fallback for BloomFilter operations in Spark 4.1.1 to handle the V1/V2 format incompatibility.

### Background

Spark 4.1.1 uses BloomFilter V2 format by default, while the GPU implementation produces V1 format. This works correctly when **both** `BloomFilterAggregate` (build) and `BloomFilterMightContain` (probe) run on GPU.

However, when partial/final aggregates are split between CPU and GPU, the GPU produces V1 format while CPU expects V2 format, causing Spark to throw `Exception`.

### Solution

This PR introduces a shim-based fallback mechanism. For Spark 4.1.1, when `BloomFilterAggregate` is explicitly disabled or `spark.rapids.sql.hashAgg.replaceMode` is set to `partial` or `final` i.e not set to `all`, both `BloomFilterAggregate` and `BloomFilterMightContain` fall back to CPU to ensure consistent V2 format usage. 

Integration tests have been updated to validate correct behavior across Spark versions, with version-specific expected classes for the bloom filter CPU build tests.

All the bloom_filter_tests pass with this PR:
Before this PR:

```
============================================= 12 failed, 16 passed, 284 warnings in 53.44s ==============================================

```


With this PR:

```
================================================== 28 passed, 426 warnings in 49.62s ==================================================
```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
