### PR TITLE
Delay Parquet reader resource collection until close.

### DIFF
--- a/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
+++ b/delta-lake/common/src/main/delta-33x-40x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
@@ -1299,7 +1299,7 @@ case class DeltaParquetTableReader(
       maxChunkedReaderMemoryUsageSizeBytes, opts, buffers, dvInfos)
   )
 
-  override protected val resources: Seq[AutoCloseable] =
+  override protected lazy val resources: Seq[AutoCloseable] =
     Seq(reader) ++ buffers ++ dvInfos.map(_.serializedBitmap)
 
   override protected def postProcessChunk(chunk: Table): Table = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -3456,7 +3456,9 @@ abstract class AbstractParquetTableReader(
 
   private[this] lazy val splitsString = splits.mkString("; ")
 
-  protected val resources: Seq[AutoCloseable] = Seq(reader) ++ buffers
+  // Should be lazy since the reader is not defined. Otherwise in practise, a native
+  // chunk reader will be leaked.
+  protected lazy val resources: Seq[AutoCloseable] = Seq(reader) ++ buffers
 
   override def hasNext: Boolean = reader.hasNext
 


### PR DESCRIPTION
Use a method instead of an eagerly initialized value so AbstractParquetTableReader does not capture an uninitialized subclass reader while the superclass constructor is still running.

This delays resource collection until close time, ensuring the cleanup path sees the fully initialized reader instance instead of a value captured too early. In practice, that should keep the JNI chunked reader in the close path and avoid leaking native or GPU-backed reader state across batches.

This is tested by a QA OOM case manually and it works well.

Made-with: Cursor (https://github.com/NVIDIA/spark-rapids/pull/14463 is for main, so need to pick it manually)

### Checklists


- [x] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
