### PR TITLE
Close stream time gap in RowToColumnarIterator hasNext

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -592,10 +592,15 @@ class RowToColumnarIterator(
   private var totalOutputRows: Long = 0
   private lazy val rowCopyProjection: UnsafeProjection = UnsafeProjection.create(localSchema)
 
-  override def hasNext: Boolean = rowIter.hasNext
+  override def hasNext: Boolean = {
+    val start = System.nanoTime()
+    val result = rowIter.hasNext
+    streamTime += System.nanoTime() - start
+    result
+  }
 
   override def next(): ColumnarBatch = {
-    if (!rowIter.hasNext) {
+    if (!hasNext) {
       throw new NoSuchElementException
     }
     buildBatch()


### PR DESCRIPTION
Fixes #14286.

### Description

This ensures the RowToColumnarIterator.hasNext check - called per batch by the downstream consumer - is captured in stream-time, since it has the side-effect of pulling a batch from the stream. [InternalRowToColumnarBatchIterator already tracks this](https://github.com/NVIDIA/spark-rapids/blob/main/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java#L105), so the gap was only present with non-fixed-width types that do not go through the accelerated C2R2C code path. 

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
