### PR TITLE
xfail test_get_json_object_quoted_question on Dataproc

### DIFF
--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ from data_gen import *
 from pyspark.sql.types import *
 from marks import *
 from spark_init_internal import spark_version
+from conftest import is_dataproc_runtime
 from spark_session import is_before_spark_400, is_databricks113_or_later, is_databricks_runtime
 
 def mk_json_str_gen(pattern):
@@ -122,6 +123,8 @@ def test_get_json_object_normalize_non_string_output():
             f.col('jsonStr'),
             f.get_json_object('jsonStr', '$')))
 
+@pytest.mark.xfail(condition=is_dataproc_runtime(),
+    reason="https://github.com/NVIDIA/spark-rapids/issues/14290")
 def test_get_json_object_quoted_question():
     schema = StructType([StructField("jsonStr", StringType())])
     data = [[r'{"?":"QUESTION"}']]


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14290

### Description

Dataproc 2.2 (image 2.2.75-ubuntu22) backported SPARK-46761 into its Spark 3.5.3, which allows `?` in quoted JSON path names. The spark-rapids pre-4.0 shim intentionally excludes`?` from the named-path regex to match vanilla Apache Spark 3.x behavior. This causes a GPU vs CPU mismatch only on Dataproc where the CPU now accepts `?`.

The proper fix already exists in the spark400 shim (PR #13104). We do not have a Dataproc-specific shim, so we cannot apply the fix only for Dataproc without breaking vanilla Apache Spark 3.5.3 where the CPU still rejects `?`. We will continue with the existing Apache Spark 3.5.3 behavior and xfail the test on Dataproc.

- xfail `test_get_json_object_quoted_question` when `is_dataproc_runtime()`
### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
