### PR TITLE
Temporarily disable AQE for some udf tests

### DIFF
--- a/integration_tests/src/main/python/udf_cudf_test.py
+++ b/integration_tests/src/main/python/udf_cudf_test.py
@@ -247,7 +247,7 @@ def test_group_agg(enable_cudf_udf):
         df = _create_df(spark)
         return df.groupby("id").agg(_sum_gpu_func(df.v)).collect()
 
-    conf=copy_and_update(_conf, {
+    conf = copy_and_update(_conf, {
         # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
         'spark.sql.adaptive.enabled': 'false'
     })
@@ -277,7 +277,7 @@ def test_sql_group(enable_cudf_udf):
         q = "SELECT sum_gpu_udf(v1) FROM VALUES (3, 0), (2, 0), (1, 1) tbl(v1, v2) GROUP BY v2"
         return spark.sql(q).collect()
 
-    conf=copy_and_update(_conf, {
+    conf = copy_and_update(_conf, {
         # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
         'spark.sql.adaptive.enabled': 'false'
     })
@@ -308,7 +308,7 @@ def test_window(enable_cudf_udf):
         w = Window.partitionBy('id').rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
         return df.withColumn('sum_v', _sum_gpu_func('v').over(w)).collect()
 
-    conf=copy_and_update(_conf, {
+    conf = copy_and_update(_conf, {
         # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
         'spark.sql.adaptive.enabled': 'false'
     })


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14355

### Description

The AQE has been enabled by default for all tests in https://github.com/NVIDIA/spark-rapids/pull/14323. There are more tests found that are failing with this change. This PR temporarily disables AQE for them until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved. I have manually verified these tests running successfully on my workstation with Spark 3.5.5.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
