### PR TITLE
[DOC] Update shims.md to refer to Spark 3.3.0+ and 4.x[skip ci]

### DIFF
--- a/docs/dev/shims.md
+++ b/docs/dev/shims.md
@@ -58,7 +58,7 @@ inject an intermediate trait e.g. `com.nvidia.spark.rapids.shims.ShimExpression`
 has a varying source code depending on the Spark version we compile against to overcome this
 issue as you can see e.g., comparing shim implementations across versions:
 
-1. [Shim implementation for 3.3.x](https://github.com/NVIDIA/spark-rapids/blob/main/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusShims.scala)
+1. [Shim implementation for 3.3.0](https://github.com/NVIDIA/spark-rapids/blob/main/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusShims.scala)
 2. [Shim service provider for 3.5.1](https://github.com/NVIDIA/spark-rapids/blob/main/sql-plugin/src/main/spark351/scala/com/nvidia/spark/rapids/shims/spark351/SparkShimServiceProvider.scala)
 
 The `ShimExpression` and related traits themselves live in a single shared file,


### PR DESCRIPTION
- Update supported version list to 3.3.x, 3.4.x, 3.5.x, 4.x (remove 3.0.2/3.1)
- Change TreeNode example from 3.1.x/3.2.x to 3.3.x/3.5.x and update links
- Replace Spark 3.0.2 URL example with Spark 3.3.0; add Spark 3.5.x URL example

Fixes #14340 

Made-with: Cursor

### Checklists


- [x] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
