### PR TITLE
Fetch the PRs for each commit in parallel to generate the CHANGELOG [skip ci]

### DIFF
--- a/scripts/generate-changelog
+++ b/scripts/generate-changelog
@@ -252,8 +252,9 @@ def get_pr_via_commits(ver_commits: set, token: str):
         for res in pr_iterators:
             commit = ''
             try:
-                commit = res.json()['data']['repository']['commit']['abbreviatedOid']
-                pr_item = res.json()['data']['repository']['commit']['associatedPullRequests']['edges'][0]['node']
+                data = res.json()
+                commit = data['data']['repository']['commit']['abbreviatedOid']
+                pr_item = data['data']['repository']['commit']['associatedPullRequests']['edges'][0]['node']
                 pr_item['ver'] = version
                 # Handle the case of multiple commits being associated with the same PR
                 if pr_item not in pr_list and pr_item['mergedAt'] is not None:


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids/issues/14265

Fetch the PRs using multiple threads to significantly reduce the overall execution time.

```
-------Current time cost: 210s----------

real    3m28.977s
user    0m13.895s
sys     0m0.153s

---------Time cost after the change: 15s--------

real    0m14.019s
user    0m18.916s
sys     0m0.258s
```