### PR TITLE
Fix DB-17.3 integration tests in join_test.py [databricks]

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -204,6 +204,8 @@ def test_empty_broadcast_hash_join(join_type, kudo_enabled):
 
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
+# https://github.com/NVIDIA/spark-rapids/issues/11100
+@allow_non_gpu('EmptyRelationExec')
 def test_broadcast_hash_join_constant_keys(join_type, kudo_enabled):
     def do_join(spark):
         left = spark.range(10).withColumn("s", lit(1))
@@ -803,7 +805,10 @@ def test_right_broadcast_nested_loop_join_condition_missing_count(data_gen, join
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.join(broadcast(right), how=join_type).selectExpr('COUNT(*)')
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled})
+    # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled,
+                                                          'spark.sql.adaptive.enabled': 'false'
+                                                          })
 
 @pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens + [binary_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Right'], ids=idfn)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14308.

### Description

This PR fixes two integration test failures in `join_test.py` on Databricks 17.3:

1. **`test_broadcast_hash_join_constant_keys`**: Allow  `EmptyRelationExec` to run on CPU. 
    We don't plan to support EmptyRelationExec on GPU - https://github.com/NVIDIA/spark-rapids/issues/11100.

3. **`test_right_broadcast_nested_loop_join_condition_missing_count`**: Disables AQE 
   temporarily to avoid a test failure caused by AQE rewriting the plan in an 
   unexpected way on DB 17.3. Tracked in https://github.com/NVIDIA/spark-rapids/issues/14319.

### Testing

Validated against DB 17.3 integration test for join_test.py :

```
= 4457 passed, 54 skipped, 12 xfailed, 12 xpassed, 2670 warnings in 7333.38s (2:02:13) =

```

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
