### PR TITLE
Shrink size of integration images and provide dedicated environment for cudf-udf cases [skip ci]

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 pytest
 sre_yield
 pandas
-pytz
 pyarrow == 17.0.0 ; python_version == '3.8'
 pyarrow == 19.0.1 ; python_version >= '3.9'
 pytest-xdist >= 2.0.0

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -48,7 +48,7 @@ ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda init && conda config --set channel_priority strict
 
-# Base python version as 3.10 to keep compatibity with spark330
+# Base python version as 3.10 to keep compatibility with spark330
 RUN conda install -y -c conda-forge -c anaconda -c defaults \
         python=3.10 && \
     conda clean -ay

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -75,7 +75,7 @@ ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda init && conda config --set channel_priority strict
 
-# Base python version as 3.10 to keep compatibity with spark330
+# Base python version as 3.10 to keep compatibility with spark330
 RUN conda install -y -c conda-forge -c anaconda -c defaults \
         python=3.10 && \
     conda clean -ay

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -487,7 +487,7 @@ fi
 # cudf_udf test: this mostly depends on cudf-py, so we run it into an independent CI
 if [[ "$TEST_MODE" == "CUDF_UDF_ONLY" ]]; then
   # Create a separate conda env for cudf-udf tests to avoid affecting the base env (python 3.10)
-  CUDF_UDF_ENV="cudf_udf"
+  CUDF_UDF_ENV="cudf_udf_$(date +"%Y%m%d")"
   CUDF_UDF_PYTHON_VER="3.12"  # since 26.04, python 3.12+ is required for cudf-py
   CUDF_VER=$(echo "${PROJECT_VER}" | cut -d '.' -f 1,2)
   CUDA_VER_FOR_CUDF=${CUDA_VER_FOR_CUDF:-'12.9'}


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14236

### Description
follow-up of https://docs.rapids.ai/notices/rsn0058/

We will maintain Python 3.10 as the default version in our regular CI to ensure compatibility with Spark 3.3.0+. For cudf-udf test cases, we will update to python 3.12 and test agasint spark350+

1. Maintain python 3.10 for regular integration tests covering Spark 3.3.0 to 4.1.1
2. Provide a dedicated conda environment (python 3.12) for cudf-udf tests only
3. Reduce image sizes through environment isolation

