### PR TITLE
Databricks run-tests: rsync test reports from scala2.13 for Spark 4.x [databricks]

### DIFF
--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,11 @@ def main():
         subprocess.check_call(ssh_command, shell=True)
     finally:
         print("Copying test report tarball back")
-        report_path_prefix = params.jar_path if params.jar_path else "/home/ubuntu/spark-rapids"
+        if params.base_spark_pom_version.startswith("4."):
+            default_jar_path = "/home/ubuntu/spark-rapids/scala2.13"
+        else:
+            default_jar_path = "/home/ubuntu/spark-rapids"
+        report_path_prefix = params.jar_path if params.jar_path else default_jar_path
         rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:%s/integration_tests/target/run_dir*/TEST-pytest-*.xml ./" % \
             (ssh_args, master_addr, report_path_prefix)
         print("rsync command: %s" % rsync_command)


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids/issues/14491

When jar_path is unset, use /home/ubuntu/spark-rapids/scala2.13 if base_spark_pom_version is 4.x; 

otherwise keep the default tree root.


- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
