### PR TITLE
Fix expensive `computeNumRowsDeleted` in multi-threaded Delta DV reader

### DIFF
--- a/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
@@ -361,14 +361,15 @@ class GpuDeltaParquetFileFormatBase2(
         rowGroupNumRows: Array[Int]): Long = {
       if (scalaBitmap.cardinality == 0) return 0L
       var count = 0L
+      val rowRanges = rowGroupOffsets.zip(rowGroupNumRows)
       // Computes the number of deleted rows by iterating only over the set bits
       // in the bitmap (deleted row indices) and checking which row group each
       // belongs to. This is O(deleted_rows * num_row_groups) instead of
       // O(total_rows). The former is usually smaller than the latter.
       // This is a temporary solution until we add a dedicated API in cuDF.
       scalaBitmap.forEach { deletedIndex: Long =>
-        rowGroupOffsets.zip(rowGroupNumRows).find { case (offset, count) =>
-          deletedIndex >= offset && deletedIndex < offset + count
+        rowRanges.find { case (offset, numRows) =>
+          deletedIndex >= offset && deletedIndex < offset + numRows
         }.foreach { _ =>
           // If the deleted index falls within this row group, count it as deleted.
           count += 1L


### PR DESCRIPTION
Fixes #14418.

### Description

It was reported in https://github.com/NVIDIA/spark-rapids/pull/14382 that the new DV-aware multi-threaded reader for Delta Lake can be slower sometimes than the existing multi-threaded reader. This is because of the expensive `computeNumRowsDeleted` calls as seen below.

<img width="3310" height="972" alt="Screenshot 2026-03-19 at 6 26 44 PM" src="https://github.com/user-attachments/assets/2bf2e638-5c1a-40d6-8851-e1e8949971b5" />

This flame graph shows that it was spending quite an amount of time in `computeNumRowsDeleted` during the scan stage.

The reasons of the slowness are twofold.

- `computeNumRowsDeleted` computes the number of rows deleted within given row ranges in a deletion vector. It iterates over every row index in every row group calling bitmap.contains() one at a time — O(total_rows)
- `computeNumRowsDeleted` is called in two cases, 1) when constructing an empty `ColumnarBatch` with a valid size, and 2) when populating partition values. These are all done in the main thread sequentially.

This PR fixes this issue by addressing both reasons.

- The deleted row count computation now uses a different algorithm that takes all set bits in the bitmap and probe them against the given row ranges. This is practically faster than the previous algorithm since, in majority cases, the bits set in the bitmap (deleted rows) is much smaller than the row count in a row group.
- Computing the deleted row count has been moved to SpillableDeletionVectorInfo construction time, which is done by the parallel reader threads.

Here are new evaluation results. I used the same test settings as what I used for https://github.com/NVIDIA/spark-rapids/pull/14382.

TPC-H

|  | Mean runtime (ms) | Speedup |
| :--- | :---: | ---: |
| CPU | 2712.6 | 1 |
| existing GPU reader | 1047.8 | 2.59 |
| DV-aware reader (before) | 1929.4 | 1.41 |
| DV-aware reader (after) | 970.2 | 2.80 |

TPC-DS

|  | Mean runtime (ms) | Speedup |
| :--- | :---: | ---: |
| CPU | 1631.4 | 1 |
| existing GPU reader | 4841.6 | 0.37 |
| DV-aware reader (before) | 1293.6 | 1.26 |
| DV-aware reader (after) | 929.0 | 1.76 |

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR is covered by existing tests.
- [x] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
