### PR TITLE
Skip delta lake tests for DB-17.3 [databricks]

### DIFF
--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -150,9 +150,13 @@ if [[ "$(pwd)" == "$SOURCE_PATH" ]]; then
     fi
 
     if [[ "$TEST_MODE" == "DEFAULT" || $TEST_MODE == "CI_PART2" || "$TEST_MODE" == "DELTA_LAKE_ONLY" ]]; then
-        ## Run Delta Lake tests
-        DRIVER_MEMORY="4g" \
-            bash integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m "delta_lake" --delta_lake --test_type=$TEST_TYPE
+        if [[ "$SPARK_SHIM_VER" == "spark400db173" ]]; then
+            echo "Skipping Delta Lake tests: not yet supported for DB-17.3 (spark400db173)"
+        else
+            ## Run Delta Lake tests
+            DRIVER_MEMORY="4g" \
+                bash integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m "delta_lake" --delta_lake --test_type=$TEST_TYPE
+        fi
     fi
 
     if [[ "$TEST_MODE" == "DEFAULT" || $TEST_MODE == "CI_PART2" || "$TEST_MODE" == "MULTITHREADED_SHUFFLE" ]]; then


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14473

### Description

DB-17.3 uses `rapids-4-spark-delta-stub` since there is no delta lake implementation yet for `spark400db173`. Skip the delta lake integration tests in `test.sh` for DB-17.3.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
