### PR TITLE
Fix splitability tests for the Delta scan with deletion vectors [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -375,7 +375,7 @@ def test_delta_scan_split_with_DV_disabled_with_DVs(spark_tmp_path, pushdown_dv_
         assert num_deleted > 0, "Expected some rows to be deleted"
         spark.sql(f"ALTER TABLE delta.`{data_path}` SET TBLPROPERTIES " +
                   "('delta.enableDeletionVectors' = 'false')")
-    # The cuDF-based reader (GpuDeltaParquetFileFormat2), which is used when dv_predicate_pushdown is True, support the file split,
+    # The cuDF-based reader (GpuDeltaParquetFileFormat2), which is used when dv_predicate_pushdown is True, supports the file split,
     # whereas the scala reader (GpuDeltaParquetFileFormat) does not support it.
     # So we expect 2 partitions when dv_predicate_pushdown is True, and 1 partition when it is False.
     expected_num_partitions = 2 if pushdown_dv_predicate else 1


### PR DESCRIPTION
Fixes #14511.

### Description

The `test_delta_scan_split_*` tests in `delta_lake_test.py` test the splitability of the Delta reader with and without deletion vectors. We have these tests as the old Delta reader (`GpuDeltaParquetFileFormat`) does not support the file split and we want to make sure of it (it will return invalid results if the file split is somehow enabled). These tests has been failing since https://github.com/NVIDIA/spark-rapids/pull/14460 was merged as the default reader for Delta is the new cuDF-based reader which does support the file split. This PR fixes those tests by using different expected number of splits based on the reader type.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
