### PR TITLE
[AutoSparkUT] Propagate SQL query context to GPU arithmetic overflow exceptions (issue #14123)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
@@ -78,10 +78,12 @@ object GpuCanonicalize {
 
   /** Rearrange expressions that are commutative or associative. */
   private def expressionReorder(e: Expression): Expression = e match {
-    case a @ GpuAdd(_, _, f) =>
-      orderCommutative(a, { case GpuAdd(l, r, _) => Seq(l, r) }).reduce(GpuAdd(_, _, f))
-    case m @ GpuMultiply(_, _, f) =>
-      orderCommutative(m, { case GpuMultiply(l, r, _) => Seq(l, r) }).reduce(GpuMultiply(_, _, f))
+    case a @ GpuAdd(_, _, f, o) =>
+      orderCommutative(a, { case GpuAdd(l, r, _, _) => Seq(l, r) })
+        .reduce(GpuAdd(_, _, f, o))
+    case m @ GpuMultiply(_, _, f, o) =>
+      orderCommutative(m, { case GpuMultiply(l, r, _, _) => Seq(l, r) })
+        .reduce(GpuMultiply(_, _, f, o))
     case o: GpuOr =>
       orderCommutative(o, { case GpuOr(l, r) if l.deterministic && r.deterministic => Seq(l, r) })
           .reduce(GpuOr)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1941,7 +1941,7 @@ object GpuOverrides extends Logging {
         }
 
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuAdd(lhs, rhs, failOnError = ansiEnabled)
+          GpuAdd(lhs, rhs, ansiEnabled, origin = a.origin)
       }),
     expr[Subtract](
       "Subtraction",
@@ -1970,7 +1970,7 @@ object GpuOverrides extends Logging {
         }
 
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuSubtract(lhs, rhs, ansiEnabled)
+          GpuSubtract(lhs, rhs, ansiEnabled, origin = a.origin)
       }),
     expr[And](
       "Logical AND",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -27,7 +27,7 @@ import com.nvidia.spark.rapids.shims.{AggregateInPandasExecShims, DistributionUt
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BinaryExpression, BoundReference, Cast, ComplexTypeMergingExpression, Expression, Literal, QuaternaryExpression, RuntimeReplaceable, String2TrimExpression, TernaryExpression, TimeZoneAwareExpression, UnaryExpression, UTCTimestamp, WindowExpression, WindowFunction}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, ImperativeAggregate, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.catalyst.trees.{TreeNodeTag, UnaryLike}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNodeTag, UnaryLike}
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{ScalarSubquery, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
@@ -1412,7 +1412,11 @@ abstract class BaseExprMeta[INPUT <: Expression](
     if (willUseGpuCpuBridge) {
       convertForGpuCpuBridge()
     } else {
-      convertToGpuImpl()
+      // Propagate the origin from the CPU expression so that GPU expressions
+      // inherit the SQL query context for error messages (e.g. ANSI overflow).
+      CurrentOrigin.withOrigin(wrapped.origin) {
+        convertToGpuImpl()
+      }
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -1481,7 +1481,8 @@ class SumBinaryFixer(toType: DataType, isAnsi: Boolean)
             if (needsBasicOverflowCheck) {
               withResource(nullsReplaced.binaryOp(BinaryOp.ADD, prev, prev.getType)) { updated =>
                 closeOnExcept(mask.ifElse(updated, windowedColumnOutput)) { ret =>
-                  AddOverflowChecks.basicOpOverflowCheck(updated, prev, ret, Some(mask))
+                  AddOverflowChecks.basicOpOverflowCheck(
+                    updated, prev, ret, mask = Some(mask))
                   ret
                 }
               }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -28,6 +28,7 @@ import com.nvidia.spark.rapids.shims.{DecimalMultiply128, GpuTypeShims, NullInto
 
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.{ComplexTypeMergingExpression, ExpectsInputTypes, Expression}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
@@ -39,6 +40,7 @@ object AddOverflowChecks {
       lhs: BinaryOperable,
       rhs: BinaryOperable,
       ret: ColumnVector,
+      origin: Origin = CurrentOrigin.get,
       mask: Option[ColumnVector] = None): Unit = {
     // Check overflow. It is true if the arguments have different signs and
     // the sign of the result is different from the sign of x.
@@ -55,7 +57,6 @@ object AddOverflowChecks {
     }
     withResource(signDiffCV) { tmpSignDiff =>
       val signDiff = if (mask.isDefined) {
-        // If a mask is passed in we only want to look for overflow within the mask
         mask.get.and(tmpSignDiff)
       } else {
         tmpSignDiff.incRefCount()
@@ -64,8 +65,8 @@ object AddOverflowChecks {
         withResource(signDiff.any()) { any =>
           if (any.isValid && any.getBoolean) {
             throw RapidsErrorUtils.arithmeticOverflowError(
-              "One or more rows overflow for Add operation."
-            )
+              "One or more rows overflow for Add operation.",
+              origin)
           }
         }
       }
@@ -102,12 +103,14 @@ object AddOverflowChecks {
       lhs: BinaryOperable,
       rhs: BinaryOperable,
       ret: ColumnVector,
-      failOnError: Boolean): ColumnVector = {
+      failOnError: Boolean,
+      origin: Origin = CurrentOrigin.get): ColumnVector = {
     withResource(didDecimalOverflow(lhs, rhs, ret)) { overflow =>
       if (failOnError) {
         withResource(overflow.any()) { any =>
           if (any.isValid && any.getBoolean) {
-            throw new ArithmeticException("One or more rows overflow for Add operation.")
+            throw RapidsErrorUtils.arithmeticOverflowError(
+              "One or more rows overflow for Add operation.", origin)
           }
         }
         ret.incRefCount()
@@ -124,7 +127,8 @@ object SubtractOverflowChecks {
   def basicOpOverflowCheck(
       lhs: BinaryOperable,
       rhs: BinaryOperable,
-      ret: ColumnVector): Unit = {
+      ret: ColumnVector,
+      origin: Origin = CurrentOrigin.get): Unit = {
     // Check overflow. It is true if the arguments have different signs and
     // the sign of the result is different from the sign of x.
     // Which is equal to "((x ^ y) & (x ^ r)) < 0" in the form of arithmetic.
@@ -141,8 +145,8 @@ object SubtractOverflowChecks {
     withResource(signDiffCV) { signDiff =>
       withResource(signDiff.any()) { any =>
         if (any.isValid && any.getBoolean) {
-          throw RapidsErrorUtils.
-            arithmeticOverflowError("One or more rows overflow for Subtract operation.")
+          throw RapidsErrorUtils.arithmeticOverflowError(
+            "One or more rows overflow for Subtract operation.", origin)
         }
       }
     }
@@ -162,17 +166,25 @@ object GpuAnsi {
       throw new IllegalArgumentException(s"$other does not need an ANSI check for this operator")
   }
 
-  def assertMinValueOverflow(cv: GpuColumnVector, op: String): Unit = {
+  def assertMinValueOverflow(
+      cv: GpuColumnVector, op: String,
+      origin: Origin): Unit = {
     withResource(minValueScalar(cv.dataType())) { minVal =>
-      assertMinValueOverflow(minVal, cv, op)
+      assertMinValueOverflow(minVal, cv, op, origin)
     }
   }
 
-  def assertMinValueOverflow(minVal: Scalar, cv: GpuColumnVector, op: String): Unit = {
+  def assertMinValueOverflow(cv: GpuColumnVector, op: String): Unit = {
+    assertMinValueOverflow(cv, op, CurrentOrigin.get)
+  }
+
+  def assertMinValueOverflow(
+      minVal: Scalar, cv: GpuColumnVector, op: String,
+      origin: Origin): Unit = {
     withResource(cv.getBase.equalToNullAware(minVal)) { isMinVal =>
       if (BoolUtils.isAnyValidTrue(isMinVal)) {
         throw RapidsErrorUtils.arithmeticOverflowError(
-          s"One or more rows overflow for $op operation")
+          s"One or more rows overflow for $op operation", origin)
       }
     }
   }
@@ -193,8 +205,7 @@ case class GpuUnaryMinus(child: Expression, failOnError: Boolean) extends GpuUna
 
   override def doColumnar(input: GpuColumnVector) : ColumnVector = {
     if (failOnError && GpuAnsi.needBasicOpOverflowCheck(dataType)) {
-      // Because of 2s compliment we need to only worry about the min value for integer types.
-      GpuAnsi.assertMinValueOverflow(input, "minus")
+      GpuAnsi.assertMinValueOverflow(input, "minus", origin)
     }
 
     def commonMinus(input: GpuColumnVector): ColumnVector = {
@@ -210,17 +221,15 @@ case class GpuUnaryMinus(child: Expression, failOnError: Boolean) extends GpuUna
           scalar.sub(input.getBase)
         }
       case t if GpuTypeShims.isSupportedDayTimeType(t) =>
-        // For day-time interval, Spark throws an exception when overflow,
-        // regardless of whether `SQLConf.get.ansiEnabled` is true or false
         withResource(Scalar.fromLong(Long.MinValue)) { minVal =>
-          GpuAnsi.assertMinValueOverflow(minVal, input, "minus")
+          GpuAnsi.assertMinValueOverflow(minVal, input, "minus", origin)
         }
         commonMinus(input)
       case t if GpuTypeShims.isSupportedYearMonthType(t) =>
         // For year-month interval, Spark throws an exception when overflow,
         // regardless of whether `SQLConf.get.ansiEnabled` is true or false
         withResource(Scalar.fromInt(Int.MinValue)) { minVal =>
-          GpuAnsi.assertMinValueOverflow(minVal, input, "minus")
+          GpuAnsi.assertMinValueOverflow(minVal, input, "minus", origin)
         }
         commonMinus(input)
       case _ =>
@@ -270,21 +279,16 @@ case class GpuAbs(child: Expression, failOnError: Boolean) extends CudfUnaryExpr
 
   override def doColumnar(input: GpuColumnVector) : ColumnVector = {
     if (failOnError && GpuAnsi.needBasicOpOverflowCheck(dataType)) {
-      // Because of 2s compliment we need to only worry about the min value for integer types.
-      GpuAnsi.assertMinValueOverflow(input, "abs")
+      GpuAnsi.assertMinValueOverflow(input, "abs", origin)
     }
 
     if (GpuTypeShims.isSupportedDayTimeType(dataType)) {
-      // For day-time interval, Spark throws an exception when overflow,
-      // regardless of whether `SQLConf.get.ansiEnabled` is true or false
       withResource(Scalar.fromLong(Long.MinValue)) { minVal =>
-        GpuAnsi.assertMinValueOverflow(minVal, input, "abs")
+        GpuAnsi.assertMinValueOverflow(minVal, input, "abs", origin)
       }
     } else if (GpuTypeShims.isSupportedYearMonthType(dataType)) {
-      // For year-month interval, Spark throws an exception when overflow,
-      // regardless of whether `SQLConf.get.ansiEnabled` is true or false
       withResource(Scalar.fromInt(Int.MinValue)) { minVal =>
-        GpuAnsi.assertMinValueOverflow(minVal, input, "abs")
+        GpuAnsi.assertMinValueOverflow(minVal, input, "abs", origin)
       }
     }
 
@@ -306,17 +310,15 @@ abstract class GpuAddBase extends CudfBinaryArithmetic with Serializable {
   override def doColumnar(lhs: BinaryOperable, rhs: BinaryOperable): ColumnVector = {
     val ret = super.doColumnar(lhs, rhs)
     withResource(ret) { ret =>
-      // No shims are needed, because it actually supports ANSI mode from Spark v3.0.1.
       if (failOnError && GpuAnsi.needBasicOpOverflowCheck(dataType) ||
           GpuTypeShims.isSupportedDayTimeType(dataType) ||
           GpuTypeShims.isSupportedYearMonthType(dataType)) {
-        // For day time interval, Spark throws an exception when overflow,
-        // regardless of whether `SQLConf.get.ansiEnabled` is true or false
-        AddOverflowChecks.basicOpOverflowCheck(lhs, rhs, ret)
+        AddOverflowChecks.basicOpOverflowCheck(lhs, rhs, ret, origin)
       }
 
       if (dataType.isInstanceOf[DecimalType]) {
-        AddOverflowChecks.decimalOpOverflowCheck(lhs, rhs, ret, failOnError)
+        AddOverflowChecks.decimalOpOverflowCheck(
+          lhs, rhs, ret, failOnError, origin)
       } else {
         ret.incRefCount()
       }
@@ -336,10 +338,8 @@ abstract class GpuSubtractBase extends CudfBinaryArithmetic with Serializable {
       lhs: BinaryOperable,
       rhs: BinaryOperable,
       ret: ColumnVector): ColumnVector = {
-    // We need a special overflow check for decimal because CUDF does not support INT128 so we
-    // cannot reuse the same code for the other types.
-    // Overflow happens if the arguments have different signs and the sign of the result is
-    // different from the sign of subtractend (RHS).
+    // Overflow happens if the arguments have different signs and the sign of
+    // the result is different from the sign of subtractend (RHS).
     val numRows = ret.getRowCount.toInt
     val zero = BigDecimal(0).bigDecimal
     val overflow = withResource(DecimalUtils.lessThan(rhs, zero, numRows)) { rhsLz =>
@@ -351,8 +351,8 @@ abstract class GpuSubtractBase extends CudfBinaryArithmetic with Serializable {
           withResource(DecimalUtils.lessThan(ret, zero)) { resultLz =>
             rhsLz.equalTo(resultLz)
           }
-        withResource(resultAndSubtrahendSameSign) { resultAndSubtrahendSameSign =>
-          resultAndSubtrahendSameSign.and(argsSignDifferent)
+        withResource(resultAndSubtrahendSameSign) { ss =>
+          ss.and(argsSignDifferent)
         }
       }
     }
@@ -360,7 +360,9 @@ abstract class GpuSubtractBase extends CudfBinaryArithmetic with Serializable {
       if (failOnError) {
         withResource(overflow.any()) { any =>
           if (any.isValid && any.getBoolean) {
-            throw new ArithmeticException("One or more rows overflow for Subtract operation.")
+            throw RapidsErrorUtils.arithmeticOverflowError(
+              "One or more rows overflow for Subtract operation.",
+              origin)
           }
         }
         ret.incRefCount()
@@ -375,13 +377,11 @@ abstract class GpuSubtractBase extends CudfBinaryArithmetic with Serializable {
   override def doColumnar(lhs: BinaryOperable, rhs: BinaryOperable): ColumnVector = {
     val ret = super.doColumnar(lhs, rhs)
     withResource(ret) { ret =>
-      // No shims are needed, because it actually supports ANSI mode from Spark v3.0.1.
       if (failOnError && GpuAnsi.needBasicOpOverflowCheck(dataType) ||
           GpuTypeShims.isSupportedDayTimeType(dataType) ||
           GpuTypeShims.isSupportedYearMonthType(dataType)) {
-        // For day time interval, Spark throws an exception when overflow,
-        // regardless of whether `SQLConf.get.ansiEnabled` is true or false
-        SubtractOverflowChecks.basicOpOverflowCheck(lhs, rhs, ret)
+        SubtractOverflowChecks.basicOpOverflowCheck(
+          lhs, rhs, ret, origin)
       }
 
       if (dataType.isInstanceOf[DecimalType]) {
@@ -738,7 +738,8 @@ object GpuDivModLike {
 case class GpuMultiply(
     left: Expression,
     right: Expression,
-    failOnError: Boolean = SQLConf.get.ansiEnabled) extends CudfBinaryArithmetic {
+    failOnError: Boolean = SQLConf.get.ansiEnabled,
+    override val origin: Origin = CurrentOrigin.get) extends CudfBinaryArithmetic {
   assert(!left.dataType.isInstanceOf[DecimalType],
     "DecimalType multiplies need to be handled by GpuDecimalMultiply")
 
@@ -749,42 +750,54 @@ case class GpuMultiply(
   override def binaryOp: BinaryOp = BinaryOp.MUL
   override def astOperator: Option[BinaryOperator] = Some(ast.BinaryOperator.MUL)
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
+  private def multiplyOverflowError(msg: String): ArithmeticException = {
+    RapidsErrorUtils.arithmeticOverflowError(msg, origin)
+  }
+
+  override def doColumnar(
+      lhs: GpuColumnVector,
+      rhs: GpuColumnVector): ColumnVector = {
     try {
-      Arithmetic.multiply(lhs.getBase, rhs.getBase, /* ansi */ failOnError, /* try_mode */ false)
+      Arithmetic.multiply(lhs.getBase, rhs.getBase, failOnError, false)
     } catch {
-      case rowException: ExceptionWithRowIndex =>
-        val errorRowIndex = rowException.getRowIndex
-        val leftValue = ColumnViewUtils.getElementStringFromColumnView(lhs.getBase, errorRowIndex)
-        val rightValue = ColumnViewUtils.getElementStringFromColumnView(rhs.getBase, errorRowIndex)
-        throw new ArithmeticException(
-          s"Multiplication failed in ANSI mode: $leftValue * $rightValue")
+      case e: ExceptionWithRowIndex =>
+        val i = e.getRowIndex
+        val l = ColumnViewUtils.getElementStringFromColumnView(
+          lhs.getBase, i)
+        val r = ColumnViewUtils.getElementStringFromColumnView(
+          rhs.getBase, i)
+        throw multiplyOverflowError(
+          s"Multiplication failed in ANSI mode: $l * $r")
     }
   }
 
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
+  override def doColumnar(
+      lhs: GpuScalar,
+      rhs: GpuColumnVector): ColumnVector = {
     try {
-      Arithmetic.multiply(lhs.getBase, rhs.getBase, /* ansi */ failOnError, /* try_mode */ false)
+      Arithmetic.multiply(lhs.getBase, rhs.getBase, failOnError, false)
     } catch {
-      case rowException: ExceptionWithRowIndex =>
-        val errorRowIndex = rowException.getRowIndex
-        val leftValue = lhs.getBase.toString
-        val rightValue = ColumnViewUtils.getElementStringFromColumnView(rhs.getBase, errorRowIndex)
-        throw new ArithmeticException(
-          s"Multiplication failed in ANSI mode: $leftValue * $rightValue")
+      case e: ExceptionWithRowIndex =>
+        val i = e.getRowIndex
+        val r = ColumnViewUtils.getElementStringFromColumnView(
+          rhs.getBase, i)
+        throw multiplyOverflowError(
+          s"Multiplication failed in ANSI mode: ${lhs.getBase} * $r")
     }
   }
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
+  override def doColumnar(
+      lhs: GpuColumnVector,
+      rhs: GpuScalar): ColumnVector = {
     try {
-      Arithmetic.multiply(lhs.getBase, rhs.getBase, /* ansi */ failOnError, /* try_mode */ false)
+      Arithmetic.multiply(lhs.getBase, rhs.getBase, failOnError, false)
     } catch {
-      case rowException: ExceptionWithRowIndex =>
-        val errorRowIndex = rowException.getRowIndex
-        val leftValue = ColumnViewUtils.getElementStringFromColumnView(lhs.getBase, errorRowIndex)
-        val rightValue = rhs.getBase.toString
-        throw new ArithmeticException(
-          s"Multiplication failed in ANSI mode: $leftValue * $rightValue")
+      case e: ExceptionWithRowIndex =>
+        val i = e.getRowIndex
+        val l = ColumnViewUtils.getElementStringFromColumnView(
+          lhs.getBase, i)
+        throw multiplyOverflowError(
+          s"Multiplication failed in ANSI mode: $l * ${rhs.getBase}")
     }
   }
 
@@ -1100,7 +1113,8 @@ object DecimalDivideChecks {
 }
 
 case class GpuDivide(left: Expression, right: Expression,
-    failOnError: Boolean = SQLConf.get.ansiEnabled) extends GpuDivModLike {
+    failOnError: Boolean = SQLConf.get.ansiEnabled,
+    override val origin: Origin = CurrentOrigin.get) extends GpuDivModLike {
   assert(!left.dataType.isInstanceOf[DecimalType],
     "DecimalType divides need to be handled by GpuDecimalDivide")
 

--- a/sql-plugin/src/main/spark321/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
+++ b/sql-plugin/src/main/spark321/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
@@ -170,7 +170,7 @@ object DecimalArithmeticOverrides {
             case _: DecimalType => throw new IllegalStateException(
               "Decimal Multiply should be converted in CheckOverflow")
             case _ =>
-              GpuMultiply(lhs, rhs)
+              GpuMultiply(lhs, rhs, origin = a.origin)
           }
         }
       }),
@@ -199,7 +199,7 @@ object DecimalArithmeticOverrides {
               throw new IllegalStateException("Internal Error: Decimal Divide operations " +
                   "should be converted to the GPU in the CheckOverflow rule")
             case _ =>
-              GpuDivide(lhs, rhs)
+              GpuDivide(lhs, rhs, origin = a.origin)
           }
       }),
     expr[IntegralDivide](
@@ -210,7 +210,7 @@ object DecimalArithmeticOverrides {
         ("rhs", TypeSig.LONG + TypeSig.DECIMAL_128, TypeSig.LONG + TypeSig.DECIMAL_128)),
       (a, conf, p, r) => new BinaryExprMeta[IntegralDivide](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuIntegralDivide(lhs, rhs)
+          GpuIntegralDivide(lhs, rhs, origin = a.origin)
       }),
     expr[Remainder](
       "Remainder or modulo",

--- a/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -28,6 +28,7 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.{NullIntolerantShim, ShimExpression}
 
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -45,7 +46,9 @@ abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolera
 case class GpuIntegralDivide(
     left: Expression,
     right: Expression,
-    failOnError: Boolean = SQLConf.get.ansiEnabled) extends GpuIntegralDivideParent(left, right)
+    failOnError: Boolean = SQLConf.get.ansiEnabled,
+    override val origin: Origin = CurrentOrigin.get
+) extends GpuIntegralDivideParent(left, right)
 
 object GpuDecimalDivide {
   def apply(left: Expression, right: Expression, dataType: DecimalType): GpuDecimalDivide = {
@@ -90,12 +93,14 @@ case class GpuDecimalMultiply(
 case class GpuAdd(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends GpuAddBase
+    failOnError: Boolean,
+    override val origin: Origin = CurrentOrigin.get) extends GpuAddBase
 
 case class GpuSubtract(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends GpuSubtractBase
+    failOnError: Boolean,
+    override val origin: Origin = CurrentOrigin.get) extends GpuSubtractBase
 
 case class GpuRemainder(
     left: Expression,

--- a/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -61,6 +61,12 @@ object RapidsErrorUtils extends RapidsQueryErrorUtils
     new ArithmeticException(message)
   }
 
+  def arithmeticOverflowError(
+      message: String,
+      origin: Origin): ArithmeticException = {
+    new ArithmeticException(message)
+  }
+
   def cannotChangeDecimalPrecisionError(      
       value: Decimal,
       toType: DecimalType,

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
@@ -64,6 +64,12 @@ trait RapidsErrorUtilsFor330plus {
     QueryExecutionErrors.overflowInIntegralDivideError(origin.context)
   }
 
+  def arithmeticOverflowError(
+      message: String,
+      origin: Origin): ArithmeticException = {
+    QueryExecutionErrors.arithmeticOverflowError(message, "", origin.context)
+  }
+
   def foundDuplicateFieldInCaseInsensitiveModeError(
       requiredFieldName: String, matchedFields: String): Throwable = {
     QueryExecutionErrors.foundDuplicateFieldInCaseInsensitiveModeError(

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
@@ -91,7 +91,7 @@ object DecimalArithmeticOverrides {
                 GpuDecimalMultiply(lhs, rhs, d,
                   useLongMultiply = intermediatePrecision > DType.DECIMAL128_MAX_PRECISION)
               case _ =>
-                GpuMultiply(lhs, rhs)
+                GpuMultiply(lhs, rhs, origin = a.origin)
             }
           }
         }),
@@ -117,7 +117,7 @@ object DecimalArithmeticOverrides {
               case d: DecimalType =>
                 GpuDecimalDivide(lhs, rhs, d)
               case _ =>
-                GpuDivide(lhs, rhs)
+                GpuDivide(lhs, rhs, origin = a.origin)
             }
         }),
       expr[IntegralDivide](
@@ -131,7 +131,7 @@ object DecimalArithmeticOverrides {
             if (lhs.dataType.isInstanceOf[DecimalType] && rhs.dataType.isInstanceOf[DecimalType]) {
               GpuIntegralDecimalDivide(lhs, rhs)
             } else {
-              GpuIntegralDivide(lhs, rhs)
+              GpuIntegralDivide(lhs, rhs, origin = a.origin)
             }
         }),
 

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -52,6 +52,7 @@ import com.nvidia.spark.rapids.shims.NullIntolerantShim
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
@@ -210,7 +211,8 @@ trait GpuAddSub extends CudfBinaryArithmetic {
 case class GpuAdd(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends GpuAddBase with GpuAddSub {
+    failOnError: Boolean,
+    override val origin: Origin = CurrentOrigin.get) extends GpuAddBase with GpuAddSub {
 
   def do128BitOperation(
       castLhs: ColumnView,
@@ -223,7 +225,8 @@ case class GpuAdd(
 case class GpuSubtract(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends GpuSubtractBase with GpuAddSub {
+    failOnError: Boolean,
+    override val origin: Origin = CurrentOrigin.get) extends GpuSubtractBase with GpuAddSub {
   def do128BitOperation(
       castLhs: ColumnView,
       castRhs: ColumnView,
@@ -514,7 +517,9 @@ case class GpuDecimalMultiply(
 case class GpuIntegralDivide(
     left: Expression,
     right: Expression,
-    failOnError: Boolean = SQLConf.get.ansiEnabled) extends GpuIntegralDivideParent(left, right) {
+    failOnError: Boolean = SQLConf.get.ansiEnabled,
+    override val origin: Origin = CurrentOrigin.get
+) extends GpuIntegralDivideParent(left, right) {
   assert(!left.dataType.isInstanceOf[DecimalType] ||
          !right.dataType.isInstanceOf[DecimalType],
     "DecimalType integral divides need to be handled by GpuIntegralDecimalDivide")

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -231,7 +231,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL -- jar contains udf class", ADJUST_UT("Replaced by testRapids version that uses testFile() to access Spark test resources instead of getContextClassLoader"))
     .exclude("SPARK-33482: Fix FileScan canonicalization", ADJUST_UT("Replaced by testRapids version using V1 sources with AQE and broadcast disabled to assert ReusedExchangeExec directly"))
     .exclude("SPARK-36093: RemoveRedundantAliases should not change expression's name", ADJUST_UT("Replaced by testRapids version that checks the partition column name of the GpuInsertIntoHadoopFsRelationCommand"))
-    .exclude("SPARK-39166: Query context of binary arithmetic should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))
     .exclude("SPARK-39175: Query context of Cast should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))
     .exclude("SPARK-39177: Query context of getting map value should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))
     .exclude("SPARK-39190,SPARK-39208,SPARK-39210: Query context of decimal overflow error should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))


### PR DESCRIPTION
Partially addresses https://github.com/NVIDIA/spark-rapids/issues/14123 (recovers 1 of 4 excluded tests).

## Summary

- GPU arithmetic expressions (GpuAdd, GpuSubtract, GpuMultiply, GpuDivide, GpuIntegralDivide) did not include SQL query context in ANSI overflow/divide-by-zero exceptions, causing test SPARK-39166 to fail.
- Root cause: `TreeNode.origin` (set from `CurrentOrigin.get` at construction) is lost when AQE re-optimization recreates plan nodes via `makeCopy`, since `origin` is not a constructor parameter.
- Fix: add `override val origin: Origin` as an explicit case class constructor parameter to the five GPU arithmetic expression classes, ensuring the origin survives `makeCopy`. The CPU expression's origin is captured during GpuOverrides conversion and forwarded.
- The remaining 3 tests (SPARK-39175 Cast, SPARK-39177 Map value, SPARK-39190 Decimal overflow) can be recovered using the same `override val origin` technique on the respective GPU expression classes in follow-up PRs.

### Mapping

| RAPIDS test | Spark original test | Spark source file | Lines | Source links |
|---|---|---|---|---|
| RapidsSQLQuerySuite (inherited) | SPARK-39166: Query context of binary arithmetic should be serialized to executors when WSCG is off | sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala | 4448-4467 | [master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala#L4448-L4467), [v3.3.0 pinned](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala#L4362-L4381) |

### Performance

This change only modifies the **cold path** — no new branches, allocations, or synchronization points are added to the normal (per-batch) execution path.

**Plan conversion phase** (once per query):
- `CurrentOrigin.withOrigin(wrapped.origin)` wraps GPU expression construction in `RapidsMeta.convertToGpu()` — a thread-local get/set, negligible.
- GPU arithmetic case classes now carry an extra `Origin` field (a case class with 7 `Option` fields). This is a plan-level object; a typical query plan has tens to hundreds of expression nodes, adding at most a few hundred bytes.

**Normal execution path** (`GpuAdd.doColumnar` etc.):
- The cuDF computation, overflow detection logic (sign-bit XOR check), and result handling are **completely unchanged**. The `origin` field is never read on the normal path.

**Error path only** (overflow/divide-by-zero detected):
- When an arithmetic overflow IS detected (which aborts the query anyway), the exception now includes `origin.context` for the SQL query text. This is the only place the new `origin` field is read.

Conclusion: benchmark is unnecessary — this is a pure cold-path / error-path change with zero impact on the per-batch hot path.

### Checklists

- [ ] This PR has added documentation for new or modified features or
behaviors.
- [x] This PR has added new tests or modified existing tests to cover
new code paths.
(The SPARK-39166 exclusion is removed and the inherited Spark test now
passes on GPU, validating that arithmetic overflow exceptions include
SQL query context. Maven output: `Tests: succeeded 216, failed 0,
ignored 18`.)
- [x] Performance testing has been performed and its results are added
in the PR description. Or, an issue has been filed with a link in the PR
description.