### PR TITLE
Add driver-compatible-relink-step for pre-merge CI

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -200,6 +200,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
                                     try {
+                                        common.resolveIncompatibleDriverIssue(this)
                                         common.pvcM2Cache(this, PVC_MOUNT_PATH)
                                         common.prepareArtNetrc(this)
                                         sh "$PREMERGE_SCRIPT mvn_verify"
@@ -241,6 +242,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
                                     try {
+                                        common.resolveIncompatibleDriverIssue(this)
                                         common.pvcM2Cache(this, PVC_MOUNT_PATH)
                                         common.prepareArtNetrc(this)
                                         sh "$PREMERGE_SCRIPT ci_2"
@@ -276,6 +278,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             container('gpu') {
                                 timeout(time: 6, unit: 'HOURS') {
                                     try {
+                                        common.resolveIncompatibleDriverIssue(this)
                                         common.pvcM2Cache(this, PVC_MOUNT_PATH)
                                         common.prepareArtNetrc(this)
                                         sh "$PREMERGE_SCRIPT ci_scala213"


### PR DESCRIPTION
Add cuda driver forward-compatibility resolve step for premerge-CI to workaround similar failure in https://github.com/NVIDIA/spark-rapids/pull/14383#issuecomment-4035452183 (ucx upgrade introduced new HW driver requirement)

