### PR TITLE
Remove deprecated GpuTimeZoneDB cache overload usage

### DIFF
--- a/docs/additional-functionality/advanced_configs.md
+++ b/docs/additional-functionality/advanced_configs.md
@@ -171,8 +171,6 @@ Name | Description | Default Value | Applicable at
 <a name="sql.window.range.int.enabled"></a>spark.rapids.sql.window.range.int.enabled|When the order-by column of a range based window is int type and the range boundary calculated for a value has overflow, CPU and GPU will get the different results. When set to false disables the range window acceleration for the int type order-by column|true|Runtime
 <a name="sql.window.range.long.enabled"></a>spark.rapids.sql.window.range.long.enabled|When the order-by column of a range based window is long type and the range boundary calculated for a value has overflow, CPU and GPU will get the different results. When set to false disables the range window acceleration for the long type order-by column|true|Runtime
 <a name="sql.window.range.short.enabled"></a>spark.rapids.sql.window.range.short.enabled|When the order-by column of a range based window is short type and the range boundary calculated for a value has overflow, CPU and GPU will get the different results. When set to false disables the range window acceleration for the short type order-by column|false|Runtime
-<a name="timezone.transitionCache.maxYear"></a>spark.rapids.timezone.transitionCache.maxYear|Set the max year for timestamp processing for timezones with transitions such as Daylight Savings. For efficiency reasons, timestamp transitions are stored on the GPU. We store transitions up to some set year. Adding more years will use more memory, every 100 years is roughly 1MB.|2200|Startup
-
 ## Supported GPU Operators and Fine Tuning
 _The RAPIDS Accelerator for Apache Spark_ can be configured to enable or disable specific
 GPU accelerated expressions.  Enabled expressions are candidates for GPU execution. If the

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -938,7 +938,7 @@ def test_cast_string_to_timestamp_valid():
             'str_col string')
     def _query(spark):
         # depends on the timezone info in `GpuTimeZoneDB`, load first
-        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase(2200)
+        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase()
         return _gen_df(spark).selectExpr("cast(str_col as timestamp)")
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: _query(spark))
@@ -991,7 +991,7 @@ def test_cast_string_to_timestamp_just_time_ANSI_OFF():
 
     def _query(spark):
         # depends on the timezone info in `GpuTimeZoneDB`, load first
-        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase(2200)
+        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase()
         return _gen_df(spark).selectExpr("cast(str_col as timestamp)")
 
     assert_gpu_and_cpu_are_equal_collect(lambda spark: _query(spark))
@@ -1026,7 +1026,7 @@ def test_cast_string_to_timestamp_valid_just_time_with_timezone():
 
     def _query(spark):
         # depends on the timezone info in `GpuTimeZoneDB`, load first
-        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase(2200)
+        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase()
         return _gen_df(spark).selectExpr("cast(str_col as timestamp)")
 
     assert_gpu_and_cpu_are_equal_collect(
@@ -1155,7 +1155,7 @@ def test_cast_string_to_timestamp_invalid_ANSI_OFF():
             'str_col string')
     def _query(spark):
         # depends on the timezone info in `GpuTimeZoneDB`, load first
-        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase(2200)
+        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase()
         return _gen_df(spark).selectExpr("cast(str_col as timestamp)")
 
     assert_gpu_and_cpu_are_equal_collect(
@@ -1170,7 +1170,7 @@ def test_cast_string_to_timestamp_invalid_ansi_enabled(invalid_item):
             'str_col string')
     def _query(spark):
         # depends on the timezone info in `GpuTimeZoneDB`, load first
-        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase(2200)
+        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase()
         return _gen_df(spark).selectExpr("cast(str_col as timestamp)")
 
     assert_gpu_and_cpu_error(
@@ -1213,7 +1213,7 @@ def test_cast_string_to_timestamp_const_format_ANSI_OFF(pattern):
     gen = [("str_col", StringGen(pattern))]
     def _query(spark):
         # depends on the timezone info in `GpuTimeZoneDB`, load first
-        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase(2200)
+        spark._jvm.com.nvidia.spark.rapids.jni.GpuTimeZoneDB.cacheDatabase()
         return gen_df(spark, gen).selectExpr("cast(str_col as timestamp)")
 
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -648,7 +648,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       }
 
       // Initialize timezone database cache asynchronously on executor startup
-      GpuTimeZoneDB.cacheDatabaseAsync(conf.timestampRulesEndYear)
+      GpuTimeZoneDB.cacheDatabaseAsync()
 
       GpuCoreDumpHandler.executorInit(conf, pluginContext)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -734,15 +734,6 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .stringConf
     .createOptional
 
-  val TIMESTAMP_RULES_END_YEAR = conf("spark.rapids.timezone.transitionCache.maxYear")
-    .doc("Set the max year for timestamp processing for timezones with transitions " +
-      "such as Daylight Savings. For efficiency reasons, timestamp" +
-      " transitions are stored on the GPU. We store transitions up to some set year." +
-      " Adding more years will use more memory, every 100 years is roughly 1MB.")
-    .startupOnly()
-    .integerConf
-    .createWithDefault(2200)
-
   // Internal Features
 
   val UVM_ENABLED = conf("spark.rapids.memory.uvm.enabled")
@@ -3889,8 +3880,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val gpuWriteMemorySpeed: Double = get(OPTIMIZER_GPU_WRITE_SPEED)
 
   lazy val driverTimeZone: Option[String] = get(DRIVER_TIMEZONE)
-
-  lazy val timestampRulesEndYear: Int = get(TIMESTAMP_RULES_END_YEAR)
 
   lazy val isRangeWindowByteEnabled: Boolean = get(ENABLE_RANGE_WINDOW_BYTES)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZonePerfSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZonePerfSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,8 +60,6 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
   private val zones = timeZoneStrings.split(",")
 
   private val path = "/tmp/tmp_TimeZonePerfSuite"
-
-  private val timestampRulesEndYear = 2200
 
   /**
    * Create a Parquet file to test
@@ -186,7 +184,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {
@@ -202,7 +200,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {
@@ -218,7 +216,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {
@@ -235,7 +233,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {
@@ -252,7 +250,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {
@@ -269,7 +267,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {
@@ -286,7 +284,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {
@@ -303,7 +301,7 @@ class TimeZonePerfSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAl
     assume(enablePerfTest)
 
     // cache time zone DB in advance
-    GpuTimeZoneDB.cacheDatabase(timestampRulesEndYear)
+    GpuTimeZoneDB.cacheDatabase()
     Thread.sleep(5L)
 
     def perfTest(spark: SparkSession, zone: String): DataFrame = {


### PR DESCRIPTION
### Description

Previously,  we use hybrid mode:
- before 2200 year, generate a transition cache for DST timezone, and run on GPU for timezone rebasing.
This mehod wastes GPU memories.
- after 2200 year, use CPU to do timezone rebasing.
This is slow.

Currently, we do not use hybrid mode any more, so remove the deprecated methods.

- Replace deprecated `GpuTimeZoneDB.cacheDatabaseAsync(int)` and `cacheDatabase(int)` usage with the no-arg APIs.
- Remove the now-unused `spark.rapids.timezone.transitionCache.maxYear` config and obsolete docs entry.
- Update timezone perf and cast tests to call the replacement API.

## Related change
* https://github.com/NVIDIA/spark-rapids-jni/pull/4422

### Checklists
- [x] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
 (Updated existing timezone perf and cast tests to exercise the replacement API entry points.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.

Signed-off-by: Chong Gao <chongg@nvidia.com>