### PR TITLE
Release GPU semaphore before host IO to reduce GPU bubbles

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -841,6 +841,9 @@ abstract class MultiFileCloudPartitionReaderBase(
 
         // Temporary until we get more to read
         batchIter = EmptyGpuColumnarBatchIterator
+        // Release the GPU semaphore before waiting for async IO or host work,
+        // allowing other tasks to use the GPU while we wait for data.
+        GpuSemaphore.releaseIfNecessary(TaskContext.get())
         // if we have batch left from the last file read return it
         if (currentFileHostBuffers.isDefined) {
           readBuffersToBatch(currentFileHostBuffers.get, false)
@@ -1231,6 +1234,9 @@ abstract class MultiFileCoalescingPartitionReaderBase(
       return true
     }
     batchIter = EmptyGpuColumnarBatchIterator
+    // Release the GPU semaphore before host IO for the next batch,
+    // allowing other tasks to use the GPU while we read from disk.
+    GpuSemaphore.releaseIfNecessary(TaskContext.get())
     if (!isDone) {
       if (!blockIterator.hasNext) {
         isDone = true

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1210,6 +1210,9 @@ class GpuOrcPartitionReader(
       return true
     }
     batchIter = EmptyGpuColumnarBatchIterator
+    // Release the GPU semaphore before host IO for the next batch,
+    // allowing other tasks to use the GPU while we read from disk.
+    GpuSemaphore.releaseIfNecessary(TaskContext.get())
     if (ctx.blockIterator.hasNext) {
       batchIter = readBatches()
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,6 +249,21 @@ object GpuSemaphore {
   def releaseIfNecessary(context: TaskContext): Unit = {
     if (context != null) {
       getInstance.releaseIfNecessary(context)
+    }
+  }
+
+  /**
+   * Acquire the GPU semaphore, execute the given block, then release.
+   * This is the preferred pattern for scoped GPU work that has a clear
+   * start and end point. The semaphore is guaranteed to be released
+   * even if the block throws an exception.
+   */
+  def withGpuSemaphore[T](context: TaskContext)(block: => T): T = {
+    acquireIfNecessary(context)
+    try {
+      block
+    } finally {
+      releaseIfNecessary(context)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
@@ -680,6 +680,9 @@ abstract class GpuTextBasedPartitionReader[BUFF <: LineBufferer, FACT <: LineBuf
 
   override def next(): Boolean = {
     batch.foreach(_.close())
+    // Release the GPU semaphore before host IO for the next batch,
+    // allowing other tasks to use the GPU while we read from disk.
+    GpuSemaphore.releaseIfNecessary(TaskContext.get())
     batch = if (isExhausted) {
       None
     } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -3159,6 +3159,9 @@ class ParquetPartitionReader(
       return true
     }
     batchIter = EmptyGpuColumnarBatchIterator
+    // Release the GPU semaphore before host IO for the next batch,
+    // allowing other tasks to use the GPU while we read from disk.
+    GpuSemaphore.releaseIfNecessary(TaskContext.get())
     if (!isDone) {
       if (!blockIterator.hasNext) {
         isDone = true


### PR DESCRIPTION
## Problem

GPU semaphore does not release when reading data on CPU, so it blocks other thread to acquire GPU semaphore.
This causes unnecessary wait on GPU.

E.g.:
In `GpuParquetScan.scala`,  the logic is like:

```scala

override def next(): Boolean = {
  ...
  batchIter = readBatches()
  ...
}

private def readBatches(): Iterator[ColumnarBatch] = {
  Step 1. readPartFile:  read data buffer -> disk IO on CPU, do not need GPU semaphore.
  Step 2. GpuSemaphore.acquireIfNecessary(TaskContext.get())
  Step 3. following GPU works: e.g.:  change CPU buffer to GPU table.
}
```

| | First Iteration | Second Iteration |
|---|---|---|
| **Step 1**: `readPartFile` (disk IO on CPU) | No semaphore held | **Semaphore held from previous iteration (No need)** |
| **Step 2**: `acquireIfNecessary` | Acquires semaphore | No-op (already held) |
| **Step 3**: GPU work | Semaphore held | Semaphore held |

In the second iteration, the semaphore acquired in Step 2 of the first iteration is never released before looping back, so Step 1's disk IO runs with the semaphore held — creating a GPU bubble.

## Fix

Release the semaphore **before** host IO between batches. The `acquireIfNecessary()` calls already present inside each `readBatch()`/`readBatches()` method re-acquire before GPU work begins.

### Changes

**`GpuSemaphore.scala`** — Added `withGpuSemaphore` loan-pattern helper for scoped GPU work (acquire + try/finally release).

**File readers** — Release semaphore at the start of the read loop, before host IO:
- `GpuTextBasedPartitionReader` (CSV/JSON)
- `MultiFileCoalescingPartitionReaderBase` (Parquet/ORC single-file)
- `MultiFileCloudPartitionReaderBase` (Parquet/ORC/Avro multi-file)
- `GpuOrcPartitionReader` (ORC single-file)
- `ParquetPartitionReader` (Parquet chunked reader)

**Shuffle coalesce** — Release semaphore before host coalescing/async IO wait:
- `GpuCoalesceIteratorBase` (sync shuffle coalesce)
- `GpuShuffleAsyncCoalesceIterator` (async shuffle coalesce)

### Safety

- First call: `releaseIfNecessary` is a no-op (nothing held yet)
- Empty data: if no GPU batch was produced, release is a no-op
- Exceptions: task completion listener still serves as the final safety net
- No behavioral change: same acquire/release semantics, just tighter scoping

### perf number

NDS, Spark 331, main branch.

| Run | Power Test Time | Speedup (vs baseline avg) |
|-----|----------------|---------------------------|
| Baseline (cold run) | 553,000 ms | — |
| Baseline (hot run) | 547,000 ms | — |
| **Optimized (cold run)** | **524,000 ms** | **4.7%** |
| **Optimized (hot run)** | **488,000 ms** | **11.3%** |

Signed-off-by: Chong Gao <res-life@users.noreply.github.com>