### PR TITLE
Increase shallow clone depth of pre-merge CI [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -432,7 +432,7 @@ void checkoutCode(String url, String sha) {
                                     credentialsId: 'github-token',
                                     url          : url,
                                     refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-             extensions      : [[$class: 'CloneOption', shallow: true]]
+             extensions      : [[$class: 'CloneOption', shallow: true, depth: 10]]
         ]
     )
     sh "git submodule update --init"

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -215,7 +215,7 @@ void checkoutCode(String url, String sha) {
                                     credentialsId: 'github-token',
                                     url          : url,
                                     refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-             extensions      : [[$class: 'CloneOption', shallow: true]]
+             extensions      : [[$class: 'CloneOption', shallow: true, depth: 10]]
         ]
     )
     sh "git submodule update --init"


### PR DESCRIPTION
Increase shallow clone depth to reduce GitOps failures caused by outdated merged SHAs
e.g.
`fatal: Invalid revision range xyz123..HEAD`

