### PR TITLE
[Doc]Put design and shuffle-metrics docs under Developer Overview in nav in main branch[skip ci]

### DIFF
--- a/docs/design/rapids_shuffle_manager_v2_phase1_design.md
+++ b/docs/design/rapids_shuffle_manager_v2_phase1_design.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: RapidsShuffleManager V2 Phase 1 Design
+nav_order: 16
+parent: Developer Overview
+---
 # RapidsShuffleManager V2 Phase 1 Design
 
 ## 1. Background & Motivation

--- a/docs/design/rapids_shuffle_manager_v2_phase2_design.md
+++ b/docs/design/rapids_shuffle_manager_v2_phase2_design.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: RapidsShuffleManager V2 Phase 2 Skip-Merge Design
+nav_order: 17
+parent: Developer Overview
+---
 # RapidsShuffleManager V2 Phase 2: Skip-Merge Design
 
 ## 1. Phase 1 Recap

--- a/docs/dev/shuffle-metrics.md
+++ b/docs/dev/shuffle-metrics.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Shuffle Metrics
+nav_order: 15
+parent: Developer Overview
+---
 # Shuffle Metrics: SparkRapidsShuffleDiskSavingsEvent
 
 When using MULTITHREADED shuffle mode with `spark.rapids.shuffle.multithreaded.skipMerge=true`,


### PR DESCRIPTION
- Add Jekyll front matter to docs/design/rapids_shuffle_manager_v2_phase1_design.md
- Add Jekyll front matter to docs/design/rapids_shuffle_manager_v2_phase2_design.md
- Add Jekyll front matter to docs/dev/shuffle-metrics.md

All three pages now use parent: Developer Overview so they appear in the Developer Overview subsection in the generated site instead of at root level.

Made-with: Cursor

### Checklists

- [x] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
