### PR TITLE
Fix DPP test failures on DBR 17.3 [databricks]

### DIFF
--- a/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastMeta.scala
+++ b/sql-plugin/src/main/spark400/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastMeta.scala
@@ -15,7 +15,6 @@
  */
 /*** spark-rapids-shim-json-lines
 {"spark": "400"}
-{"spark": "400db173"}
 {"spark": "401"}
 {"spark": "402"}
 {"spark": "411"}


### PR DESCRIPTION
Fixes #14302.

### Description

The `spark400` version of `GpuSubqueryBroadcastMeta` incorrectly included `{"spark": "400db173"}` in its shim-json-lines, causing the Apache Spark base class (`GpuSubqueryBroadcastMetaBase`) to be used for DBR 17.3 instead of the Databricks-specific base class (`GpuSubqueryBroadcastMeta330DBBase` from `spark350db143`).

The Apache Spark path expects `AdaptiveSparkPlanExec` wrapping `BroadcastExchangeExec`, but DBR 17.3 uses `BroadcastQueryStageExec` (the Databricks plan structure). This caused:
- **AQE on**: `AssertionError: Unexpected child exec in AdaptiveSparkPlan: CollectLimitExec`
- **AQE off**: graceful GPU fallback followed by `FileSourceScanExec.doExecute` assertion failure in the CPU path

Removing `400db173` from the `spark400` shim-json-lines lets the `spark350db143` version (which correctly extends the DB base class) handle DBR 17.3.

### Checklists
- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      The existing `dpp_test.py::test_dpp_reuse_broadcast_exchange` tests (32 cases) cover this fix. They were all failing before and should pass after this change.
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.

Signed-off-by: Chong Gao <chongg@nvidia.com>