### PR TITLE
Fix batched window passthrough for mixed ROWS windows

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids.{BaseExprMeta, DataFromReplacementRule, GpuAlias, GpuExec, GpuLiteral, GpuOverrides, GpuProjectExec, RapidsConf, RapidsMeta, SparkPlanMeta}
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, CurrentRow, ExprId, Expression, NamedExpression, RowFrame, SortOrder, UnboundedFollowing, UnboundedPreceding}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, CurrentRow, Expression, ExprId, NamedExpression, RowFrame, SortOrder, UnboundedFollowing, UnboundedPreceding}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.rapids.aggregate.GpuAggregateExpression
@@ -239,48 +239,68 @@ case class BatchedOps(running: Seq[NamedExpression],
    */
   private def collectPassthroughDependencies(
       futureExpressions: Seq[NamedExpression],
-      availableOutputs: Seq[NamedExpression]): Seq[NamedExpression] = {
+      availableOutputs: Seq[NamedExpression],
+      childOutput: Seq[Attribute]): Seq[NamedExpression] = {
     val seen = mutable.HashSet.empty[ExprId]
     seen ++= availableOutputs.map(_.exprId)
+    val childOutputByExprId = childOutput.iterator.map(attr => attr.exprId -> attr).toMap
     val needed = ArrayBuffer.empty[NamedExpression]
     futureExpressions.foreach(_.foreach {
       case attr: Attribute if !seen.contains(attr.exprId) =>
-        seen += attr.exprId
-        needed += attr
+        val resolvedAttr = childOutputByExprId.getOrElse(attr.exprId, {
+          throw new IllegalArgumentException(
+            s"Unable to preserve passthrough dependency $attr because it is not produced by " +
+                s"the original child output")
+        })
+        seen += resolvedAttr.exprId
+        needed += resolvedAttr
       case _ =>
     })
     needed.toSeq
   }
 
-  private lazy val runningPassthrough: Seq[NamedExpression] =
+  private def getRunningPassthrough(childOutput: Seq[Attribute]): Seq[NamedExpression] =
     dedupeByExprId(passThrough ++
       collectPassthroughDependencies(
         unboundedAgg ++ unboundedDoublePass ++ bounded,
-        passThrough ++ running))
+        passThrough ++ running,
+        childOutput))
 
-  private lazy val unboundedAggPassthrough: Seq[NamedExpression] =
+  private def getUnboundedAggPassthrough(childOutput: Seq[Attribute]): Seq[NamedExpression] = {
+    val runningPassthrough = getRunningPassthrough(childOutput)
     dedupeByExprId(runningPassthrough ++
       collectPassthroughDependencies(
         unboundedDoublePass ++ bounded,
-        runningPassthrough ++ running ++ unboundedAgg))
+        runningPassthrough ++ running ++ unboundedAgg,
+        childOutput))
+  }
 
-  private lazy val doublePassPassthrough: Seq[NamedExpression] =
+  private def getDoublePassPassthrough(childOutput: Seq[Attribute]): Seq[NamedExpression] = {
+    val unboundedAggPassthrough = getUnboundedAggPassthrough(childOutput)
     dedupeByExprId(unboundedAggPassthrough ++
       collectPassthroughDependencies(
         bounded,
-        unboundedAggPassthrough ++ running ++ unboundedAgg ++ unboundedDoublePass))
+        unboundedAggPassthrough ++ running ++ unboundedAgg ++ unboundedDoublePass,
+        childOutput))
+  }
 
-  def getRunningExpressionsWithPassthrough: Seq[NamedExpression] =
-    runningPassthrough ++ running
+  def getRunningExpressionsWithPassthrough(childOutput: Seq[Attribute]): Seq[NamedExpression] =
+    getRunningPassthrough(childOutput) ++ running
 
