### PR TITLE
[AutoSparkUT] Fix LIKE escape pattern validation for GPU-CPU parity (SPARK-33677)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3501,6 +3501,23 @@ object GpuOverrides extends Logging {
         ("src", TypeSig.STRING, TypeSig.STRING),
         ("search", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING)),
       (a, conf, p, r) => new BinaryExprMeta[Like](a, conf, p, r) {
+        override def tagExprForGpu(): Unit = {
+          import org.apache.spark.sql.catalyst.util.StringUtils
+          try {
+            a.right match {
+              case l: Literal
+                  if l.value.isInstanceOf[UTF8String] =>
+                StringUtils.escapeLikeRegex(
+                  l.value.toString, a.escapeChar)
+              case _ =>
+            }
+          } catch {
+            case NonFatal(e) =>
+              willNotWorkOnGpu(
+                s"invalid LIKE escape pattern: " +
+                  s"${e.getMessage}")
+          }
+        }
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuLike(lhs, rhs, a.escapeChar)
       }),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -36,6 +36,7 @@ import com.nvidia.spark.rapids.jni.RegexRewriteUtils
 import com.nvidia.spark.rapids.shims.{NullIntolerantShim, ShimExpression, SparkShimImpl}
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.errors.ConvUtils
 import org.apache.spark.sql.rapids.catalyst.expressions._
 import org.apache.spark.sql.types._
@@ -976,12 +977,19 @@ case class GpuLike(left: Expression, right: Expression, escapeChar: Char)
 
   def this(left: Expression, right: Expression) = this(left, right, '\\')
 
+  @transient private var escapeValidated = false
+
   override def toString: String = escapeChar match {
     case '\\' => s"$left gpulike $right"
     case c => s"$left gpulike $right ESCAPE '$c'"
   }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
+    if (!escapeValidated && rhs.isValid) {
+      StringUtils.escapeLikeRegex(
+        rhs.getValue.toString, escapeChar)
+      escapeValidated = true
+    }
     withResource(Scalar.fromString(Character.toString(escapeChar))) { escapeScalar =>
       lhs.getBase.like(rhs.getBase, escapeScalar)
     }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSQLQuerySuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsSQLQuerySuite.scala
@@ -250,33 +250,4 @@ class RapidsSQLQuerySuite extends SQLQuerySuite with RapidsSQLTestsTrait {
     }
   }
 
-  // GPU-adapted test for "SPARK-33677: LikeSimplification
-  // should be skipped if pattern contains any escapeChar"
-  // Original: SQLQuerySuite.scala lines 3758-3773
-  // (Spark 3.3.0: uses intercept[AnalysisException])
-  // Adaptation: GPU handles LIKE with escape chars correctly
-  // without throwing AnalysisException. The pattern
-  // 'm%@ca' ESCAPE '%' means literal "m@ca" — GPU returns
-  // correct result true instead of rejecting the pattern.
-  testRapids("SPARK-33677: LikeSimplification should " +
-    "be skipped if pattern contains any escapeChar") {
-    withTempView("df") {
-      import testImplicits._
-      Seq("m@ca").toDF("s")
-        .createOrReplaceTempView("df")
-
-      // GPU evaluates the escaped pattern correctly:
-      // '%' as escape char, '%@' = literal '@'
-      checkAnswer(
-        sql("SELECT s LIKE 'm%@ca' ESCAPE '%' " +
-          "FROM df"),
-        Row(true))
-
-      checkAnswer(
-        sql("SELECT s LIKE 'm@@ca' ESCAPE '@' " +
-          "FROM df"),
-        Row(true))
-    }
-  }
-
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -227,7 +227,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-19650: An action on a Command should not trigger a Spark job", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14110"))
     .exclude("SPARK-31594: Do not display the seed of rand/randn with no argument in output schema", ADJUST_UT("Replaced by testRapids version with a correct regex expression to match the projectExplainOutput, randn isn't supported now. See https://github.com/NVIDIA/spark-rapids/issues/11613"))
     .exclude("normalize special floating numbers in subquery", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14116"))
-    .exclude("SPARK-33677: LikeSimplification should be skipped if pattern contains any escapeChar", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14117"))
     .exclude("SPARK-33593: Vector reader got incorrect data with binary partition value", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14118"))
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL -- jar contains udf class", ADJUST_UT("Replaced by testRapids version that uses testFile() to access Spark test resources instead of getContextClassLoader"))
     .exclude("SPARK-33482: Fix FileScan canonicalization", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14122"))


### PR DESCRIPTION
## Summary

Fix GPU-CPU parity for `LIKE ... ESCAPE` patterns with invalid escape sequences (SPARK-33677, issue #14117).

The original Spark test expects `AnalysisException` when using `LIKE 'm%@ca' ESCAPE '%'` — the pattern `%@` is rejected because the escape character `%` precedes a non-special char `@`. GPU was silently evaluating this instead of throwing, violating GPU-CPU parity.

**Approach: plugin-level validation (two layers)**

- **`GpuOverrides.tagExprForGpu()`** — validates escape patterns at planning time by calling `StringUtils.escapeLikeRegex()`. If the pattern is invalid, calls `willNotWorkOnGpu()` to fall back to CPU, which then throws the expected `AnalysisException`.
- **`GpuLike.doColumnar()`** — defense-in-depth: validates at execution time for non-literal patterns that may bypass planning-time checks. Uses a `@transient escapeValidated` flag to avoid repeated validation.
- **`RapidsTestSettings`** — removes the `KNOWN_ISSUE` exclusion for SPARK-33677. The original Spark test now passes directly on GPU without any `testRapids` override.

### Traceability

| Field | Value |
|---|---|
| Spark original | `test("SPARK-33677: LikeSimplification should be skipped if pattern contains any escapeChar")` in `SQLQuerySuite` |
| Spark source | `SQLQuerySuite.scala` L3758-3773 (Spark 3.3.0) |
| Fix location | `GpuOverrides.scala` (planning-time validation), `stringFunctions.scala` (execution-time defense-in-depth) |
| Issue | https://github.com/NVIDIA/spark-rapids/issues/14117 |

## Test plan

- [x] `mvn package -DskipTests -pl tests -am -Dbuildver=330` — BUILD SUCCESS
- [x] `mvn package -pl tests -Dbuildver=330 -DwildcardSuites=...RapidsSQLQuerySuite` — **Tests: succeeded 215, failed 0, ignored 19**
- [x] Original Spark test `SPARK-33677` passes directly on GPU (no `testRapids` needed)
- [x] No new failures introduced
- [ ] Pre-merge CI


Made with [Cursor](https://cursor.com)