### PR TITLE
[AutoSparkUT] Reclassify ParquetEncodingSuite mixed encoding exclusion as ADJUST_UT

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -151,7 +151,7 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsParquetDeltaEncodingLong]
   enableSuite[RapidsParquetDeltaLengthByteArrayEncodingSuite]
   enableSuite[RapidsParquetEncodingSuite]
-    .exclude("Read row group containing both dictionary and plain encoded pages", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13739"))
+    .exclude("Read row group containing both dictionary and plain encoded pages", ADJUST_UT("Test uses CPU VectorizedParquetRecordReader directly, not a GPU path. GPU-native mixed encoding test added in PR #13982. See https://github.com/NVIDIA/spark-rapids/issues/13739"))
     .exclude("parquet v2 pages - delta encoding", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13745"))
     .exclude("parquet v2 pages - rle encoding for boolean value columns", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13746"))
   enableSuite[RapidsParquetFileFormatSuite]


### PR DESCRIPTION
## Summary

- Reclassify the exclusion for test "Read row group containing both dictionary and plain encoded pages" in `RapidsParquetEncodingSuite` from `KNOWN_ISSUE` to `ADJUST_UT`.
- Issue [#13739](https://github.com/NVIDIA/spark-rapids/issues/13739) confirmed the original Spark test uses CPU `VectorizedParquetRecordReader` directly — not a GPU execution path. The GPU-native mixed encoding test was already added in [PR #13982](https://github.com/NVIDIA/spark-rapids/pull/13982).
- This is a metadata-only change to accurately reflect the exclusion reason.

Closes #13739

## Test plan

- [ ] No functional code change; only exclusion category updated in `RapidsTestSettings.scala`.
- [ ] Verify `RapidsParquetEncodingSuite` still compiles and runs with the updated exclusion.


Made with [Cursor](https://cursor.com)