### PR TITLE
Fix wrong row index offsets from native footer reader for deletion vectors [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -677,8 +677,10 @@ def test_delta_filter_out_metadata_col(spark_tmp_path):
 @ignore_order(local=True)
 @pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "COALESCING", "MULTITHREADED"], ids=idfn)
 @pytest.mark.parametrize("footer_type", ["NATIVE", "JAVA"], ids=idfn)
-@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
-                    reason="Delta Lake deletion vector support is required")
+@pytest.mark.skipif(is_before_spark_353(),
+                    reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="Deletion vector scan is not supported on Databricks")
 def test_delta_deletion_vector_native_footer_multi_row_group(spark_tmp_path, parquet_reader_type, footer_type):
     """
     Tests deletion vector filtering on a Delta table whose single Parquet file has multiple

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -677,11 +677,16 @@ def test_delta_filter_out_metadata_col(spark_tmp_path):
 @ignore_order(local=True)
 @pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "COALESCING", "MULTITHREADED"], ids=idfn)
 @pytest.mark.parametrize("footer_type", ["NATIVE", "JAVA"], ids=idfn)
+@pytest.mark.parametrize("query", [
+    "SELECT a FROM delta.`{path}`",
+    "SELECT a, b FROM delta.`{path}`",
+], ids=["one_col", "two_cols"])
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
 @pytest.mark.skipif(is_databricks_runtime(),
                     reason="Deletion vector scan is not supported on Databricks")
-def test_delta_deletion_vector_native_footer_multi_row_group(spark_tmp_path, parquet_reader_type, footer_type):
+def test_delta_deletion_vector_native_footer_multi_row_group(spark_tmp_path, parquet_reader_type,
+                                                             footer_type, query):
     """
     Tests deletion vector filtering on a Delta table whose single Parquet file has multiple
     row groups, with deletions targeting rows beyond the first row group. A small
@@ -723,7 +728,57 @@ def test_delta_deletion_vector_native_footer_multi_row_group(spark_tmp_path, par
 
     with_cpu_session(setup_tables, conf=write_conf)
 
-    # Read only column 'a' from the 3-column table.
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.sql(f"SELECT a FROM delta.`{data_path}`"),
+        lambda spark: spark.sql(query.format(path=data_path)),
+        conf=read_conf)
+
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.parametrize("parquet_reader_type", ["COALESCING", "MULTITHREADED"], ids=idfn)
+@pytest.mark.parametrize("footer_type", ["NATIVE", "JAVA"], ids=idfn)
+@pytest.mark.skipif(is_before_spark_353(),
+                    reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="Deletion vector scan is not supported on Databricks")
+def test_delta_deletion_vector_native_footer_multi_row_group_count_star(
+        spark_tmp_path, parquet_reader_type, footer_type):
+    """
+    Tests zero-column projection (COUNT(*)) with deletion vectors on a partitioned Delta
+    table where each partition's Parquet file has multiple row groups. Uses a partition
+    filter so Spark performs a true zero-column scan while still applying DVs.
+    """
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    num_rows = 10000
+    row_group_size = 10000
+
+    write_conf = {
+        "parquet.block.size": str(row_group_size),
+    }
+    read_conf = {
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
+        "spark.rapids.sql.format.parquet.reader.type": parquet_reader_type,
+        "spark.rapids.sql.format.parquet.reader.footer.type": footer_type,
+        "spark.sql.files.maxPartitionBytes": str(row_group_size),
+    }
+
+    def setup_tables(spark):
+        # Partition by a column with few distinct values so each partition has enough
+        # rows to produce multiple row groups per file.
+        spark.range(num_rows).selectExpr(
+            "CAST(id AS INT) AS a",
+            "CAST(id % 2 AS INT) AS part"
+        ).coalesce(1).write.format("delta") \
+            .option("delta.enableDeletionVectors", "true") \
+            .partitionBy("part") \
+            .save(data_path)
+        # Delete rows in later row groups within partition part=0.
+        spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a >= 5000 AND a < 5100 AND part = 0")
+
+    with_cpu_session(setup_tables, conf=write_conf)
+
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.sql(f"SELECT COUNT(*) FROM delta.`{data_path}` WHERE part = 0"),
         conf=read_conf)

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -670,3 +670,58 @@ def test_delta_filter_out_metadata_col(spark_tmp_path):
 
     with_cpu_session(create_delta)
     assert_gpu_and_cpu_are_equal_collect(read_table)
