### PR TITLE
[auto-merge] release/26.04 to main [skip ci] [bot]

### DIFF
--- a/docs/archive.md
+++ b/docs/archive.md
@@ -5,6 +5,178 @@ nav_order: 15
 ---
 Below are archived releases for RAPIDS Accelerator for Apache Spark.
 
+## Release v26.02.1
+### Hardware Requirements:
+
+The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Hopper and Blackwell generation datacenter GPUs.  The plugin jar is tested on the following GPUs:
+
+	GPU Models: NVIDIA V100, T4, A10, A100, L4, H100 and B100 GPUs
+
+### Software Requirements:
+
+    OS: Spark RAPIDS is compatible with any Linux distribution with glibc >= 2.28 (Please check ldd --version output).  glibc 2.28 was released August 1, 2018. 
+    Tested on Ubuntu 22.04, Ubuntu 24.04, Rocky Linux 8 and Rocky Linux 9
+
+	NVIDIA Driver*: R525+
+
+	Runtime: 
+		Scala 2.12, 2.13
+		Python, Java Virtual Machine (JVM) compatible with your spark-version. 
+
+		* Check the Spark documentation for Python and Java version compatibility with your specific 
+		Spark version. For instance, visit `https://spark.apache.org/docs/3.4.1` for Spark 3.4.1.
+
+	Supported Spark versions:
+        Scala 2.12: Spark 3.3.x to Spark 3.5.x
+        Scala 2.13: Spark 3.5.0+, 4.0.0, 4.0.1, 4.1.1
+	
+	Supported Databricks runtime versions for Azure and AWS:
+		Databricks 12.2 ML LTS (GPU, Scala 2.12, Spark 3.3.2)
+		Databricks 13.3 ML LTS (GPU, Scala 2.12, Spark 3.4.1)
+		Databricks 14.3 ML LTS (GPU, Scala 2.12, Spark 3.5.0)
+	
+	Supported Dataproc versions (Debian/Ubuntu/Rocky):
+		GCP Dataproc 2.1
+		GCP Dataproc 2.2
+		GCP Dataproc 2.3
+
+	Supported Dataproc Serverless versions:
+		Spark runtime 1.1 LTS
+		Spark runtime 1.2
+		Spark runtime 2.0
+		Spark runtime 2.1
+		Spark runtime 2.2
+
+*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+for your hardware's minimum driver version.
+
+*For Cloudera and EMR support, please refer to the
+[Distributions](https://docs.nvidia.com/spark-rapids/user-guide/latest/faq.html#which-distributions-are-supported) section of the FAQ.
+
+### RAPIDS Accelerator's Support Policy for Apache Spark
+The RAPIDS Accelerator maintains support for Apache Spark versions available for download from [Apache Spark](https://spark.apache.org/downloads.html)
+
+### Download RAPIDS Accelerator for Apache Spark v26.02.1
+
+| Processor | Scala Version | Download Jar | Download Signature | Download From Maven |
+|-----------|---------------|--------------|--------------------|---------------------|
+| x86_64    | Scala 2.12    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
+| x86_64    | Scala 2.13    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.12    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.13    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+
+This package is built against CUDA 12.9. It is tested on V100, T4, A10, A100, L4, H100 and GB100 GPUs with
+CUDA 12.9.
+
+### Verify signature
+* Download the [PUB_KEY](https://keys.openpgp.org/search?q=sw-spark@nvidia.com).
+* Import the public key: `gpg --import PUB_KEY`
+* Verify the signature for Scala 2.12 jar:
+    `gpg --verify rapids-4-spark_2.12-26.02.1.jar.asc rapids-4-spark_2.12-26.02.1.jar`
+* Verify the signature for Scala 2.13 jar:
+    `gpg --verify rapids-4-spark_2.13-26.02.1.jar.asc rapids-4-spark_2.13-26.02.1.jar`
+
+The output of signature verify:
+
+	gpg: Good signature from "NVIDIA Spark (For the signature of spark-rapids release jars) <sw-spark@nvidia.com>"
+
+### Release Notes
+* Add support for Spark 4.1.1 ([#14120](https://github.com/NVIDIA/spark-rapids/pull/14120))
+* Iceberg enhancements: identity partitioning support ([#14183](https://github.com/NVIDIA/spark-rapids/pull/14183)), all types for bucket transform ([#14001](https://github.com/NVIDIA/spark-rapids/pull/14001)), and Iceberg 1.9.2 support ([#13986](https://github.com/NVIDIA/spark-rapids/pull/13986))
+* SHA-2 hash support ([#14038](https://github.com/NVIDIA/spark-rapids/pull/14038))
+* Rapids shuffle manager V2 phase 1 with pipelined write ([#13724](https://github.com/NVIDIA/spark-rapids/pull/13724))
+* Enable GPU kudo reads by default ([#14125](https://github.com/NVIDIA/spark-rapids/pull/14125))
+* Multiple deadlock and OOM fixes for improved stability ([#14202](https://github.com/NVIDIA/spark-rapids/pull/14202), [#14180](https://github.com/NVIDIA/spark-rapids/pull/14180), [#14175](https://github.com/NVIDIA/spark-rapids/pull/14175))
+
+For a detailed list of changes, please refer to the
+[CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
+
+## Release v26.02.0
+### Hardware Requirements:
+
+The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Hopper and Blackwell generation datacenter GPUs.  The plugin jar is tested on the following GPUs:
+
+	GPU Models: NVIDIA V100, T4, A10, A100, L4, H100 and B100 GPUs
+
+### Software Requirements:
+
+    OS: Spark RAPIDS is compatible with any Linux distribution with glibc >= 2.28 (Please check ldd --version output).  glibc 2.28 was released August 1, 2018. 
+    Tested on Ubuntu 22.04, Ubuntu 24.04, Rocky Linux 8 and Rocky Linux 9
+
+	NVIDIA Driver*: R525+
+
+	Runtime: 
+		Scala 2.12, 2.13
+		Python, Java Virtual Machine (JVM) compatible with your spark-version. 
+
+		* Check the Spark documentation for Python and Java version compatibility with your specific 
+		Spark version. For instance, visit `https://spark.apache.org/docs/3.4.1` for Spark 3.4.1.
+
+	Supported Spark versions:
+        Scala 2.12: Spark 3.3.x to Spark 3.5.x
+        Scala 2.13: Spark 3.5.0+, 4.0.0, 4.0.1, 4.1.1
+	
+	Supported Databricks runtime versions for Azure and AWS:
+		Databricks 12.2 ML LTS (GPU, Scala 2.12, Spark 3.3.2)
+		Databricks 13.3 ML LTS (GPU, Scala 2.12, Spark 3.4.1)
+		Databricks 14.3 ML LTS (GPU, Scala 2.12, Spark 3.5.0)
+	
+	Supported Dataproc versions (Debian/Ubuntu/Rocky):
+		GCP Dataproc 2.1
+		GCP Dataproc 2.2
+		GCP Dataproc 2.3
+
+	Supported Dataproc Serverless versions:
+		Spark runtime 1.1 LTS
+		Spark runtime 1.2
+		Spark runtime 2.0
+		Spark runtime 2.1
+		Spark runtime 2.2
+
+*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
+for your hardware's minimum driver version.
+
+*For Cloudera and EMR support, please refer to the
+[Distributions](https://docs.nvidia.com/spark-rapids/user-guide/latest/faq.html#which-distributions-are-supported) section of the FAQ.
+
+### RAPIDS Accelerator's Support Policy for Apache Spark
+The RAPIDS Accelerator maintains support for Apache Spark versions available for download from [Apache Spark](https://spark.apache.org/downloads.html)
+
+### Download RAPIDS Accelerator for Apache Spark v26.02.0
+
+| Processor | Scala Version | Download Jar | Download Signature | Download From Maven |
+|-----------|---------------|--------------|--------------------|---------------------|
+| x86_64    | Scala 2.12    | [RAPIDS Accelerator v26.02.0](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.0/rapids-4-spark_2.12-26.02.0.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.0/rapids-4-spark_2.12-26.02.0.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.0&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
+| x86_64    | Scala 2.13    | [RAPIDS Accelerator v26.02.0](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.0/rapids-4-spark_2.13-26.02.0.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.0/rapids-4-spark_2.13-26.02.0.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.0&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.12    | [RAPIDS Accelerator v26.02.0](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.0/rapids-4-spark_2.12-26.02.0-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.0/rapids-4-spark_2.12-26.02.0-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.0&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.13    | [RAPIDS Accelerator v26.02.0](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.0/rapids-4-spark_2.13-26.02.0-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.0/rapids-4-spark_2.13-26.02.0-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.0&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+
+This package is built against CUDA 12.9. It is tested on V100, T4, A10, A100, L4, H100 and GB100 GPUs with
+CUDA 12.9.
+
+### Verify signature
+* Download the [PUB_KEY](https://keys.openpgp.org/search?q=sw-spark@nvidia.com).
+* Import the public key: `gpg --import PUB_KEY`
+* Verify the signature for Scala 2.12 jar:
+    `gpg --verify rapids-4-spark_2.12-26.02.0.jar.asc rapids-4-spark_2.12-26.02.0.jar`
+* Verify the signature for Scala 2.13 jar:
+    `gpg --verify rapids-4-spark_2.13-26.02.0.jar.asc rapids-4-spark_2.13-26.02.0.jar`
+
+The output of signature verify:
+
+	gpg: Good signature from "NVIDIA Spark (For the signature of spark-rapids release jars) <sw-spark@nvidia.com>"
+
+### Release Notes
+* Add support for Spark 4.1.1 ([#14120](https://github.com/NVIDIA/spark-rapids/pull/14120))
+* Iceberg enhancements: identity partitioning support ([#14183](https://github.com/NVIDIA/spark-rapids/pull/14183)), all types for bucket transform ([#14001](https://github.com/NVIDIA/spark-rapids/pull/14001)), and Iceberg 1.9.2 support ([#13986](https://github.com/NVIDIA/spark-rapids/pull/13986))
+* SHA-2 hash support ([#14038](https://github.com/NVIDIA/spark-rapids/pull/14038))
+* Rapids shuffle manager V2 phase 1 with pipelined write ([#13724](https://github.com/NVIDIA/spark-rapids/pull/13724))
+* Enable GPU kudo reads by default ([#14125](https://github.com/NVIDIA/spark-rapids/pull/14125))
+* Multiple deadlock and OOM fixes for improved stability ([#14202](https://github.com/NVIDIA/spark-rapids/pull/14202), [#14180](https://github.com/NVIDIA/spark-rapids/pull/14180), [#14175](https://github.com/NVIDIA/spark-rapids/pull/14175))
+
+For a detailed list of changes, please refer to the
+[CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
+
 ## Release v25.12.0
 ### Hardware Requirements:
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -4,21 +4,22 @@ title: Download
 nav_order: 3
 ---
 
-[RAPIDS Accelerator For Apache Spark](https://github.com/NVIDIA/spark-rapids) provides a set of
+The [RAPIDS Accelerator for Apache Spark](https://github.com/NVIDIA/spark-rapids) provides a set of
 plugins for Apache Spark that leverage GPUs to accelerate Dataframe and SQL processing.
 
 The accelerator is built upon the [RAPIDS cuDF project](https://github.com/rapidsai/cudf) and
 [UCX](https://github.com/openucx/ucx/).
 
-The RAPIDS Accelerator For Apache Spark requires each worker node in the cluster to have
-[CUDA](https://developer.nvidia.com/cuda-toolkit) installed.
+RAPIDS Spark requires each worker node in the cluster to have an NVIDIA GPU and the [NVIDIA
+driver](https://www.nvidia.com/en-us/drivers/) installed.
 
-The RAPIDS Accelerator For Apache Spark consists of two jars: a plugin jar along with the RAPIDS
-cuDF jar, that is either preinstalled in the Spark classpath on all nodes or submitted with each job
-that uses the RAPIDS Accelerator For Apache Spark. See the [getting-started
-guide](https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html) for more details.
+RAPIDS Spark consists of the rapids-4-spark plugin jar.  The jar is either preinstalled in the Spark
+classpath on all nodes or submitted with each job that uses the RAPIDS Spark. See the
+[getting-started
+guide](https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html) for
+more details.
 
-## Release v26.02.1
+## Release v26.02.2
 ### Hardware Requirements:
 
 The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Hopper and Blackwell generation datacenter GPUs.  The plugin jar is tested on the following GPUs:
@@ -41,7 +42,7 @@ The plugin is designed to work on NVIDIA Volta, Turing, Ampere, Ada Lovelace, Ho
 
 	Supported Spark versions:
         Scala 2.12: Spark 3.3.x to Spark 3.5.x
-        Scala 2.13: Spark 3.5.0+, 4.0.0, 4.0.1, 4.0.2, 4.1.1
+        Scala 2.13: Spark 3.5.0+, 4.0.0, 4.0.1, 4.1.1
 	
 	Supported Databricks runtime versions for Azure and AWS:
 		Databricks 13.3 ML LTS (GPU, Scala 2.12, Spark 3.4.1)
@@ -69,25 +70,37 @@ for your hardware's minimum driver version.
 ### RAPIDS Accelerator's Support Policy for Apache Spark
 The RAPIDS Accelerator maintains support for Apache Spark versions available for download from [Apache Spark](https://spark.apache.org/downloads.html)
 
-### Download RAPIDS Accelerator for Apache Spark v26.02.1
+### Download RAPIDS Accelerator for Apache Spark v26.02.2
+
+#### CUDA 12
 
 | Processor | Scala Version | Download Jar | Download Signature | Download From Maven |
 |-----------|---------------|--------------|--------------------|---------------------|
-| x86_64    | Scala 2.12    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
-| x86_64    | Scala 2.13    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
-| arm64     | Scala 2.12    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.1/rapids-4-spark_2.12-26.02.1-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
-| arm64     | Scala 2.13    | [RAPIDS Accelerator v26.02.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.1/rapids-4-spark_2.13-26.02.1-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.1&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+| x86_64    | Scala 2.12    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
+| x86_64    | Scala 2.13    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.12    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.13    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2-cuda12-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2-cuda12-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>    &lt;classifier&gt;cuda12-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
 
-This package is built against CUDA 12.9. It is tested on V100, T4, A10, A100, L4, H100 and GB100 GPUs with 
-CUDA 12.9.  
+
+#### CUDA 13
+
+| Processor | Scala Version | Download Jar | Download Signature | Download From Maven |
+|-----------|---------------|--------------|--------------------|---------------------|
+| x86_64    | Scala 2.12    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2-cuda13.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2-cuda13.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>    &lt;classifier&gt;cuda13&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+| x86_64    | Scala 2.13    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2-cuda13.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2-cuda13.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>    &lt;classifier&gt;cuda13&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.12    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2-cuda13-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/26.02.2/rapids-4-spark_2.12-26.02.2-cuda13-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.12&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>    &lt;classifier&gt;cuda13-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+| arm64     | Scala 2.13    | [RAPIDS Accelerator v26.02.2](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2-cuda13-arm64.jar) | [Signature](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/26.02.2/rapids-4-spark_2.13-26.02.2-cuda13-arm64.jar.asc) | <pre>&lt;dependency&gt;<br/>    &lt;groupId&gt;com.nvidia&lt;/groupId&gt;<br/>    &lt;artifactId&gt;rapids-4-spark_2.13&lt;/artifactId&gt;<br/>    &lt;version&gt;26.02.2&lt;/version&gt;<br/>    &lt;classifier&gt;cuda13-arm64&lt;/classifier&gt;<br/>&lt;/dependency&gt;</pre> |
+
+
+The above packages are built against CUDA 12.9 or CUDA 13.1. They are tested on V100, T4, A10, A100, L4, H100 and GB100 GPUs.
 
 ### Verify signature
 * Download the [PUB_KEY](https://keys.openpgp.org/search?q=sw-spark@nvidia.com).
 * Import the public key: `gpg --import PUB_KEY`
 * Verify the signature for Scala 2.12 jar:
-    `gpg --verify rapids-4-spark_2.12-26.02.1.jar.asc rapids-4-spark_2.12-26.02.1.jar`
+    `gpg --verify rapids-4-spark_2.12-26.02.2.jar.asc rapids-4-spark_2.12-26.02.2.jar`
 * Verify the signature for Scala 2.13 jar:
-    `gpg --verify rapids-4-spark_2.13-26.02.1.jar.asc rapids-4-spark_2.13-26.02.1.jar`
+    `gpg --verify rapids-4-spark_2.13-26.02.2.jar.asc rapids-4-spark_2.13-26.02.2.jar`
 
 The output of signature verify:
 
@@ -100,6 +113,10 @@ The output of signature verify:
 * Rapids shuffle manager V2 phase 1 with pipelined write ([#13724](https://github.com/NVIDIA/spark-rapids/pull/13724))
 * Enable GPU kudo reads by default ([#14125](https://github.com/NVIDIA/spark-rapids/pull/14125))
 * Multiple deadlock and OOM fixes for improved stability ([#14202](https://github.com/NVIDIA/spark-rapids/pull/14202), [#14180](https://github.com/NVIDIA/spark-rapids/pull/14180), [#14175](https://github.com/NVIDIA/spark-rapids/pull/14175))
+
+Note: There is a known issue in the 26.02.2 release where a query that combines running
+(UNBOUNDED PRECEDING to CURRENT ROW) and bounded window frames in the same PARTITION BY / ORDER BY
+clause, where both use AVG(), may fail with `RuntimeException: Couldn't find _gpu_w* in [...]`.
 
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).


### PR DESCRIPTION
auto-merge triggered by github actions on `release/26.04` to create a PR keeping `main` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.