### PR TITLE
Support `Iterator[pandas.DataFrame]` in `GpuGroupedMapPandasUDF` [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapGroupsInPandasExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapGroupsInPandasExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
 import org.apache.spark.TaskContext
-import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
+import org.apache.spark.api.python.ChainedPythonFunctions
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
@@ -124,7 +124,7 @@ case class GpuFlatMapGroupsInPandasExec(
 
     val runnerFactory = GpuGroupedPythonRunnerFactory(conf, chainedFunc, Array(argOffsets),
         DataTypeUtilsShim.fromAttributes(dedupAttrs), pythonOutputSchema,
-        PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
+        udf.evalType)
 
     // Start processing. Map grouped batches to ArrowPythonRunner results.
     child.executeColumnar().mapPartitionsInternal { inputIter =>


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/14322

This PR adds in the support of `Iterator[pandas.DataFrame]` to GpuGroupedMapPandasUDF to align with what is done in Spark SPARK-53614.

