### PR TITLE
Fix compile break from BloomFilter.create deprecation

### DIFF
--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
@@ -112,7 +112,10 @@ object GpuBloomFilterAggregate {
 
 case class GpuBloomFilterUpdate(numHashes: Int, numBits: Long) extends CudfAggregate {
   override val reductionAggregate: ColumnVector => Scalar = (col: ColumnVector) => {
-    closeOnExcept(BloomFilter.create(numHashes, numBits)) { bloomFilter =>
+    // TODO: Address this properly in https://github.com/NVIDIA/spark-rapids/pull/14406.
+    // For now, only the v1 version of bloom-filters is supported.
+    closeOnExcept(BloomFilter.create(
+      BloomFilter.VERSION_1, numHashes, numBits, BloomFilter.DEFAULT_SEED)) { bloomFilter =>
       BloomFilter.put(bloomFilter, col)
       bloomFilter
     }


### PR DESCRIPTION
Fixes #14462.

### Description
This change addresses the build breakage in `spark-rapids` from the deprecation of `spark-rapids-jni` `BloomFilter.create(int,int)` deprecation, introduced in NVIDIA/spark-rapids-jni#4360.

This is a stop-gap solution that only restores prior behaviour, i.e. support for the BloomFilter v1 binary format.

Actual support for the BloomFilter v2 format will follow in #14406.

### Checklists
- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
