### PR TITLE
Fix BloomFilterAggregate buffer conversion across CPU/GPU stages

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.execution.{ExplainUtils, ProjectExec, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.{ExplainUtils, SortExec, SparkPlan}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.aggregate.{CudfAggregate, GpuAggregateExpression}
@@ -1129,52 +1129,19 @@ object GpuBaseAggregateMeta {
   private val aggPairReplaceChecked = TreeNodeTag[Boolean](
     "rapids.gpu.aggPairReplaceChecked")
 
-  // Mixed CPU/GPU aggregate chains can have pass-through operators inserted between stages while
-  // still belonging to the same logical aggregate. BloomFilterAggregate currently hits this via
-  // ProjectExec injected around the bridge expressions.
-  private def isAggregateChainPassThrough(meta: SparkPlanMeta[_]): Boolean = meta match {
-    case _: GpuShuffleMeta => true
-    case _: GpuSortMeta => true
-    case _ => meta.wrapped.isInstanceOf[ProjectExec]
-  }
-
-  @tailrec
-  private def getAggregateChainRoot(
-      currentMeta: SparkPlanMeta[_],
-      logical: LogicalPlan): SparkPlanMeta[_] = {
-    currentMeta.parent match {
-      case Some(parentAgg: GpuBaseAggregateMeta[_])
-          if parentAgg.agg.logicalLink.contains(logical) =>
-        getAggregateChainRoot(parentAgg, logical)
-      // Bridge ProjectExec nodes are inserted in the physical plan around buffer conversions but
-      // do not carry the aggregate logical link, so we intentionally climb through them first and
-      // let the next aggregate parent decide whether the chain still belongs to this logical plan.
-      case Some(parentMeta: SparkPlanMeta[_]) if isAggregateChainPassThrough(parentMeta) =>
-        getAggregateChainRoot(parentMeta, logical)
-      case _ =>
-        currentMeta
-    }
-  }
-
-  @tailrec
-  private def collectAggregateStages(
-      currentMeta: SparkPlanMeta[_],
-      logical: LogicalPlan,
-      acc: List[GpuBaseAggregateMeta[_]]): List[GpuBaseAggregateMeta[_]] = {
-    currentMeta match {
-      case aggMeta: GpuBaseAggregateMeta[_] if aggMeta.agg.logicalLink.contains(logical) =>
-        collectAggregateStages(aggMeta.childPlans.head, logical, acc :+ aggMeta)
-      case meta if isAggregateChainPassThrough(meta) && meta.childPlans.nonEmpty =>
-        collectAggregateStages(meta.childPlans.head, logical, acc)
-      case _ =>
-        acc
-    }
-  }
-
   def getAggregateOfAllStages(
       currentMeta: SparkPlanMeta[_], logical: LogicalPlan): List[GpuBaseAggregateMeta[_]] = {
-    val root = getAggregateChainRoot(currentMeta, logical)
-    collectAggregateStages(root, logical, Nil)
+    currentMeta match {
+      case aggMeta: GpuBaseAggregateMeta[_] if aggMeta.agg.logicalLink.contains(logical) =>
+        List[GpuBaseAggregateMeta[_]](aggMeta) ++
+          getAggregateOfAllStages(aggMeta.childPlans.head, logical)
+      case shuffleMeta: GpuShuffleMeta =>
+        getAggregateOfAllStages(shuffleMeta.childPlans.head, logical)
+      case sortMeta: GpuSortMeta =>
+        getAggregateOfAllStages(sortMeta.childPlans.head, logical)
+      case _ =>
+        List[GpuBaseAggregateMeta[_]]()
+    }
   }
 }
 
@@ -1618,16 +1585,13 @@ object GpuTypedImperativeSupportedAggregateExecMeta {
    */
   private def handleAggregationBuffer(
       meta: GpuTypedImperativeSupportedAggregateExecMeta[_]): Unit = {
-    // Mixed CPU/GPU aggregates may only have the GPU side on a partial stage, so we cannot
-    // restrict bridge discovery to final stages only.
-    val needToCheck = containTypedImperativeAggregate(meta)
+    // We only run the check for final stages which contain TypedImperativeAggregate.
+    val needToCheck = containTypedImperativeAggregate(meta, Some(Final))
     if (!needToCheck) return
-    // Avoid duplicated check and fallback across all physical stages of the same aggregate chain.
-    val checked = meta.agg.getTagValue[Boolean](bufferConverterInjected).contains(true) ||
-      meta.agg.logicalLink.exists(_.getTagValue[Boolean](bufferConverterInjected).contains(true))
+    // Avoid duplicated check and fallback.
+    val checked = meta.agg.getTagValue[Boolean](bufferConverterInjected).contains(true)
     if (checked) return
     meta.agg.setTagValue(bufferConverterInjected, true)
-    meta.agg.logicalLink.foreach(_.setTagValue(bufferConverterInjected, true))
 
     // Fetch AggregateMetas of all stages which belong to current Aggregate
     val stages = GpuBaseAggregateMeta.getAggregateOfAllStages(meta, meta.agg.logicalLink.get)
@@ -1729,11 +1693,9 @@ object GpuTypedImperativeSupportedAggregateExecMeta {
       plan.logicalLink match {
         case Some(logicalPlan) =>
           logicalPlan.setTagValue(tag, (expr, aggregateStageMask(plan)))
-        case None =>
-          // AQE/EnsureRequirements may insert CPU plans, such as exchanges, that end up as the
-          // transition parent but do not have a logical link. Fall back to storing the tag on the
-          // physical plan so transition rewrites can still materialize the converter on this tree.
-          plan.setTagValue(tag, (expr, 0))
+        case None => // logicalLink is guaranteed to be present normally
+          throw new IllegalStateException(
+            s"Failed to store ${tag.name} due to missing LogicalPlanLink: $plan")
       }
     }
   }
@@ -1865,8 +1827,8 @@ class GpuHashAggregateMeta(
     conf: RapidsConf,
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule)
-  extends GpuTypedImperativeSupportedAggregateExecMeta(agg,
-    agg.requiredChildDistributionExpressions, conf, parent, rule)
+  extends GpuBaseAggregateMeta(agg, agg.requiredChildDistributionExpressions,
+    conf, parent, rule)
 
 class GpuSortAggregateExecMeta(
     override val agg: SortAggregateExec,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -1729,9 +1729,11 @@ object GpuTypedImperativeSupportedAggregateExecMeta {
       plan.logicalLink match {
         case Some(logicalPlan) =>
           logicalPlan.setTagValue(tag, (expr, aggregateStageMask(plan)))
-        case None => // logicalLink is guaranteed to be present normally
-          throw new IllegalStateException(
-            s"Failed to store ${tag.name} due to missing LogicalPlanLink: $plan")
+        case None =>
+          // AQE/EnsureRequirements may insert CPU plans, such as exchanges, that end up as the
+          // transition parent but do not have a logical link. Fall back to storing the tag on the
+          // physical plan so transition rewrites can still materialize the converter on this tree.
+          plan.setTagValue(tag, (expr, 0))
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -40,10 +40,10 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.execution.{ExplainUtils, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.{ExplainUtils, ProjectExec, SortExec, SparkPlan}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.aggregate.{CpuToGpuAggregateBufferConverter, CudfAggregate, GpuAggregateExpression, GpuToCpuAggregateBufferConverter}
+import org.apache.spark.sql.rapids.aggregate.{CudfAggregate, GpuAggregateExpression}
 import org.apache.spark.sql.rapids.execution.{GpuBatchSubPartitioner, GpuShuffleMeta, TrampolineUtil}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -1129,19 +1129,48 @@ object GpuBaseAggregateMeta {
   private val aggPairReplaceChecked = TreeNodeTag[Boolean](
     "rapids.gpu.aggPairReplaceChecked")
 
-  def getAggregateOfAllStages(
-      currentMeta: SparkPlanMeta[_], logical: LogicalPlan): List[GpuBaseAggregateMeta[_]] = {
+  // Mixed CPU/GPU aggregate chains can have pass-through operators inserted between stages while
+  // still belonging to the same logical aggregate. BloomFilterAggregate currently hits this via
+  // ProjectExec injected around the bridge expressions.
+  private def isAggregateChainPassThrough(meta: SparkPlanMeta[_]): Boolean = meta match {
+    case _: GpuShuffleMeta => true
+    case _: GpuSortMeta => true
+    case _ => meta.wrapped.isInstanceOf[ProjectExec]
+  }
+
+  @tailrec
+  private def getAggregateChainRoot(
+      currentMeta: SparkPlanMeta[_],
+      logical: LogicalPlan): SparkPlanMeta[_] = {
+    currentMeta.parent match {
+      case Some(parentAgg: GpuBaseAggregateMeta[_]) if parentAgg.agg.logicalLink.contains(logical) =>
+        getAggregateChainRoot(parentAgg, logical)
+      case Some(parentMeta: SparkPlanMeta[_]) if isAggregateChainPassThrough(parentMeta) =>
+        getAggregateChainRoot(parentMeta, logical)
+      case _ =>
+        currentMeta
+    }
+  }
+
+  @tailrec
+  private def collectAggregateStages(
+      currentMeta: SparkPlanMeta[_],
+      logical: LogicalPlan,
+      acc: List[GpuBaseAggregateMeta[_]]): List[GpuBaseAggregateMeta[_]] = {
     currentMeta match {
       case aggMeta: GpuBaseAggregateMeta[_] if aggMeta.agg.logicalLink.contains(logical) =>
-        List[GpuBaseAggregateMeta[_]](aggMeta) ++
-          getAggregateOfAllStages(aggMeta.childPlans.head, logical)
-      case shuffleMeta: GpuShuffleMeta =>
-        getAggregateOfAllStages(shuffleMeta.childPlans.head, logical)
-      case sortMeta: GpuSortMeta =>
-        getAggregateOfAllStages(sortMeta.childPlans.head, logical)
+        collectAggregateStages(aggMeta.childPlans.head, logical, acc :+ aggMeta)
+      case meta if isAggregateChainPassThrough(meta) && meta.childPlans.nonEmpty =>
+        collectAggregateStages(meta.childPlans.head, logical, acc)
       case _ =>
-        List[GpuBaseAggregateMeta[_]]()
+        acc
     }
+  }
+
+  def getAggregateOfAllStages(
+      currentMeta: SparkPlanMeta[_], logical: LogicalPlan): List[GpuBaseAggregateMeta[_]] = {
+    val root = getAggregateChainRoot(currentMeta, logical)
+    collectAggregateStages(root, logical, Nil)
   }
 }
 
@@ -1585,13 +1614,16 @@ object GpuTypedImperativeSupportedAggregateExecMeta {
    */
   private def handleAggregationBuffer(
       meta: GpuTypedImperativeSupportedAggregateExecMeta[_]): Unit = {
-    // We only run the check for final stages which contain TypedImperativeAggregate.
-    val needToCheck = containTypedImperativeAggregate(meta, Some(Final))
+    // Mixed CPU/GPU aggregates may only have the GPU side on a partial stage, so we cannot
+    // restrict bridge discovery to final stages only.
+    val needToCheck = containTypedImperativeAggregate(meta)
     if (!needToCheck) return
-    // Avoid duplicated check and fallback.
-    val checked = meta.agg.getTagValue[Boolean](bufferConverterInjected).contains(true)
+    // Avoid duplicated check and fallback across all physical stages of the same aggregate chain.
+    val checked = meta.agg.getTagValue[Boolean](bufferConverterInjected).contains(true) ||
+      meta.agg.logicalLink.exists(_.getTagValue[Boolean](bufferConverterInjected).contains(true))
     if (checked) return
     meta.agg.setTagValue(bufferConverterInjected, true)
+    meta.agg.logicalLink.foreach(_.setTagValue(bufferConverterInjected, true))
 
     // Fetch AggregateMetas of all stages which belong to current Aggregate
     val stages = GpuBaseAggregateMeta.getAggregateOfAllStages(meta, meta.agg.logicalLink.get)
@@ -1768,12 +1800,11 @@ object GpuTypedImperativeSupportedAggregateExecMeta {
       partialAggMeta: GpuBaseAggregateMeta[_],
       fromCpuToGpu: Boolean): Seq[NamedExpression] = {
 
-    val converters = mutable.Queue[Either[
-      CpuToGpuAggregateBufferConverter, GpuToCpuAggregateBufferConverter]]()
-    mergeAggMeta.childExprs.foreach {
+    val converters = mergeAggMeta.childExprs.collect {
       case e if e.childExprs.length == 1 &&
-        e.childExprs.head.isInstanceOf[TypedImperativeAggExprMeta[_]] =>
-        e.wrapped.asInstanceOf[AggregateExpression].mode match {
+          e.childExprs.head.isInstanceOf[TypedImperativeAggExprMeta[_]] =>
+        val aggExpr = e.wrapped.asInstanceOf[AggregateExpression]
+        aggExpr.mode match {
           case Final | PartialMerge =>
             val typImpAggMeta = e.childExprs.head.asInstanceOf[TypedImperativeAggExprMeta[_]]
             val converter = if (fromCpuToGpu) {
@@ -1781,31 +1812,32 @@ object GpuTypedImperativeSupportedAggregateExecMeta {
             } else {
               Right(typImpAggMeta.createGpuToCpuBufferConverter())
             }
-            converters.enqueue(converter)
-          case _ =>
+            val aggFn = aggExpr.aggregateFunction.asInstanceOf[TypedImperativeAggregate[_]]
+            Some(aggFn.inputAggBufferAttributes.head.exprId -> converter)
+          case _ => None
         }
-      case _ =>
-    }
+      case _ => None
+    }.flatten.toMap
 
     val expressions = partialAggMeta.resultExpressions.map {
-      case retExpr if retExpr.typeMeta.typeConverted =>
-        val resultExpr = retExpr.wrapped.asInstanceOf[AttributeReference]
-        val ref = if (fromCpuToGpu) {
-          resultExpr
-        } else {
-          resultExpr.copy(dataType = retExpr.typeMeta.dataType.get)(
-            resultExpr.exprId, resultExpr.qualifier)
-        }
-        converters.dequeue() match {
-          case Left(converter) =>
-            Alias(converter.createExpression(ref),
-              ref.name + "_converted")(NamedExpression.newExprId)
-          case Right(converter) =>
-            Alias(converter.createExpression(ref),
-              ref.name + "_converted")(NamedExpression.newExprId)
-        }
       case retExpr =>
-        retExpr.wrapped.asInstanceOf[NamedExpression]
+        retExpr.wrapped match {
+          // Some typed imperative aggregates, like BloomFilterAggregate, keep BinaryType on both
+          // CPU and GPU but still need a bridge conversion because the buffer semantics differ.
+          case resultExpr: AttributeReference if converters.contains(resultExpr.exprId) =>
+            val ref = if (fromCpuToGpu || !retExpr.typeMeta.typeConverted) {
+              resultExpr
+            } else {
+              resultExpr.copy(dataType = retExpr.typeMeta.dataType.get)(
+                resultExpr.exprId, resultExpr.qualifier)
+            }
+            val convertedExpr = converters(resultExpr.exprId).fold(
+              _.createExpression(ref),
+              _.createExpression(ref))
+            Alias(convertedExpr, ref.name + "_converted")(NamedExpression.newExprId)
+          case _ =>
+            retExpr.wrapped.asInstanceOf[NamedExpression]
+        }
     }
 
     expressions
@@ -1827,8 +1859,8 @@ class GpuHashAggregateMeta(
     conf: RapidsConf,
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule)
-  extends GpuBaseAggregateMeta(agg, agg.requiredChildDistributionExpressions,
-    conf, parent, rule)
+  extends GpuTypedImperativeSupportedAggregateExecMeta(agg,
+    agg.requiredChildDistributionExpressions, conf, parent, rule)
 
 class GpuSortAggregateExecMeta(
     override val agg: SortAggregateExec,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -1145,6 +1145,9 @@ object GpuBaseAggregateMeta {
     currentMeta.parent match {
       case Some(parentAgg: GpuBaseAggregateMeta[_]) if parentAgg.agg.logicalLink.contains(logical) =>
         getAggregateChainRoot(parentAgg, logical)
+      // Bridge ProjectExec nodes are inserted in the physical plan around buffer conversions but
+      // do not carry the aggregate logical link, so we intentionally climb through them first and
+      // let the next aggregate parent decide whether the chain still belongs to this logical plan.
       case Some(parentMeta: SparkPlanMeta[_]) if isAggregateChainPassThrough(parentMeta) =>
         getAggregateChainRoot(parentMeta, logical)
       case _ =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -1143,7 +1143,8 @@ object GpuBaseAggregateMeta {
       currentMeta: SparkPlanMeta[_],
       logical: LogicalPlan): SparkPlanMeta[_] = {
     currentMeta.parent match {
-      case Some(parentAgg: GpuBaseAggregateMeta[_]) if parentAgg.agg.logicalLink.contains(logical) =>
+      case Some(parentAgg: GpuBaseAggregateMeta[_])
+          if parentAgg.agg.logicalLink.contains(logical) =>
         getAggregateChainRoot(parentAgg, logical)
       // Bridge ProjectExec nodes are inserted in the physical plan around buffer conversions but
       // do not carry the aggregate logical link, so we intentionally climb through them first and

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -20,7 +20,7 @@ import java.time.ZoneId
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.GpuTypedImperativeSupportedAggregateExecMeta.{preRowToColProjection, readBufferConverter}
+import com.nvidia.spark.rapids.GpuTypedImperativeSupportedAggregateExecMeta.{postColToRowProjection, preRowToColProjection, readBufferConverter}
 import com.nvidia.spark.rapids.RapidsMeta.noNeedToReplaceReason
 import com.nvidia.spark.rapids.shims.{AggregateInPandasExecShims, DistributionUtil, SparkShimImpl}
 
@@ -724,6 +724,18 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
   // child can't be replaced.
   private def fixUpExchangeOverhead(): Unit = {
     childPlans.foreach(_.fixUpExchangeOverhead())
+
+    // `preRowToColProjection` already gets bubbled through CPU shuffles below. Do the symmetric
+    // propagation for `postColToRowProjection` as well: gpu->cpu typed imperative aggregate
+    // converters can be bound to an intermediate CPU node that later disappears when transitions
+    // are materialized, so move the tag to the first surviving CPU parent.
+    if (childPlans.size == 1 && !canThisBeReplaced &&
+        wrapped.getTagValue(postColToRowProjection).isEmpty) {
+      readBufferConverter(childPlans.head.wrapped, isR2C = false).foreach { c2r =>
+        wrapped.setTagValue(postColToRowProjection, c2r -> 0)
+      }
+    }
+
     if (wrapped.isInstanceOf[ShuffleExchangeExec] &&
         !SparkShimImpl.isExecutorBroadcastShuffle(wrapped.asInstanceOf[ShuffleExchangeExec]) &&
         !childPlans.exists(_.supportsColumnar) &&

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -20,7 +20,7 @@ import java.time.ZoneId
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.GpuTypedImperativeSupportedAggregateExecMeta.{postColToRowProjection, preRowToColProjection, readBufferConverter}
+import com.nvidia.spark.rapids.GpuTypedImperativeSupportedAggregateExecMeta.{preRowToColProjection, readBufferConverter}
 import com.nvidia.spark.rapids.RapidsMeta.noNeedToReplaceReason
 import com.nvidia.spark.rapids.shims.{AggregateInPandasExecShims, DistributionUtil, SparkShimImpl}
 
@@ -724,18 +724,6 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
   // child can't be replaced.
   private def fixUpExchangeOverhead(): Unit = {
     childPlans.foreach(_.fixUpExchangeOverhead())
-
-    // `preRowToColProjection` already gets bubbled through CPU shuffles below. Do the symmetric
-    // propagation for `postColToRowProjection` as well: gpu->cpu typed imperative aggregate
-    // converters can be bound to an intermediate CPU node that later disappears when transitions
-    // are materialized, so move the tag to the first surviving CPU parent.
-    if (childPlans.size == 1 && !canThisBeReplaced &&
-        wrapped.getTagValue(postColToRowProjection).isEmpty) {
-      readBufferConverter(childPlans.head.wrapped, isR2C = false).foreach { c2r =>
-        wrapped.setTagValue(postColToRowProjection, c2r -> 0)
-      }
-    }
-
     if (wrapped.isInstanceOf[ShuffleExchangeExec] &&
         !SparkShimImpl.isExecutorBroadcastShuffle(wrapped.asInstanceOf[ShuffleExchangeExec]) &&
         !childPlans.exists(_.supportsColumnar) &&

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
@@ -102,6 +102,7 @@ object BloomFilterShims {
             aggBuffer.copy(dataType = a.dataType)(aggBuffer.exprId, aggBuffer.qualifier)
           }
 
+          // This is a defensive correctness fix for the rare mixed CPU/GPU bridge path.
           // BloomFilterAggregate crosses the CPU/GPU boundary as BinaryType in both directions,
           // but empty GPU partial buffers can be null while Spark CPU final expects a serialized
           // empty bloom filter. We still need a converter even though the runtime type

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
@@ -104,7 +104,8 @@ object BloomFilterShims {
 
           // BloomFilterAggregate crosses the CPU/GPU boundary as BinaryType in both directions,
           // but empty GPU partial buffers can be null while Spark CPU final expects a serialized
-          // empty bloom filter. We still need a converter even though the runtime type is unchanged.
+          // empty bloom filter. We still need a converter even though the runtime type
+          // is unchanged.
           override def createCpuToGpuBufferConverter(): CpuToGpuAggregateBufferConverter =
             CpuToGpuBloomFilterBufferConverter()
 

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
@@ -51,7 +51,9 @@ import com.nvidia.spark.rapids.jni.BloomFilter
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
-import org.apache.spark.sql.rapids.aggregate.GpuBloomFilterAggregate
+import org.apache.spark.sql.rapids.aggregate.{CpuToGpuAggregateBufferConverter,
+  CpuToGpuBloomFilterBufferConverter, GpuBloomFilterAggregate,
+  GpuToCpuAggregateBufferConverter, GpuToCpuBloomFilterBufferConverter}
 
 object BloomFilterShims {
   val exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
@@ -77,15 +79,39 @@ object BloomFilterShims {
                   TypeSig.lit(TypeEnum.LONG), TypeSig.lit(TypeEnum.LONG)),
                 ParamCheck("numBits",
                   TypeSig.lit(TypeEnum.LONG), TypeSig.lit(TypeEnum.LONG))))))),
-        (a, conf, p, r) => new ExprMeta[BloomFilterAggregate](a, conf, p, r) {
-          override def convertToGpuImpl(): GpuExpression = {
+        (a, conf, p, r) => new TypedImperativeAggExprMeta[BloomFilterAggregate](a, conf, p, r) {
+          private lazy val estimatedNumItems =
+            GpuBloomFilterAggregate.clampEstimatedNumItems(
+              a.estimatedNumItemsExpression.eval().asInstanceOf[Number].longValue)
+
+          private lazy val numBits =
+            GpuBloomFilterAggregate.clampNumBits(
+              a.numBitsExpression.eval().asInstanceOf[Number].longValue)
+
+          override def convertToGpu(childExprs: Seq[Expression]): GpuExpression = {
             GpuBloomFilterAggregate(
-              childExprs.head.convertToGpu(),
+              childExprs.head,
               a.estimatedNumItemsExpression.eval().asInstanceOf[Number].longValue,
               a.numBitsExpression.eval().asInstanceOf[Number].longValue,
               BloomFilterConstantsShims.BLOOM_FILTER_FORMAT_VERSION,
               BloomFilter.DEFAULT_SEED)
           }
+
+          override def aggBufferAttribute: AttributeReference = {
+            val aggBuffer = a.aggBufferAttributes.head
+            aggBuffer.copy(dataType = a.dataType)(aggBuffer.exprId, aggBuffer.qualifier)
+          }
+
+          // BloomFilterAggregate crosses the CPU/GPU boundary as BinaryType in both directions,
+          // but empty GPU partial buffers can be null while Spark CPU final expects a serialized
+          // empty bloom filter. We still need a converter even though the runtime type is unchanged.
+          override def createCpuToGpuBufferConverter(): CpuToGpuAggregateBufferConverter =
+            CpuToGpuBloomFilterBufferConverter()
+
+          override def createGpuToCpuBufferConverter(): GpuToCpuAggregateBufferConverter =
+            GpuToCpuBloomFilterBufferConverter(estimatedNumItems, numBits)
+
+          override val supportBufferConversion: Boolean = true
         })
     ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
   }

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
@@ -202,8 +202,8 @@ case class GpuToCpuBloomFilterBufferTransition(
       withResource(new DataOutputStream(out)) { dataOut =>
         bloomFilter.writeTo(dataOut)
         dataOut.flush()
+        out.toByteArray
       }
-      out.toByteArray
     }
   }
 
@@ -216,5 +216,7 @@ case class GpuToCpuBloomFilterBufferTransition(
     }
   }
 
+  // ShimUnaryExpression still requires nullSafeEval even though eval handles the null-to-empty
+  // bloom filter rewrite directly for this bridge expression.
   override protected def nullSafeEval(input: Any): Array[Byte] = input.asInstanceOf[Array[Byte]]
 }

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
@@ -46,17 +46,21 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.aggregate
 
+import java.io.{ByteArrayOutputStream, DataOutputStream}
+
 import ai.rapids.cudf.{ColumnVector, DType, GroupByAggregation, HostColumnVector, Scalar, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuLiteral
 import com.nvidia.spark.rapids.jni.BloomFilter
 import com.nvidia.spark.rapids.shims.BloomFilterConstantsShims
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
 import org.apache.spark.sql.internal.SQLConf.{RUNTIME_BLOOM_FILTER_MAX_NUM_BITS, RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.aggregate.GpuBloomFilterAggregate.optimalNumOfHashFunctions
 import org.apache.spark.sql.types.{BinaryType, DataType}
+import org.apache.spark.util.sketch.{BloomFilter => SparkBloomFilter}
 
 case class GpuBloomFilterAggregate(
     child: Expression,
@@ -72,10 +76,9 @@ case class GpuBloomFilterAggregate(
   override def prettyName: String = "bloom_filter_agg"
 
   private val estimatedNumItems: Long =
-    Math.min(estimatedNumItemsRequested, SQLConf.get.getConf(RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS))
+    GpuBloomFilterAggregate.clampEstimatedNumItems(estimatedNumItemsRequested)
 
-  private val numBits: Long = Math.min(numBitsRequested,
-    SQLConf.get.getConf(RUNTIME_BLOOM_FILTER_MAX_NUM_BITS))
+  private val numBits: Long = GpuBloomFilterAggregate.clampNumBits(numBitsRequested)
 
   private lazy val numHashes: Int = optimalNumOfHashFunctions(estimatedNumItems, numBits)
 
@@ -98,6 +101,12 @@ case class GpuBloomFilterAggregate(
 }
 
 object GpuBloomFilterAggregate {
+  def clampEstimatedNumItems(estimatedNumItemsRequested: Long): Long =
+    Math.min(estimatedNumItemsRequested, SQLConf.get.getConf(RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS))
+
+  def clampNumBits(numBitsRequested: Long): Long =
+    Math.min(numBitsRequested, SQLConf.get.getConf(RUNTIME_BLOOM_FILTER_MAX_NUM_BITS))
+
   /**
    * From Spark's BloomFilter.optimalNumOfHashFunctions
    *
@@ -161,4 +170,51 @@ case class GpuBloomFilterMerge() extends CudfAggregate {
   override def dataType: DataType = BinaryType
 
   override val name: String = "gpu_bloom_filter_merge"
+}
+
+case class CpuToGpuBloomFilterBufferConverter() extends CpuToGpuAggregateBufferConverter {
+  override def createExpression(child: Expression): CpuToGpuBufferTransition =
+    CpuToGpuBloomFilterBufferTransition(child)
+}
+
+case class CpuToGpuBloomFilterBufferTransition(override val child: Expression)
+    extends CpuToGpuBufferTransition {
+  override def dataType: DataType = BinaryType
+
+  override protected def nullSafeEval(input: Any): Array[Byte] = input.asInstanceOf[Array[Byte]]
+}
+
+case class GpuToCpuBloomFilterBufferConverter(
+    estimatedNumItems: Long,
+    numBits: Long) extends GpuToCpuAggregateBufferConverter {
+  override def createExpression(child: Expression): GpuToCpuBufferTransition =
+    GpuToCpuBloomFilterBufferTransition(child, estimatedNumItems, numBits)
+}
+
+case class GpuToCpuBloomFilterBufferTransition(
+    override val child: Expression,
+    estimatedNumItems: Long,
+    numBits: Long) extends GpuToCpuBufferTransition {
+
+  private lazy val emptyBloomFilterBytes: Array[Byte] = {
+    val bloomFilter = SparkBloomFilter.create(estimatedNumItems, numBits)
+    withResource(new ByteArrayOutputStream()) { out =>
+      withResource(new DataOutputStream(out)) { dataOut =>
+        bloomFilter.writeTo(dataOut)
+        dataOut.flush()
+      }
+      out.toByteArray
+    }
+  }
+
+  override def eval(input: InternalRow): Any = {
+    val buffer = child.eval(input)
+    if (buffer == null) {
+      emptyBloomFilterBytes.clone()
+    } else {
+      buffer.asInstanceOf[Array[Byte]]
+    }
+  }
+
+  override protected def nullSafeEval(input: Any): Array[Byte] = input.asInstanceOf[Array[Byte]]
 }

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuite.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuite.scala
@@ -28,7 +28,16 @@
 {"spark": "342"}
 {"spark": "343"}
 {"spark": "344"}
+{"spark": "350"}
 {"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids
 

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuiteBase.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuiteBase.scala
@@ -150,6 +150,11 @@ trait BloomFilterAggregateQuerySuiteBase extends SparkQueryCompareTestSuite {
 
   // Keep the empty-partition mixed CPU/GPU regression coverage in the shared base so both the
   // 3.3x/3.5x suites and the 4.1.1 suite exercise the same bridge behavior.
+  // This is a defensive correctness path that is unlikely in normal workloads because a supported
+  // BloomFilterAggregate would normally keep both partial and final stages on GPU.
+  // The test forces the mixed plan on purpose: BloomFilterMightContain falls back to CPU,
+  // hashAgg.replaceMode keeps only one aggregate stage on GPU, AQE stays off so the plan shape is
+  // stable, and extra shuffle partitions guarantee empty build partitions.
   for (mode <- Seq("partial", "final")) {
     ALLOW_NON_GPU_testSparkResultsAreEqualWithCapture(
       s"might_contain GPU $mode build CPU probe with empty build partitions",

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuiteBase.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuiteBase.scala
@@ -51,6 +51,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{BloomFilterMightContain, Expression, ExpressionInfo}
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
 
@@ -130,5 +131,60 @@ trait BloomFilterAggregateQuerySuiteBase extends SparkQueryCompareTestSuite {
       val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(gpuPlan)
       assert(searchPlan(executedPlan), s"Could not find $exec in the GPU plan:\n$executedPlan")
     }
+  }
+
+  protected def getPartialAggPlanValidator(exec: String): (SparkPlan, SparkPlan) => Unit = {
+    def searchPlan(p: SparkPlan): Boolean = {
+      ExecutionPlanCaptureCallback.didFallBack(p, exec) ||
+        p.children.exists(searchPlan) ||
+        p.subqueries.exists(searchPlan)
+    }
+    (_, gpuPlan) => {
+      val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(gpuPlan)
+      val planString = executedPlan.toString()
+      assert(searchPlan(executedPlan), s"Could not find $exec in the GPU plan:\n$executedPlan")
+      assert(planString.contains("partial_bloom_filter_agg"),
+        s"Could not find partial_bloom_filter_agg in the GPU plan:\n$executedPlan")
+    }
+  }
+
+  // Keep the empty-partition mixed CPU/GPU regression coverage in the shared base so both the
+  // 3.3x/3.5x suites and the 4.1.1 suite exercise the same bridge behavior.
+  for (mode <- Seq("partial", "final")) {
+    ALLOW_NON_GPU_testSparkResultsAreEqualWithCapture(
+      s"might_contain GPU $mode build CPU probe with empty build partitions",
+      spark => {
+        import spark.implicits._
+        spark.range(0, 4).select($"id".cast("long").as("col"))
+      },
+      Seq("ObjectHashAggregateExec", "ProjectExec", "ShuffleExchangeExec"),
+      conf = bloomFilterEnabledConf.clone()
+        .set("spark.rapids.sql.expression.BloomFilterMightContain", "false")
+        .set("spark.rapids.sql.hashAgg.replaceMode", mode)
+        .set("spark.sql.adaptive.enabled", "false")
+        .set("spark.sql.shuffle.partitions", "16")) {
+      probeDf =>
+        val probeTable = s"bloom_filter_empty_partition_probe_$mode"
+        val buildTable = s"bloom_filter_empty_partition_build_$mode"
+        probeDf.createOrReplaceTempView(probeTable)
+        probeDf.sparkSession.range(0, 4)
+          .selectExpr("cast(id as long) as col")
+          .repartition(16)
+          .createOrReplaceTempView(buildTable)
+        withExposedSqlFuncs(probeDf.sparkSession) { spark =>
+          spark.sql(
+            s"""
+               |SELECT might_contain(
+               |         (SELECT bloom_filter_agg(col,
+               |            cast(${SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.defaultValue.get}
+               |              as long),
+               |            cast(${SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_BITS.defaultValue.get}
+               |              as long))
+               |          FROM $buildTable),
+               |         col)
+               |FROM $probeTable
+               |""".stripMargin)
+        }
+    }(getPartialAggPlanValidator("ObjectHashAggregateExec"))
   }
 }


### PR DESCRIPTION
### Description

- **Problem being fixed**:
  GPU partial `BloomFilterAggregate` can emit null aggregate buffers for empty partitions.
  When a later CPU final aggregation deserializes that null buffer, Spark throws a
  `NullPointerException` instead of treating it as an empty bloom filter.
- **Scope clarification**:
  This is a defensive correctness fix for a low-probability mixed CPU/GPU bridge path.
  In normal supported execution, both partial and final `BloomFilterAggregate` stages stay on GPU.
  The mixed plan typically appears only when a later stage falls back to CPU or tests force
  `spark.rapids.sql.hashAgg.replaceMode`.
- **Why not change `initialValues` directly**:
  `initialValues` is only used for the reduction-only empty-input path, where the aggregate emits
  a single result row without processing any input rows. This bug happens later in a mixed
  CPU/GPU plan, when a GPU partial stage emits a null intermediate buffer for an empty shuffle
  partition and a CPU final stage consumes that buffer. Changing `initialValues` would not fix
  that bridge path, and it would also change the existing empty-input `bloom_filter_agg`
  semantics that are still validated against Spark.
- **Update buffer converter planning**:
  Insert the buffer converters if a converter exists, even the CPU/GPU data types are the same. Since
  for the Bloom filter case, they have different empty data sematics.
- **Add Bloom filter buffer conversion support**:
  Enable `BloomFilterAggregate` buffer conversion in the shim even though the runtime type stays
  `BinaryType`, because the CPU and GPU sides do not share the same empty-buffer semantics.
- **Fix the empty-partition conversion path**:
  Convert null GPU partial bloom filter buffers into serialized empty bloom filters before CPU
  final aggregation consumes them, which avoids the CPU-side deserialize failure.
- **Extend regression coverage**:
  Restore and extend Bloom filter tests with shared empty-partition mixed CPU/GPU coverage and
  restored 3.5x shim coverage so this bridge path stays validated across supported Spark shims.
  The shared test now also documents how the test-only config overrides force this corner case.
- **Validation**:
  `mvn --settings .m2/settings.xml -Dbuildver=356 -Dcuda.version=cuda13 -DallowConventionalDistJar=true -DwildcardSuites=com.nvidia.spark.rapids.BloomFilterAggregateQuerySuite clean package`
  `mvn --settings .m2/settings.xml -Dbuildver=411 -Dcuda.version=cuda13 -DallowConventionalDistJar=true -DwildcardSuites=com.nvidia.spark.rapids.BloomFilterAggregateQuerySuiteSpark411 clean package`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required