+
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "COALESCING", "MULTITHREADED"], ids=idfn)
+@pytest.mark.parametrize("footer_type", ["NATIVE", "JAVA"], ids=idfn)
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
+                    reason="Delta Lake deletion vector support is required")
+def test_delta_deletion_vector_native_footer_multi_row_group(spark_tmp_path, parquet_reader_type, footer_type):
+    """
+    Tests deletion vector filtering on a Delta table whose single Parquet file has multiple
+    row groups, with deletions targeting rows beyond the first row group. A small
+    maxPartitionBytes forces Spark to assign per-row-group splits so the footer reader
+    sees only a subset of the file's row groups per split.
+    """
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    num_rows = 10000
+    # Small row group size → multiple row groups per file.
+    # 10000 rows * 4 bytes * 3 cols = 120KB total; with 10KB row groups we get ~12 row groups.
+    row_group_size = 10000
+
+    write_conf = {
+        "parquet.block.size": str(row_group_size),
+    }
+    read_conf = {
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
+        "spark.rapids.sql.format.parquet.reader.type": parquet_reader_type,
+        "spark.rapids.sql.format.parquet.reader.footer.type": footer_type,
+        # Force Spark to split the file at row group boundaries so the NATIVE footer
+        # reader returns one row group per PartitionedFile split.
+        "spark.sql.files.maxPartitionBytes": str(row_group_size),
+    }
+
+    def setup_tables(spark):
+        # Create a multi-column table with monotonic data so row positions are predictable.
+        # coalesce(1) ensures a single data file with multiple row groups.
+        spark.range(num_rows).selectExpr(
+            "CAST(id AS INT) AS a",
+            "CAST(id * 2 AS INT) AS b",
+            "CAST(id * 3 AS INT) AS c"
+        ).coalesce(1).write.format("delta") \
+            .option("delta.enableDeletionVectors", "true") \
+            .save(data_path)
+        # Delete rows in later row groups. With ~800 rows per row group,
+        # rows a >= 5000 are in row group 6+.
+        spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a >= 5000 AND a < 5100")
+
+    with_cpu_session(setup_tables, conf=write_conf)
+
+    # Read only column 'a' from the 3-column table.
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.sql(f"SELECT a FROM delta.`{data_path}`"),
+        conf=read_conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -727,6 +727,11 @@ protected case class GpuParquetFileFilterHandler(
                   val numRows = tableFooter.getNumRows
                   val block = new BlockMetaData()
                   block.setRowCount(numRows)
+                  // Fix up the row index offset
+                  val offsets = tableFooter.getRowIndexOffsets
+                  if (offsets.nonEmpty) {
+                    block.setRowIndexOffset(offsets(0))
+                  }
                   val schema = new MessageType("root")
                   return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
                     schema, readDataSchema, DateTimeRebaseLegacy, DateTimeRebaseLegacy,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -753,7 +753,7 @@ protected case class GpuParquetFileFilterHandler(
             // So we compute the correct offsets from all row groups before filtering,
             // and then apply them to the filtered blocks.
             val blocks = footer.getBlocks
-            assert(blocks.size() == rowIndexOffsets.length,
+            require(blocks.size() == rowIndexOffsets.length,
               s"Row index offsets length (${rowIndexOffsets.length}) != " +
               s"blocks count (${blocks.size()})")
             blocks.asScala.zip(rowIndexOffsets).foreach { case (block, offset) =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -720,8 +720,8 @@ protected case class GpuParquetFileFilterHandler(
       val footer: ParquetMetadata = try {
         footerReader match {
           case ParquetFooterReaderType.NATIVE =>
-            val serialized = withResource(readAndFilterFooter(fileIO, file, conf,
-              readDataSchema, filePath)) { tableFooter =>
+            val (serialized, rowIndexOffsets) = withResource(readAndFilterFooter(fileIO, file,
+              conf, readDataSchema, filePath)) { tableFooter =>
                 if (tableFooter.getNumColumns <= 0) {
                   // Special case because java parquet reader does not like having 0 columns.
                   val numRows = tableFooter.getNumRows
@@ -733,9 +733,9 @@ protected case class GpuParquetFileFilterHandler(
                     hasInt96Timestamps = false)
                 }
 
-                tableFooter.serializeThriftFile()
+                (tableFooter.serializeThriftFile(), tableFooter.getRowIndexOffsets)
             }
-            withResource(serialized) { serialized =>
+            val footer = withResource(serialized) { serialized =>
               NvtxRegistry.PARQUET_READ_FILTERED_FOOTER {
                 val inputFile = new HMBInputFile(serialized)
 
@@ -743,6 +743,23 @@ protected case class GpuParquetFileFilterHandler(
                 ParquetFileReader.readFooter(inputFile, ParquetMetadataConverter.NO_FILTER)
               }
             }
+            // Fix up row index offsets. ParquetFileReader.readFooter computes row
+            // index offsets assuming the row groups it receives are the entire file.
+            // The native footer reader filters row groups by byte range in C++ before
+            // serialization, so readFooter can see only a subset and compute wrong
+            // offsets (e.g. always 0 for a single surviving row group). This breaks
+            // any logic relying on file-global row indices such as deletion vector
+            // filtering.
+            // So we compute the correct offsets from all row groups before filtering,
+            // and then apply them to the filtered blocks.
+            val blocks = footer.getBlocks
+            assert(blocks.size() == rowIndexOffsets.length,
+              s"Row index offsets length (${rowIndexOffsets.length}) != " +
+              s"blocks count (${blocks.size()})")
+            blocks.asScala.zip(rowIndexOffsets).foreach { case (block, offset) =>
+              block.setRowIndexOffset(offset)
+            }
+            footer
           case _ =>
             readAndSimpleFilterFooter(fileIO, file, conf, filePath)
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -45,7 +45,7 @@ import com.nvidia.spark.rapids.jni.{DateTimeRebase, ParquetFooter, RmmSpark}
 import com.nvidia.spark.rapids.jni.fileio.{RapidsFileIO, RapidsInputFile, SeekableInputStream}
 import com.nvidia.spark.rapids.parquet.ParquetPartitionReader.{CopyRange, LocalCopy, PARQUET_MAGIC}
 import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, GpuParquetCrypto, GpuTypeShims, ShimFilePartitionReaderFactory, SparkShimImpl}
-import com.nvidia.spark.rapids.shims.parquet.{ParquetLegacyNanoAsLongShims, ParquetSchemaClipShims, ParquetStringPredShims}
+import com.nvidia.spark.rapids.shims.parquet.{GpuParquetUtilsShims, ParquetLegacyNanoAsLongShims, ParquetSchemaClipShims, ParquetStringPredShims}
 import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -730,7 +730,7 @@ protected case class GpuParquetFileFilterHandler(
                   // Fix up the row index offset
                   val offsets = tableFooter.getRowIndexOffsets
                   if (offsets.nonEmpty) {
-                    block.setRowIndexOffset(offsets(0))
+                    GpuParquetUtilsShims.setRowIndexOffset(block, offsets(0))
                   }
                   val schema = new MessageType("root")
                   return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
@@ -762,7 +762,7 @@ protected case class GpuParquetFileFilterHandler(
               s"Row index offsets length (${rowIndexOffsets.length}) != " +
               s"blocks count (${blocks.size()})")
             blocks.asScala.zip(rowIndexOffsets).foreach { case (block, offset) =>
-              block.setRowIndexOffset(offset)
+              GpuParquetUtilsShims.setRowIndexOffset(block, offset)
             }
             footer
           case _ =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -760,7 +760,8 @@ protected case class GpuParquetFileFilterHandler(
             val blocks = footer.getBlocks
             require(blocks.size() == rowIndexOffsets.length,
               s"Row index offsets length (${rowIndexOffsets.length}) != " +
-              s"blocks count (${blocks.size()})")
+              s"blocks count (${blocks.size()}) for $filePath " +
+              s"[range=${file.start}:${file.length}]")
             blocks.asScala.zip(rowIndexOffsets).foreach { case (block, offset) =>
               GpuParquetUtilsShims.setRowIndexOffset(block, offset)
             }

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
@@ -30,6 +30,11 @@ import org.apache.parquet.hadoop.metadata.{BlockMetaData, ColumnChunkMetaData}
 object GpuParquetUtilsShims {
 
   /**
+   * Sets the given row index offset on the BlockMetaData. No-op for Spark 3.3.x.
+   */
+  def setRowIndexOffset(block: BlockMetaData, offset: Long): Unit = {}
+
+  /**
    * Build a new BlockMetaData from an existing one, but with a new set of column chunks metadata.
    *
    * @param existingMetadata the existing BlockMetaData to copy row index offset from

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
@@ -44,6 +44,13 @@ import org.apache.parquet.hadoop.metadata.{BlockMetaData, ColumnChunkMetaData}
 object GpuParquetUtilsShims {
 
   /**
+   * Sets the given row index offset on the BlockMetaData.
+   */
+  def setRowIndexOffset(block: BlockMetaData, offset: Long): Unit = {
+    block.setRowIndexOffset(offset)
+  }
+
+  /**
    * Build a new BlockMetaData from an existing one, but with a new set of column chunks metadata.
    *
    * @param existingMetadata the existing BlockMetaData to copy row count and row index offset from


### PR DESCRIPTION
Fixes #14564.

### Description

  The native Parquet footer reader filters row groups by byte range in C++ before serialization. When `ParquetFileReader.readFooter` deserializes the result, it computes row index offsets assuming those row groups are the entire file. For splits that contain only a subset of the file's row groups, the offsets are wrong (e.g. always 0 for a single surviving row group). This breaks deletion vector filtering which relies on file-global row indices — some deletions are missed and others are applied to the wrong rows.

  The JAVA footer reader does not have this issue because parquet-mr's `RangeMetadataFilter` computes offsets from all row groups in the file before filtering by byte range.

  This PR uses the new `ParquetFooter.getRowIndexOffsets` JNI method (https://github.com/NVIDIA/spark-rapids-jni/pull/4445) to retrieve correct file-global offsets computed from all row groups before byte-range filtering, and apply them to the deserialized `BlockMetaData` objects after `ParquetFileReader.readFooter` reads the footer.

 Added `test_delta_deletion_vector_native_footer_multi_row_group` which demonstrates the bug. It creates a single-file Delta table with multiple row groups, deletes rows in later row groups, and forces per-row-group splits. It verifies whether the task assigned a non-first-row-group split correctly computes the row group offsets.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
