### PR TITLE
Exclude PythonUDF cases in JoinSuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -66,6 +66,8 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("test SortMergeJoin (with spill)", WONT_FIX_ISSUE("The case is to test spill in SortMergeJoin, which is not applicable for GPU."))
     .exclude("SPARK-32649: Optimize BHJ/SHJ inner/semi join with empty hashed relation", WONT_FIX_ISSUE("The case is to test the codegen behavior for BHJ/SHJ inner/semi join, which is not applicable for GPU."))
     .exclude("SPARK-36794: Ignore duplicated key when building relation for semi/anti hash join", ADJUST_UT("Replaced by testRapids version that checks GPU or CPU join operators"))
+    .exclude("SPARK-28323: PythonUDF should be able to use in join condition", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14258"))
+    .exclude("SPARK-28345: PythonUDF predicate should be able to pushdown to join", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14258"))
   enableSuite[RapidsSubquerySuite]
     .exclude("runtime error when the number of rows is greater than 1", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14158"))
     .exclude("SPARK-26893: Allow pushdown of partition pruning subquery filters to file source", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14172 - partition pruning with subquery not working on GPU"))


### PR DESCRIPTION
Exclude python udf test case in JoinSuites.

Related to https://github.com/NVIDIA/spark-rapids/issues/14258