-  def getUnboundedAggWithRunningAsPassthrough: Seq[NamedExpression] =
-    unboundedAggPassthrough ++ unboundedAgg ++ running.map(_.toAttribute)
+  def getUnboundedAggWithRunningAsPassthrough(
+      childOutput: Seq[Attribute]): Seq[NamedExpression] =
+    getUnboundedAggPassthrough(childOutput) ++ unboundedAgg ++ running.map(_.toAttribute)
 
-  def getDoublePassExpressionsWithRunningAndUnboundedAggAsPassthrough: Seq[NamedExpression] =
-    doublePassPassthrough ++ unboundedDoublePass ++ (unboundedAgg ++ running).map(_.toAttribute)
+  def getDoublePassExpressionsWithRunningAndUnboundedAggAsPassthrough(
+      childOutput: Seq[Attribute]): Seq[NamedExpression] =
+    getDoublePassPassthrough(childOutput) ++
+      unboundedDoublePass ++
+      (unboundedAgg ++ running).map(_.toAttribute)
 
-  def getBoundedExpressionsWithTheRestAsPassthrough: Seq[NamedExpression] =
-    doublePassPassthrough ++ bounded ++
+  def getBoundedExpressionsWithTheRestAsPassthrough(
+      childOutput: Seq[Attribute]): Seq[NamedExpression] =
+    getDoublePassPassthrough(childOutput) ++
+      bounded ++
       (unboundedDoublePass ++ unboundedAgg ++ running).map(_.toAttribute)
 
   def getMinPrecedingMaxFollowingForBoundedWindows: (Int, Int) = {
@@ -301,10 +321,11 @@ case class BatchedOps(running: Seq[NamedExpression],
       gpuPartitionSpec: Seq[Expression],
       gpuOrderSpec: Seq[SortOrder],
       child: SparkPlan,
+      childOutput: Seq[Attribute],
       cpuPartitionSpec: Seq[Expression],
       cpuOrderSpec: Seq[SortOrder]): GpuExec =
     GpuRunningWindowExec(
-      getRunningExpressionsWithPassthrough,
+      getRunningExpressionsWithPassthrough(childOutput),
       gpuPartitionSpec,
       gpuOrderSpec,
       child)(cpuPartitionSpec, cpuOrderSpec)
@@ -313,11 +334,12 @@ case class BatchedOps(running: Seq[NamedExpression],
       gpuPartitionSpec: Seq[Expression],
       gpuOrderSpec: Seq[SortOrder],
       child: SparkPlan,
+      childOutput: Seq[Attribute],
       cpuPartitionSpec: Seq[Expression],
       cpuOrderSpec: Seq[SortOrder],
       conf: RapidsConf): GpuExec =
     GpuUnboundedToUnboundedAggWindowExec(
-      getUnboundedAggWithRunningAsPassthrough,
+      getUnboundedAggWithRunningAsPassthrough(childOutput),
       gpuPartitionSpec,
       gpuOrderSpec,
       child)(cpuPartitionSpec, cpuOrderSpec, conf.gpuTargetBatchSizeBytes)
@@ -326,10 +348,11 @@ case class BatchedOps(running: Seq[NamedExpression],
       gpuPartitionSpec: Seq[Expression],
       gpuOrderSpec: Seq[SortOrder],
       child: SparkPlan,
+      childOutput: Seq[Attribute],
       cpuPartitionSpec: Seq[Expression],
       cpuOrderSpec: Seq[SortOrder]): GpuExec =
     GpuCachedDoublePassWindowExec(
-      getDoublePassExpressionsWithRunningAndUnboundedAggAsPassthrough,
+      getDoublePassExpressionsWithRunningAndUnboundedAggAsPassthrough(childOutput),
       gpuPartitionSpec,
       gpuOrderSpec,
       child)(cpuPartitionSpec, cpuOrderSpec)
@@ -337,10 +360,11 @@ case class BatchedOps(running: Seq[NamedExpression],
   private def getBatchedBoundedWindowExec(gpuPartitionSpec: Seq[Expression],
       gpuOrderSpec: Seq[SortOrder],
       child: SparkPlan,
+      childOutput: Seq[Attribute],
       cpuPartitionSpec: Seq[Expression],
       cpuOrderSpec: Seq[SortOrder]): GpuExec = {
     val (prec@_, foll@_) = getMinPrecedingMaxFollowingForBoundedWindows
-    new GpuBatchedBoundedWindowExec(getBoundedExpressionsWithTheRestAsPassthrough,
+    new GpuBatchedBoundedWindowExec(getBoundedExpressionsWithTheRestAsPassthrough(childOutput),
       gpuPartitionSpec,
       gpuOrderSpec,
       child)(cpuPartitionSpec, cpuOrderSpec, prec, foll)
@@ -355,24 +379,28 @@ case class BatchedOps(running: Seq[NamedExpression],
       conf: RapidsConf): GpuExec = {
     // The order of these matter so we can match the order of the parameters used to
     //  create the various aggregation functions
+    val childOutput = child.output
     var currentPlan = child
     if (hasRunning) {
-      currentPlan = getRunningWindowExec(gpuPartitionSpec, gpuOrderSpec, currentPlan,
+      currentPlan = getRunningWindowExec(gpuPartitionSpec, gpuOrderSpec, currentPlan, childOutput,
         cpuPartitionSpec, cpuOrderSpec)
     }
 
     if (hasUnboundedAgg) {
       currentPlan = getUnboundedAggWindowExec(gpuPartitionSpec, gpuOrderSpec, currentPlan,
+        childOutput,
         cpuPartitionSpec, cpuOrderSpec, conf)
     }
 
     if (hasDoublePass) {
       currentPlan = getDoublePassWindowExec(gpuPartitionSpec, gpuOrderSpec, currentPlan,
+        childOutput,
         cpuPartitionSpec, cpuOrderSpec)
     }
 
     if (hasBounded) {
       currentPlan = getBatchedBoundedWindowExec(gpuPartitionSpec, gpuOrderSpec, currentPlan,
+        childOutput,
         cpuPartitionSpec, cpuOrderSpec)
     }
     currentPlan.asInstanceOf[GpuExec]

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
@@ -464,21 +464,97 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
       df.sparkSession.sql(
         """
           |SELECT id, grp, cat, val_dbl, val_long,
-          |  SUM(val_dbl) OVER (
-          |    PARTITION BY grp ORDER BY id
+          |  SUM(val_dbl + cat) OVER (
+          |    PARTITION BY grp ORDER BY id + cat
           |    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_sum,
-          |  SUM(val_dbl) OVER (
-          |    PARTITION BY grp ORDER BY id
+          |  SUM(val_dbl + cat) OVER (
+          |    PARTITION BY grp ORDER BY id + cat
           |    ROWS BETWEEN 5 PRECEDING AND 5 FOLLOWING) AS bounded_sum,
-          |  AVG(val_dbl) OVER (
-          |    PARTITION BY grp ORDER BY id
+          |  AVG(val_dbl + cat) OVER (
+          |    PARTITION BY grp ORDER BY id + cat
           |    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_avg,
-          |  AVG(val_dbl) OVER (
-          |    PARTITION BY grp ORDER BY id
+          |  AVG(val_dbl + cat) OVER (
+          |    PARTITION BY grp ORDER BY id + cat
           |    ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING) AS bounded_avg,
-          |  RANK() OVER (PARTITION BY grp ORDER BY val_dbl) AS rnk,
-          |  DENSE_RANK() OVER (PARTITION BY grp ORDER BY val_dbl) AS d_rnk
+          |  RANK() OVER (PARTITION BY grp ORDER BY val_dbl + cat) AS rnk,
+          |  DENSE_RANK() OVER (PARTITION BY grp ORDER BY val_dbl + cat) AS d_rnk
           |FROM mixed_window_bug
+          |ORDER BY id
+          |""".stripMargin)
+      // scalastyle:on line.size.limit
+  }
+
+  testSparkResultsAreEqual(
+    "[Window] [ROWS] mixed unbounded agg and bounded windows preserve pre-projected inputs",
+    spark => {
+      import spark.implicits._
+
+      spark.range(0, 40).select(
+        $"id".cast("int").as("id"),
+        ($"id" % 4).cast("int").as("grp"),
+        ($"id" % 7).cast("int").as("cat"),
+        (($"id" % 17).cast("double") + 0.5d).as("val_dbl"),
+        ($"id" * 13L).as("val_long"))
+    },
+    conf = new SparkConf()
+      .set("spark.sql.adaptive.enabled", "false")
+      .set("spark.rapids.sql.window.collectSet.enabled", "true")
+      .set("spark.rapids.sql.window.unboundedAgg.enabled", "true"),
+    existClasses = "GpuUnboundedToUnboundedAggWindowExec,GpuBatchedBoundedWindowExec") {
+    (df: DataFrame) =>
+      df.createOrReplaceTempView("mixed_unbounded_window_bug")
+      // scalastyle:off line.size.limit
+      df.sparkSession.sql(
+        """
+          |SELECT id, grp, cat, val_dbl,
+          |  SORT_ARRAY(COLLECT_SET(cat + 1) OVER (
+          |    PARTITION BY grp ORDER BY id
+          |    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)) AS full_collect,
+          |  SUM(val_dbl + cat) OVER (
+          |    PARTITION BY grp ORDER BY id + cat
+          |    ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS bounded_sum,
+          |  AVG(val_dbl + cat) OVER (
+          |    PARTITION BY grp ORDER BY id + cat
+          |    ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS bounded_avg
+          |FROM mixed_unbounded_window_bug
+          |ORDER BY id
+          |""".stripMargin)
+      // scalastyle:on line.size.limit
+  }
+
+  testSparkResultsAreEqual(
+    "[Window] [ROWS] mixed double-pass and bounded windows preserve pre-projected inputs",
+    spark => {
+      import spark.implicits._
+
+      spark.range(0, 100).select(
+        $"id".cast("int").as("id"),
+        ($"id" % 5).cast("int").as("grp"),
+        ($"id" % 7).cast("int").as("cat"),
+        (($"id" % 17).cast("double") + 0.5d).as("val_dbl"),
+        ($"id" * 13L).as("val_long"))
+    },
+    conf = new SparkConf().set("spark.sql.adaptive.enabled", "false"),
+    existClasses = "GpuCachedDoublePassWindowExec,GpuBatchedBoundedWindowExec") {
+    (df: DataFrame) =>
+      df.createOrReplaceTempView("mixed_double_pass_window_bug")
+      // scalastyle:off line.size.limit
+      df.sparkSession.sql(
+        """
+          |SELECT id, grp, cat, val_dbl, val_long,
+          |  MIN(val_long) OVER (
+          |    PARTITION BY grp ORDER BY id
+          |    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS full_min,
+          |  MAX(val_long) OVER (
+          |    PARTITION BY grp ORDER BY id
+          |    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS full_max,
+          |  COUNT(val_dbl) OVER (
+          |    PARTITION BY grp ORDER BY id
+          |    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS full_count,
+          |  SUM(val_dbl + cat) OVER (
+          |    PARTITION BY grp ORDER BY id + cat
+          |    ROWS BETWEEN 4 PRECEDING AND 4 FOLLOWING) AS bounded_sum
+          |FROM mixed_double_pass_window_bug
           |ORDER BY id
           |""".stripMargin)
       // scalastyle:on line.size.limit


### PR DESCRIPTION
Preserve pre-projected inputs across running, unbounded, double-pass, and bounded batched window stages so downstream window expressions keep required intermediate attributes. Add a WindowFunctionSuite regression test for mixed running and bounded ROWS windows.

Made-with: Cursor
(picked from https://github.com/NVIDIA/spark-rapids/pull/14529)
### Checklists

- [x] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
