### PR TITLE
Fix GPU first reduction state tracking

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1695,7 +1695,7 @@ case class GpuFirst(child: Expression, ignoreNulls: Boolean)
   private lazy val valueSet = AttributeReference("valueSet", BooleanType)()
 
   override lazy val inputProjection: Seq[Expression] =
-    Seq(child, GpuLiteral(ignoreNulls, BooleanType))
+    Seq(child, GpuLiteral(!ignoreNulls, BooleanType))
 
   private lazy val commonExpressions: Seq[CudfAggregate] = if (ignoreNulls) {
     Seq(CudfNthLikeAggregate.newFirstExcludeNulls(cudfFirst.dataType),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -966,9 +966,27 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
     frame => frame.agg(first("b", ignoreNulls = false))
   }
 
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "first reduction ignoreNulls=false null-leading",
+      firstReductionNullDf,
+      skipCanonicalizationCheck = true) {
+    // skip canonicalization check because Spark uses SortAggregate for this reduction case, while
+    // we replace it with HashAggregate on the GPU.
+    frame => frame.agg(first("b", ignoreNulls = false))
+  }
+
   IGNORE_ORDER_testMatrixSparkResultsAreEqual("last ignoreNulls=false", intCsvDf,
     conf = enableCsvConf()) {
     frame => frame.groupBy(col("more_ints")).agg(last("ints", false))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "last reduction ignoreNulls=false null-trailing",
+      lastReductionDf,
+      skipCanonicalizationCheck = true) {
+    // skip canonicalization check because Spark uses SortAggregate for this reduction case, while
+    // we replace it with HashAggregate on the GPU.
+    frame => frame.agg(last("b", ignoreNulls = false))
   }
 
   IGNORE_ORDER_testMatrixSparkResultsAreEqual("first/last ints column", intCsvDf,
@@ -1068,6 +1086,26 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       (2, "z", 1000.0),
       (5, "x", 1500.0),
       (3, "y", 1200.0)
+    ).toDF("a", "b", "c")
+  }
+
+  private def firstReductionNullDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[(Int, String, Double)](
+      (1, null, 900.0),
+      (2, "z", 1000.0),
+      (5, "x", 1500.0),
+      (3, "y", 1200.0)
+    ).toDF("a", "b", "c")
+  }
+
+  private def lastReductionDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[(Int, String, Double)](
+      (2, "z", 1000.0),
+      (5, "x", 1500.0),
+      (3, "y", 1200.0),
+      (6, null, 1800.0)
     ).toDF("a", "b", "c")
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -957,6 +957,15 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
     frame => frame.groupBy(col("more_ints")).agg(first("ints", false))
   }
 
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "first reduction ignoreNulls=false",
+      firstReductionDf,
+      skipCanonicalizationCheck = true) {
+    // skip canonicalization check because Spark uses SortAggregate for this reduction case, while
+    // we replace it with HashAggregate on the GPU.
+    frame => frame.agg(first("b", ignoreNulls = false))
+  }
+
   IGNORE_ORDER_testMatrixSparkResultsAreEqual("last ignoreNulls=false", intCsvDf,
     conf = enableCsvConf()) {
     frame => frame.groupBy(col("more_ints")).agg(last("ints", false))
@@ -1051,6 +1060,15 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       ("ff", Long.MaxValue),
       ("ff", null)
     ).toDF("c0", "c1")
+  }
+
+  private def firstReductionDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq(
+      (2, "z", 1000.0),
+      (5, "x", 1500.0),
+      (3, "y", 1200.0)
+    ).toDF("a", "b", "c")
   }
 
   private def randomDF(dataType: DataType)(spark: SparkSession) : DataFrame = {


### PR DESCRIPTION
Fixes #14168.

### Description

This PR fixes the GPU/CPU mismatch for `first()` reduction aggregations when
`ignoreNulls=false`.

`GpuFirst` now initializes its value-set flag correctly when nulls are included, so the
reduction keeps the first observed value instead of incorrectly falling back to null.
The PR also adds a regression test for the no-grouping `first()` case that exposed the
problem.

The new regression skips canonicalization checking because CPU and GPU legitimately choose
different aggregate plans for this case.

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [x] This PR has added new tests or modified existing tests to cover new code paths.
      The PR adds a `HashAggregatesSuite` regression test for the no-grouping
      `first(ignoreNulls = false)` reduction case.
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.