### PR TITLE
Fix dyn.shim.excluded.releases validation for scala2.13 POM

### DIFF
--- a/build/get_buildvers.py
+++ b/build/get_buildvers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #14425.

### Description

When adding Databricks shims (e.g. 332db, 341db) to dyn.shim.excluded.releases in pom.xml, the build fails with:

"Shim 332db listed in dyn.shim.excluded.releases in pom.xml not present in releases"

This happens because build/get_buildvers.py validates that every excluded shim exists as a release profile in the POM. However, scala2.13/pom.xml has Scala 2.12-only Databricks profiles commented out via #if scala-2.12 markers, making them invisible to the XML parser. Since both POMs share the same dyn.shim.excluded.releases value (synced by make-scala-version-build-files.sh), any Scala 2.12-only shim added to the exclusion list passes validation in pom.xml but fails in scala2.13/pom.xml.

This fix skips the validation for scala2.13/pom.xml where missing profiles are expected, while retaining strict validation for the main pom.xml to continue catching invalid shims/typos.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
