### PR TITLE
[AutoSparkUT] Fix GpuIf null predicate handling for side-effect expressions

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
@@ -273,7 +273,10 @@ case class GpuIf(
     val colTypes = GpuColumnVector.extractTypes(batch)
 
     withResource(GpuColumnVector.from(batch)) { tbl =>
-      withResource(pred.getBase.unaryOp(UnaryOp.NOT)) { inverted =>
+      // Use boolInverted instead of NOT so null predicates become true,
+      // routing null-condition rows to the false branch (matching CPU
+      // semantics where null is treated as "not true").
+      withResource(boolInverted(pred.getBase)) { inverted =>
         // evaluate true expression against true batch
         val tt = withResource(filterBatch(tbl, pred.getBase, colTypes)) { trueBatch =>
           gpuTrueExpr.columnarEvalAny(trueBatch)

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -56,7 +56,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsColumnExpressionSuite]
     .exclude("input_file_name, input_file_block_start, input_file_block_length - HadoopRDD", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14153"))
     .exclude("input_file_name, input_file_block_start, input_file_block_length - NewHadoopRDD", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14153"))
-    .exclude("assert_true", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14154"))
     .exclude("SPARK-34868: divide year-month interval by numeric", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14155"))
   enableSuite[RapidsDataFrameFunctionsSuite]
     .exclude("map_from_entries function", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14128"))


### PR DESCRIPTION
## Summary

- Fix a bug in `GpuIf.conditionalWithSideEffects` where null predicate rows were dropped from both true and false branches, causing side-effect expressions (e.g., `RaiseError`) to never execute for those rows.
- Root cause: `UnaryOp.NOT` on null returns null (not true), so `filterBatch` excluded null-condition rows from the false branch. Replaced with `boolInverted()` which correctly maps null→true, routing null-condition rows to the false branch (matching CPU semantics where null is treated as "not true").
- Remove the `assert_true` test exclusion from `RapidsColumnExpressionSuite` since the original Spark test now passes on GPU.

Fixes https://github.com/NVIDIA/spark-rapids/issues/14154

## Details

`AssertTrue(cond, msg)` is a `RuntimeReplaceable` expression that expands to `If(cond, Literal(null), RaiseError(msg))`. On CPU, when `cond` is null, `If` treats it as "not true" and evaluates the false branch (`RaiseError`), throwing the expected exception. On GPU, `GpuIf.conditionalWithSideEffects` was using `pred.getBase.unaryOp(UnaryOp.NOT)` to compute the inverted predicate for the false branch. However, cuDF's `NOT(null)` returns `null`, not `true`. This caused:

1. True branch filter: `filterBatch(tbl, pred=[null, true])` → keeps only the `true` row (null excluded)
2. False branch filter: `filterBatch(tbl, inverted=[null, false])` → keeps **no** rows (null excluded)
3. `GpuRaiseError` receives 0 rows → returns empty column instead of throwing

The fix replaces `UnaryOp.NOT` with the existing `boolInverted()` utility (which `GpuCaseWhen` already uses correctly), mapping `null→true`, `true→false`, `false→true`.

### Changed files

| File | Change |
|------|--------|
| `conditionalExpressions.scala` | Replace `UnaryOp.NOT` with `boolInverted()` in `GpuIf.conditionalWithSideEffects` |
| `RapidsTestSettings.scala` | Remove `.exclude("assert_true", ...)` |

### Spark original test reference

- **RAPIDS test**: `RapidsColumnExpressionSuite` (inherited `assert_true`)
- **Spark test**: `ColumnExpressionSuite.test("assert_true")`
- **Spark source**: `sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala` lines 2418-2450
- **Source links**:
  - [master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala#L2567)
  - [v3.3.0 (pinned)](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala#L2418)

## Test plan

- [x] `mvn install -DskipTests -Dbuildver=330` — build passes
- [x] `mvn test -pl tests -Dbuildver=330 -Dsuites=org.apache.spark.sql.rapids.suites.RapidsColumnExpressionSuite` — **Tests: succeeded 147, failed 0, ignored 2**
- [ ] CI passes


Made with [Cursor](https://cursor.com)