### PR TITLE
BroadcastExchangeExec should not reset metrics [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -518,6 +518,12 @@ abstract class GpuBroadcastExchangeExecBase(
     Statistics(
       sizeInBytes = metrics("dataSize").value,
       rowCount = Some(metrics(GpuMetric.NUM_OUTPUT_ROWS).value))
+  }
+
+  override def resetMetrics(): Unit = {
+    // no-op
+    // BroadcastExchangeExec after materialized won't be materialized again, so we should not
+    // reset the metrics. Otherwise, we will lose the metrics collected in the broadcast job.
   }
 
   override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {


### PR DESCRIPTION
Fixes #14037.

### Description
Cherry-pick code from Spark.
BroadcastExchangeExec after materialized won't be materialized again, so we should not reset the metrics.
Cherry-pick to `GpuBroadcastExchangeExecBase`.
The https://github.com/apache/spark/commit/a823f95c522 targets Spark 4.1, because it's a common fix,
we do not only add this to 411 shim, the change applies to all Spark versions.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      It's only related to metrics, so do not impact any feature.
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
