### PR TITLE
[AutoSparkUT] Forward GPU memory allocation properties to forked test JVM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -925,6 +925,9 @@
         <rapids.delta.artifactId3>${rapids.delta.artifactId1}</rapids.delta.artifactId3>
         <test.include.tags/>
         <rapids.shuffle.manager.override>true</rapids.shuffle.manager.override>
+        <rapids.test.gpu.allocFraction>1</rapids.test.gpu.allocFraction>
+        <rapids.test.gpu.maxAllocFraction>1</rapids.test.gpu.maxAllocFraction>
+        <rapids.test.gpu.minAllocFraction>0.25</rapids.test.gpu.minAllocFraction>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1516,6 +1519,9 @@ This will force full Scala code rebuild in downstream modules.
                             <spark.ui.enabled>false</spark.ui.enabled>
                             <spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
                             <spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
+                            <rapids.test.gpu.allocFraction>${rapids.test.gpu.allocFraction}</rapids.test.gpu.allocFraction>
+                            <rapids.test.gpu.maxAllocFraction>${rapids.test.gpu.maxAllocFraction}</rapids.test.gpu.maxAllocFraction>
+                            <rapids.test.gpu.minAllocFraction>${rapids.test.gpu.minAllocFraction}</rapids.test.gpu.minAllocFraction>
                         </systemProperties>
                         <tagsToExclude>${test.exclude.tags}</tagsToExclude>
                         <tagsToInclude>${test.include.tags}</tagsToInclude>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -925,6 +925,9 @@
         <rapids.delta.artifactId3>${rapids.delta.artifactId1}</rapids.delta.artifactId3>
         <test.include.tags/>
         <rapids.shuffle.manager.override>true</rapids.shuffle.manager.override>
+        <rapids.test.gpu.allocFraction>1</rapids.test.gpu.allocFraction>
+        <rapids.test.gpu.maxAllocFraction>1</rapids.test.gpu.maxAllocFraction>
+        <rapids.test.gpu.minAllocFraction>0.25</rapids.test.gpu.minAllocFraction>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1516,6 +1519,9 @@ This will force full Scala code rebuild in downstream modules.
                             <spark.ui.enabled>false</spark.ui.enabled>
                             <spark.ui.showConsoleProgress>false</spark.ui.showConsoleProgress>
                             <spark.unsafe.exceptionOnMemoryLeak>true</spark.unsafe.exceptionOnMemoryLeak>
+                            <rapids.test.gpu.allocFraction>${rapids.test.gpu.allocFraction}</rapids.test.gpu.allocFraction>
+                            <rapids.test.gpu.maxAllocFraction>${rapids.test.gpu.maxAllocFraction}</rapids.test.gpu.maxAllocFraction>
+                            <rapids.test.gpu.minAllocFraction>${rapids.test.gpu.minAllocFraction}</rapids.test.gpu.minAllocFraction>
                         </systemProperties>
                         <tagsToExclude>${test.exclude.tags}</tagsToExclude>
                         <tagsToInclude>${test.include.tags}</tagsToInclude>


### PR DESCRIPTION
## Summary

- **Fixes a bug in #14369** where `-Drapids.test.gpu.allocFraction=0.3` on the Maven command line had no effect on the forked test JVM.
- `scalatest-maven-plugin` forks a separate JVM and only passes system properties explicitly listed in `<systemProperties>`. The `rapids.test.gpu.*` properties were never added there, so `System.getProperty("rapids.test.gpu.allocFraction")` in the forked JVM always returned `null`, falling back to `allocFraction=1.0` and monopolizing GPU memory.
- Adds `rapids.test.gpu.{allocFraction, maxAllocFraction, minAllocFraction}` to both `<properties>` (safe defaults) and `<systemProperties>` (forwarding to forked JVM) in the root `pom.xml`.

## Test plan

- [x] Verified locally: run `mvn test -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 -Drapids.test.gpu.minAllocFraction=0 -DwildcardSuites=RapidsDateExpressionsSuite -pl tests -Dbuildver=330` — GPU memory is correctly limited to 30% (~14.7 GiB on RTX 5880 48GB), confirmed via `nvidia-smi` during test execution.
- [x] Without the fix, the same flags had no effect (GPU used ~48 GiB).
- [x] Without `-D` flags, defaults (`allocFraction=1`) are preserved — no behavioral change for existing users.


Made with [Cursor](https://cursor.com)