### PR TITLE
[SPARK-54220] Xfail null_list.parquet for Spark 4.1.0+ due to array<void> inference

### DIFF
--- a/integration_tests/src/main/python/parquet_testing_test.py
+++ b/integration_tests/src/main/python/parquet_testing_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ from data_gen import copy_and_update, non_utc_allow
 from marks import allow_non_gpu
 from pathlib import Path
 import pytest
-from spark_session import is_before_spark_330, is_spark_350_or_later
+from spark_session import is_before_spark_330, is_spark_350_or_later, is_spark_411_or_later
 import warnings
 
 _rebase_confs = {
@@ -72,6 +72,12 @@ if is_spark_350_or_later():
 else:
     _error_files["lz4_raw_compressed.parquet"] = "Exception"
     _error_files["lz4_raw_compressed_larger.parquet"] = "Exception"
+
+if is_spark_411_or_later():
+    # XFAIL null_list.parquet for Spark 4.1.0+ due to https://github.com/NVIDIA/spark-rapids/issues/14242
+    # Before Spark 4.1.0, infers array<int>  type for the null_list.parquet,
+    # After Spark 4.1.0+, infers array<void> type for the null_list.parquet
+    _xfail_files["null_list.parquet"] = "https://github.com/NVIDIA/spark-rapids/issues/14242"
 
 def hdfs_glob(path_str, pattern):
     """


### PR DESCRIPTION
Closes #14233

## Description
This PR addresses test failures in `test_parquet_testing_valid_files` for `null_list.parquet` on Spark 4.1.0+.

## Root Cause
**SPARK-54220** introduced correct NullType/VOID/UNKNOWN type support in Parquet schema inference starting from Spark 4.1.0. This upstream change causes different schema inference behavior:

- **Spark 3.5.0 - 4.0.x**: Incorrectly infers `array<int>` for null arrays with UNKNOWN logical type
- **Spark 4.1.0+**: Correctly infers `array<void>` for null arrays with UNKNOWN logical type (per SPARK-54220)

The `null_list.parquet` file from the `parquet-testing` repository has a physical schema with `optional int32 item` but uses the UNKNOWN logical type annotation. RAPIDS plugin does not support `array<void>` on GPU (TypeSig.NULL is not included in nested types for Parquet cudfRead), causing the test to fail with:

```
IllegalArgumentException: Part of the plan is not columnar class org.apache.spark.sql.execution.ColumnarToRowExec
ReadSchema: struct<emptylist:array<void>>
```

## Solution
Add a version-conditional xfail for `null_list.parquet` on Spark 4.1.0+ to reflect the upstream schema inference improvement and RAPIDS' current limitation with `array<void>` support.

## Changes
- Updated `parquet_testing_test.py` to xfail `null_list.parquet` for Spark 4.1.0+
- Added `is_spark_411_or_later()` import
- Updated copyright year to 2026

## Related Issues
- Related to #14242 (audit issue for SPARK-54220)

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.

Signed-off-by: Chong Gao <res_life@163.com>