### PR TITLE
Explicit check boxes for non-applicable PR checklist items [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,11 +29,20 @@ Please provide a description of the changes proposed in this pull request. Here 
 ### Checklists
 
 <!-- 
-Check the items that apply by putting "x" in the brackets.
-Leave non-applicable items unchecked — do not delete them.
+For each category, check the one item that applies by putting "x" in the brackets.
 -->
 
-- [ ] This PR has added documentation for new or modified features or behaviors.
-- [ ] This PR has added new tests or modified existing tests to cover new code paths.
-      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
-- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
+Documentation
+- [ ] Updated for new or modified user-facing features or behaviors
+- [ ] No user-facing change
+
+Testing
+- [ ] Added or modified tests to cover new code paths
+- [ ] Covered by existing tests
+      (Please provide the names of the existing tests in the PR description.)
+- [ ] Not required
+
+Performance
+- [ ] Tests ran and results are added in the PR description
+- [ ] Issue filed with a link in the PR description
+- [ ] Not required


### PR DESCRIPTION
### Description

We have a checklist in the PR template. This is useful not only for authors but also for reviewers to remember the baseline requirements for majority of PRs. Authors should think about them carefully and check if they apply. Reviewers should think about unchecked items whether they make sense if any. For this reason, the checklist items should remain unchecked in the PR description if they do not apply to the PR. However, it appears that this is not clear to people. This PR adds explicit check boxes for non-applicable checklist items.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.
