### PR TITLE
Fix wrong config name in shuffle checksum fallback check

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1783,8 +1783,10 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
       fallThroughReasons += "Plugin is in explain only mode"
     }
     if (GpuShuffleEnv.isRowBasedChecksumEnabled) {
-      fallThroughReasons += "Detected spark.shuffle.checksum.enabled=true. " +
-        "This feature is supported in Spark 4.1+, but is not yet supported by Spark-Rapids."
+      fallThroughReasons += "Detected order-independent checksum enabled " +
+        "(spark.sql.shuffle.orderIndependentChecksum.enabled or " +
+        "enableFullRetryOnMismatch). " +
+        "This Spark 4.1+ feature is not yet supported by Spark-Rapids."
     }
     if (fallThroughReasons.nonEmpty) {
       logWarning(s"Rapids Shuffle Plugin is falling back to SortShuffleManager " +


### PR DESCRIPTION
Contributes to #14085

### Description

Fixes the config name checked in `GpuShuffleEnv.isRowBasedChecksumEnabled`.

The previous commit (719345e) checked `spark.shuffle.checksum.enabled` which is the **wrong config**:
- `spark.shuffle.checksum.enabled` is the old Spark 3.2+ config for IO-level corruption diagnosis. It is **already supported** by the RAPIDS Shuffle Manager via `ShuffleChecksumSupport`.
- The correct configs for the Spark 4.1 row-based checksum feature (SPARK-51756, SPARK-53575) are:
  - `spark.sql.shuffle.orderIndependentChecksum.enabled` (default `false`), controls generating checksum.
  - `spark.sql.shuffle.orderIndependentChecksum.enableFullRetryOnMismatch` (default `false`), controls retry.

With the wrong config name, users who explicitly set `spark.shuffle.checksum.enabled=true` would have the RAPIDS Shuffle Manager unnecessarily fall back to `SortShuffleManager`, even though RAPIDS already supports that old IO-level checksum.

### Changes
- `GpuShuffleEnv.isRowBasedChecksumEnabled`: Check the two correct Spark 4.1 order-independent checksum configs instead of the old `spark.shuffle.checksum.enabled`
- `RapidsShuffleInternalManagerBase`: Updated warning message to reference the correct config names

### Checklists
- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
- [ ] Performance testing has been performed. No perf impact — config check only.

Signed-off-by: Chong Gao <res_life@163.com>