### PR TITLE
Fix DB-17.3 integration tests in udf_test.py [databricks]

### DIFF
--- a/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/execution/python/shims/WindowBoundTypeConfShims.scala
+++ b/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/execution/python/shims/WindowBoundTypeConfShims.scala
@@ -40,7 +40,6 @@
 {"spark": "357"}
 {"spark": "358"}
 {"spark": "400"}
-{"spark": "400db173"}
 {"spark": "401"}
 {"spark": "402"}
 spark-rapids-shim-json-lines ***/

--- a/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/rapids/execution/python/shims/WindowBoundTypeConfShims.scala
+++ b/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/rapids/execution/python/shims/WindowBoundTypeConfShims.scala
@@ -15,13 +15,15 @@
  */
 
 /*** spark-rapids-shim-json-lines
+{"spark": "400db173"}
 {"spark": "411"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution.python.shims
 
 /**
  * Shim for window bound type config key.
- * In Spark 4.1.x, the config key changed from "pandas_window_bound_types" to "window_bound_types".
+ * In Spark 4.1.x and Databricks-17.3, the config key changed from "pandas_window_bound_types"
+ * to "window_bound_types".
  */
 object WindowBoundTypeConfShims {
   val windowBoundTypeConf: String = "window_bound_types"


### PR DESCRIPTION
Fixes #14318 

### Description

The WindowBoundTypeConfShims shim for Databricks 17.3 (400db173) was incorrectly placed in the spark321 shim group alongside standard Spark versions, and was missing its own dedicated shim file. This caused integration test failures in udf_test.py for the DB 17.3 cluster because the wrong window bound type config key was being used.

Removed 400db173 from the spark321-based WindowBoundTypeConfShims.scala shim descriptor and  created a dedicated spark400db173/ shim file that groups 400db173 with spark411, both of which use the new window_bound_types config key introduced in Spark 4.1.x and Databricks 17.3.

#### Testing
Verified by running udf_test.py integration tests against the Databricks 17.3 cluster.

```
====== 127 passed, 2 skipped, 9 xpassed, 28 warnings in 575.51s (0:09:35) ======
```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
