### PR TITLE
[AutoSparkUT] Fix trunc/date_trunc to return null for invalid format strings

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -1543,15 +1543,14 @@ abstract class GpuTruncDateTime(fmtStr: Option[String]) extends GpuBinaryExpress
   }
 
   protected def truncate(datetimeCol: GpuColumnVector, fmtVal: GpuScalar): ColumnVector = {
-    // fmtVal is unused, as it was extracted to `fmtStr` before.
     fmtStr match {
       case Some(fmt) => DateTimeUtils.truncate(datetimeCol.getBase, fmt)
-      case None => throw new IllegalArgumentException("Invalid format string.")
+      case None =>
+        GpuColumnVector.columnVectorFromNull(datetimeCol.getRowCount.toInt, dataType)
     }
   }
 
   protected def truncate(numRows: Int, datetimeVal: GpuScalar, fmtVal: GpuScalar): ColumnVector = {
-    // fmtVal is unused, as it was extracted to `fmtStr` before.
     fmtStr match {
       case Some(fmt) =>
         withResource(ColumnVector.fromScalar(datetimeVal.getBase, 1)) { datetimeCol =>
@@ -1566,7 +1565,7 @@ abstract class GpuTruncDateTime(fmtStr: Option[String]) extends GpuBinaryExpress
             }
           }
         }
-      case None => throw new IllegalArgumentException("Invalid format string.")
+      case None => GpuColumnVector.columnVectorFromNull(numRows, dataType)
     }
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -114,7 +114,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-21258: complex object in combination with spilling", WONT_FIX_ISSUE("GPU implementation doesn't respect the inMemoryThreshold and spillThreshold"))
     .exclude("SPARK-38237: require all cluster keys for child required distribution for window query", ADJUST_UT("Replaced by testRapids version for GPU execution"))
   enableSuite[RapidsDateExpressionsSuite]
-    .exclude("unsupported fmt fields for trunc/date_trunc results null", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13757"))
     .exclude("SPARK-31896: Handle am-pm timestamp parsing when hour is missing", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13758"))
     .exclude("SPARK-33498: GetTimestamp,UnixTimestamp,ToUnixTimestamp with parseError", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13759"))
     .exclude("SPARK-34761,SPARK-35889: add a day-time interval to a timestamp", ADJUST_UT("Replaced by modified version without intercept[Exception] part"))


### PR DESCRIPTION
## Summary

- **Fix**: `GpuTruncDate` and `GpuTruncTimestamp` threw `IllegalArgumentException("Invalid format string.")` when the format string was null or could not be extracted at analysis time (non-foldable literal). CPU Spark returns null in these cases. Changed the two `case None` branches in `GpuTruncDateTime.truncate()` to return a null column via `GpuColumnVector.columnVectorFromNull(...)`, matching CPU behavior.
- **Exclusion removed**: `"unsupported fmt fields for trunc/date_trunc results null"` from `RapidsDateExpressionsSuite` in `RapidsTestSettings.scala`.

Closes #13757

## Test Mapping

| RAPIDS Test | Spark Original Test | Spark Source File | Lines | Links |
|---|---|---|---|---|
| `RapidsDateExpressionsSuite` (inherited) `"unsupported fmt fields for trunc/date_trunc results null"` | `DateExpressionsSuite` `"unsupported fmt fields for trunc/date_trunc results null"` | `sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala` | 854–861 | [master](https://github.com/apache/spark/blob/master/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala#L854-L861) · [pinned](https://github.com/apache/spark/blob/f66c3361852/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala#L854-L861) |

## Validation

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsDateExpressionsSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0

Tests: succeeded 59, failed 0, canceled 0, ignored 3, pending 0
All tests passed.
```

### Performance

This change modifies only the `case None` (cold path) branches in two `GpuTruncDateTime.truncate()` overloads. The `case None` branch executes only when the format literal is null or non-foldable — never in normal production queries where `trunc(date, 'YEAR')` uses a foldable string literal. The hot path (`case Some(fmt) => DateTimeUtils.truncate(...)`) is completely untouched: zero new allocations, branches, or synchronization points added to the normal execution flow. No GPU memory usage pattern changes on the hot path.

### Checklists

- [ ] This PR has added documentation for new or modified features or
behaviors.
- [x] This PR has added new tests or modified existing tests to cover
new code paths.
(The existing Spark test `"unsupported fmt fields for trunc/date_trunc results null"` from
`DateExpressionsSuite` now runs on GPU via `RapidsDateExpressionsSuite` — previously
excluded, now re-enabled by removing the `.exclude()` entry.)
- [x] Performance testing has been performed and its results are added
in the PR description. Or, an issue has been filed with a link in the PR
description.
(See Performance section above — cold-path-only impact analysis.)


Made with [Cursor](https://cursor.com)