### PR TITLE
Update shared actions to Node 24 for GitHub Actions Node 20 deprecation [skip ci]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ jobs:
     runs-on: vulnerability-scan
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: NVIDIA/spark-rapids-common/checkout@main
         with:
           repository: ${{ fromJson(needs.Authorization.outputs.args).repo }}
           ref: ${{ fromJson(needs.Authorization.outputs.args).ref }}

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ jobs:
           echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 10 ))" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: NVIDIA/spark-rapids-common/checkout@main
         with:
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 

--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: work around permission issue
       run: git config --global --add safe.directory /github/workspace
-    - uses: actions/checkout@master
+    - uses: NVIDIA/spark-rapids-common/checkout@main
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         max-depth: -1

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ jobs:
       sparkTailVersions: ${{ steps.all212ShimVersionsStep.outputs.tailVersions }}
       sparkJDKVersions: ${{ steps.all212ShimVersionsStep.outputs.jdkVersions }}
     steps:
-      - uses: actions/checkout@v4 # refs/pull/:prNumber/merge
+      - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -61,7 +61,7 @@ jobs:
       - name: Cache local Maven repository
         id: cache
         continue-on-error: true
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ env.dailyCacheKey }}
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # refs/pull/:prNumber/merge
+      - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
         uses: actions/setup-java@v5
@@ -123,7 +123,7 @@ jobs:
 
       - name: Cache local Maven repository
         continue-on-error: true
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ needs.cache-dependencies.outputs.dailyCacheKey }}
@@ -162,7 +162,7 @@ jobs:
       scala213Versions: ${{ steps.all213ShimVersionsStep.outputs.scala213Versions }}
       sparkJDK17Versions: ${{ steps.all213ShimVersionsStep.outputs.jdkVersions }}
     steps:
-      - uses: actions/checkout@v4 # refs/pull/:prNumber/merge
+      - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -179,7 +179,7 @@ jobs:
       - name: Cache local Maven repository
         id: cache
         continue-on-error: true
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ env.scala213dailyCacheKey }}
@@ -224,7 +224,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v4 # refs/pull/:prNumber/merge
+      - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
         uses: actions/setup-java@v5
@@ -234,7 +234,7 @@ jobs:
 
       - name: Cache local Maven repository
         continue-on-error: true
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ needs.cache-dependencies-scala213.outputs.scala213dailyCacheKey }}
@@ -280,7 +280,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.cache-dependencies-scala213.outputs.sparkJDK17Versions) }}
     steps:
-      - uses: actions/checkout@v4 # refs/pull/:prNumber/merge
+      - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
         uses: actions/setup-java@v5
@@ -290,7 +290,7 @@ jobs:
 
       - name: Cache local Maven repository
         continue-on-error: true
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ needs.cache-dependencies-scala213.outputs.scala213dailyCacheKey }}
@@ -335,7 +335,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.cache-dependencies.outputs.sparkJDKVersions) }}
     steps:
-      - uses: actions/checkout@v4 # refs/pull/:prNumber/merge
+      - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
         uses: actions/setup-java@v5
@@ -345,7 +345,7 @@ jobs:
 
       - name: Cache local Maven repository
         continue-on-error: true
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ needs.cache-dependencies.outputs.dailyCacheKey }}
@@ -383,7 +383,7 @@ jobs:
       matrix:
         maven-version: [3.6.3, 3.8.8, 3.9.3]
     steps:
-      - uses: actions/checkout@v4 # refs/pull/:prNumber/merge
+      - uses: NVIDIA/spark-rapids-common/checkout@main # refs/pull/:prNumber/merge
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -393,7 +393,7 @@ jobs:
 
       - name: Cache local Maven repository
         continue-on-error: true
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ needs.cache-dependencies.outputs.dailyCacheKey }}


### PR DESCRIPTION
  ### Changes

  Update all GitHub Actions workflow dependencies to Node 24 compatible versions, addressing the upcoming https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

  | File | Before | After |
  |------|--------|-------|
  | `blossom-ci.yml` | `actions/checkout@v4` | `NVIDIA/spark-rapids-common/checkout@main` (Node 24) |
  | `license-header-check.yml` | `actions/checkout@v4` | `NVIDIA/spark-rapids-common/checkout@main` (Node 24) |
  | `markdown-links-check.yml` | `actions/checkout@master` | `NVIDIA/spark-rapids-common/checkout@main` (Node 24) |
  | `mvn-verify-check.yml` | `actions/checkout@v4` (7x) | `NVIDIA/spark-rapids-common/checkout@main` (Node 24) |
  | `mvn-verify-check.yml` | `actions/cache@v4` (7x) | `actions/cache@v5` (Node 24) |
  
### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.



All checkout usages now use the shared `NVIDIA/spark-rapids-common/checkout@main` wrapper for centralized version management. Existing `with:` parameters (fetch-depth, repository, ref, lfs) are preserved.