### PR TITLE
Fix combining small files when reading Delta tables using multi-threaded reader

### DIFF
--- a/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase.scala
@@ -237,11 +237,11 @@ class GpuDeltaParquetFileFormatBase(
       fileScan.allMetrics,
       useMetadataRowIndex = false,
       tablePath,
-      // queryUsesInputFile is used to enable combining small files in the multi-threaded reader.
+      // queryUsesInputFile is used to disable combining small files in the multi-threaded reader.
       // When it is true, combining small files is disabled. Since we don't currently support
       // combining small files with deletion vectors, we need to disable it when deletion vectors
       // exist (which is when tablePath is defined).
-      queryUsesInputFile = tablePath.isEmpty && fileScan.queryUsesInputFile)
+      queryUsesInputFile = hasTablePath || fileScan.queryUsesInputFile)
   }
 
   /**


### PR DESCRIPTION
Fixes #14267.

### Description

The multi-threaded reader currently has the `queryUsesInputFile` flag fixed to true for Delta. This was added in https://github.com/NVIDIA/spark-rapids/pull/13491 to disable the combining of small files when reading Delta tables with deletion vectors. However, how the logic is implemented is disabling it even when there is no deletion vector. This introduced a performance regression in 25.10.

This PR fixes this bug. I tested the fix manually by running NDS in my workstation and comparing performance against the main branch without the fix (c125e895b). Here is the result.


| | NDS run time (ms) |
|---|---|
| without fix | 640000 |
| with fix | 342000 |

I'm not sure how to add an automated test for this fix. Welcome any suggestion.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
