### PR TITLE
Spark-4.1.1: Resolve integration tests in map_test.py and bloom_filter tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/14135

### Description
This PR fixes integration test failures in Spark 4.1.1 related to map_test.py and temporarily disables some of the bloom filter tests that fail due to an upstream format change.

### Checklists
1. Failures in map_test.py:
In Spark 4.1.1, SQLConf.MAP_KEY_DEDUP_POLICY returns an enum value instead of a String. The existing code compared directly against a String value which failed on Spark 4.1.1. Changed the comparison to use `.toString.toUpperCase` to fix the failures.

2. Failures in bloom filter tests:
   Spark 4.1.1 introduced BloomFilter V2 format via SPARK-47547, which is not yet supported by spark-rapids-jni. The failing tests 
explicitly fall off GPU for BloomFilterAggregate in one case and in another case this only seems to happen if hashAgg.replaceMode is set to partial/final. So the actual queries if run on GPU will still run V1 format. More discussion about it in the github issue- https://github.com/NVIDIA/spark-rapids/issues/14148#issuecomment-3781545120

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
