### PR TITLE
Improve pytest-xdist load balancing by leveraging pytest-xdist worksteal mode [databricks]

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ sre_yield
 pandas
 pyarrow == 17.0.0 ; python_version == '3.8'
 pyarrow == 19.0.1 ; python_version >= '3.9'
-pytest-xdist >= 2.0.0
+pytest-xdist >= 3.3.0
 pytz
 findspark
 fsspec == 2025.3.0

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -228,9 +228,9 @@ else
         # 0 is more efficient
         TEST_PARALLEL_OPTS=()
     elif [[ ${TEST_PARALLEL} -gt ${MAX_PARALLEL} ]]; then
-        TEST_PARALLEL_OPTS=("-n" "$MAX_PARALLEL")
+        TEST_PARALLEL_OPTS=("-n" "$MAX_PARALLEL" "--dist" "worksteal")
     else
-        TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")
+        TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL" "--dist" "worksteal")
     fi
 
     mkdir -p "$TARGET_DIR"


### PR DESCRIPTION
## Summary
  - Switch pytest-xdist distribution mode to `--dist=worksteal` to eliminate long-tail scheduling in parallel test runs.

  ## Problem
  With the default xdist scheduling (`--dist=load`), tests are dispatched to workers sequentially from a single queue. In practice, we've observed a **long-tail problem**: 5 of 6 workers finish while the last worker still has a large batch of heavyweight parametrized tests (e.g., `hash_aggregate_test` with 400+ items, `join_test` with 300+). 

Idle workers can't help once tests are dispatched, they're locked to their assigned worker. This frequently causes some stages to take **5–6 hours** when they should complete in ~3-4 hours.

  ## Fix
  Use `--dist=worksteal` (available since pytest-xdist 3.2). Unlike `--dist=load` where tests are pulled from a single global queue, `worksteal` gives each worker its own local queue. When a worker finishes its queue, it **steals tests from other workers' queues**. This directly eliminates the long-tail problem at the scheduler level — no worker sits idle while another has work remaining.

  Changes:
  - `run_pyspark_from_build.sh`: add `--dist worksteal` to `TEST_PARALLEL_OPTS`
  - `requirements.txt`: bump `pytest-xdist >= 2.0.0` to `>= 3.3.0` (worksteal requires 3.2+, but 3.3+ include a critical bug fix of worksteal mode)