### PR TITLE
Fix thread-safety issue in RapidsShuffleInternalManagerBase.unregisterShuffle

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -2104,8 +2104,10 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
     shuffleBlockResolver match {
       case isbr: IndexShuffleBlockResolver =>
         Option(taskIdMapsForShuffle.remove(shuffleId)).foreach { mapTaskIds =>
-          mapTaskIds.iterator.foreach { mapTaskId =>
-            isbr.removeDataByMap(shuffleId, mapTaskId)
+          mapTaskIds.synchronized {
+            mapTaskIds.iterator.foreach { mapTaskId =>
+              isbr.removeDataByMap(shuffleId, mapTaskId)
+            }
           }
         }
       case _: GpuShuffleBlockResolver => // noop


### PR DESCRIPTION
Fixes #14249.

### Description
Synchronize on mapTaskIds during iteration in unregisterShuffle to prevent races with trackMapTaskForCleanup which adds entries under the same lock. This mirrors the Spark fix in SPARK-53636.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
 No need to test perf, because:
 The lock is uncontended in practice -- After taskIdMapsForShuffle.remove(shuffleId) atomically removes the entry, no other thread can obtain a reference to this same OpenHashSet via computeIfAbsent (they'd get a new instance). So the synchronized block will almost never actually block.


