### PR TITLE
Optimize format number implementation

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2418,14 +2418,15 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     }
     val signCol = closeOnExcept(decimalPart) { _ =>
       closeOnExcept(integerWithCommas) { _ =>
-        withResource(cv.castTo(DType.FLOAT64)) { cvDouble =>
+        val isNeg = withResource(cv.castTo(DType.FLOAT64)) { cvDouble =>
           withResource(Scalar.fromDouble(0.0)) { zero =>
-            withResource(cvDouble.lessThan(zero)) { isNeg =>
-              withResource(Scalar.fromString("-")) { neg =>
-                withResource(Scalar.fromString("")) { empty =>
-                  isNeg.ifElse(neg, empty)
-                }
-              }
+            cvDouble.lessThan(zero)
+          }
+        }
+        withResource(isNeg) { _ =>
+          withResource(Scalar.fromString("-")) { neg =>
+            withResource(Scalar.fromString("")) { empty =>
+              isNeg.ifElse(neg, empty)
             }
           }
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2418,9 +2418,9 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     }
     val signCol = closeOnExcept(decimalPart) { _ =>
       closeOnExcept(integerWithCommas) { _ =>
-        val isNeg = withResource(cv.castTo(DType.FLOAT64)) { cvDouble =>
-          withResource(Scalar.fromDouble(0.0)) { zero =>
-            cvDouble.lessThan(zero)
+        val isNeg = withResource(cv.castTo(DType.FLOAT32)) { cvFloat =>
+          withResource(Scalar.fromFloat(0.0f)) { zero =>
+            cvFloat.lessThan(zero)
           }
         }
         withResource(isNeg) { _ =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2385,12 +2385,14 @@ case class GpuFormatNumber(x: Expression, d: Expression)
       }
     }
     if (maxstrlen <= 3) {
+      // no commas are needed for strings of 3 or fewer chars
       str.incRefCount()
     } else {
       val substrs = (0 until maxstrlen by 3).safeMap { i =>
         str.substring(i, i + 3).asInstanceOf[ColumnView]
       }.toArray
       withResource(substrs) { _ =>
+        // join the 3-char chunks with commas using a scalar separator
         withResource(Scalar.fromString(",")) { sep =>
           withResource(Scalar.fromString("")) { narep =>
             withResource(ColumnVector.stringConcatenate(sep, narep, substrs)) { res =>
@@ -2416,8 +2418,14 @@ case class GpuFormatNumber(x: Expression, d: Expression)
         reversedWithCommas.reverseStringsOrLists()
       }
     }
+    // build a small per-row sign prefix column ("-" or "") based on the sign
+    // of the value, that we will prepend at the end.
+    // this way, we avoid creating bigger signed/unsigned versions of the formatted column
+    // followed by an ifElse.
     val signCol = closeOnExcept(decimalPart) { _ =>
       closeOnExcept(integerWithCommas) { _ =>
+        // since we only need the sign bit, cast to float and compare < 0.
+        // this is cheaper than casting to string and checking for "-".
         val isNeg = withResource(cv.castTo(DType.FLOAT32)) { cvFloat =>
           withResource(Scalar.fromFloat(0.0f)) { zero =>
             cvFloat.lessThan(zero)
@@ -2436,6 +2444,7 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     val formatted = d match {
       case 0 =>
         decimalPart.close()
+        // no decimal - just prepend the precomputed sign prefix
         withResource(signCol) { _ =>
           withResource(integerWithCommas) { _ =>
             ColumnVector.stringConcatenate(
@@ -2443,7 +2452,7 @@ case class GpuFormatNumber(x: Expression, d: Expression)
           }
         }
       case _ =>
-        // join integer and decimal with ".", then prepend sign
+        // join integer and decimal with scalar separator "."
         val intDotDec = closeOnExcept(signCol) { _ =>
           withResource(integerWithCommas) { _ =>
             withResource(decimalPart) { _ =>
@@ -2456,6 +2465,7 @@ case class GpuFormatNumber(x: Expression, d: Expression)
             }
           }
         }
+        // prepend the precomputed sign prefix to the formatted number
         withResource(signCol) { _ =>
           withResource(intDotDec) { _ =>
             ColumnVector.stringConcatenate(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2435,12 +2435,11 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     // single concatenation pass for sign + integer [+ "." + decimal]
     val formatted = d match {
       case 0 =>
-        withResource(decimalPart) { _ =>
-          withResource(signCol) { _ =>
-            withResource(integerWithCommas) { _ =>
-              ColumnVector.stringConcatenate(
-                Array[ColumnView](signCol, integerWithCommas))
-            }
+        decimalPart.close()
+        withResource(signCol) { _ =>
+          withResource(integerWithCommas) { _ =>
+            ColumnVector.stringConcatenate(
+              Array[ColumnView](signCol, integerWithCommas))
           }
         }
       case _ =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2406,14 +2406,14 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     val (integerPart, decimalPart) = getParts(cv, d)
     // reverse integer part for adding commas
     val integerWithCommas = closeOnExcept(decimalPart) { _ =>
-      withResource(integerPart) { _ =>
-        val reversed = integerPart.reverseStringsOrLists()
-        val reversedWithCommas = withResource(reversed) { _ =>
-          addCommas(reversed)
-        }
-        withResource(reversedWithCommas) { _ =>
-          reversedWithCommas.reverseStringsOrLists()
-        }
+      val reversed = withResource(integerPart) { _ =>
+        integerPart.reverseStringsOrLists()
+      }
+      val reversedWithCommas = withResource(reversed) { _ =>
+        addCommas(reversed)
+      }
+      withResource(reversedWithCommas) { _ =>
+        reversedWithCommas.reverseStringsOrLists()
       }
     }
     val signCol = closeOnExcept(decimalPart) { _ =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2444,12 +2444,14 @@ case class GpuFormatNumber(x: Expression, d: Expression)
         }
       case _ =>
         // join integer and decimal with ".", then prepend sign
-        val intDotDec = withResource(integerWithCommas) { _ =>
-          withResource(decimalPart) { _ =>
-            withResource(Scalar.fromString(".")) { dot =>
-              withResource(Scalar.fromString("")) { narep =>
-                ColumnVector.stringConcatenate(dot, narep,
-                  Array[ColumnView](integerWithCommas, decimalPart))
+        val intDotDec = closeOnExcept(signCol) { _ =>
+          withResource(integerWithCommas) { _ =>
+            withResource(decimalPart) { _ =>
+              withResource(Scalar.fromString(".")) { dot =>
+                withResource(Scalar.fromString("")) { narep =>
+                  ColumnVector.stringConcatenate(dot, narep,
+                    Array[ColumnView](integerWithCommas, decimalPart))
+                }
               }
             }
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2385,16 +2385,17 @@ case class GpuFormatNumber(x: Expression, d: Expression)
       }
     }
     if (maxstrlen <= 3) {
-      return str.incRefCount()
-    }
-    val substrs = (0 until maxstrlen by 3).safeMap { i =>
-      str.substring(i, i + 3).asInstanceOf[ColumnView]
-    }.toArray
-    withResource(substrs) { _ =>
-      withResource(Scalar.fromString(",")) { sep =>
-        withResource(Scalar.fromString("")) { narep =>
-          withResource(ColumnVector.stringConcatenate(sep, narep, substrs)) { res =>
-            removeExtraCommas(res)
+      str.incRefCount()
+    } else {
+      val substrs = (0 until maxstrlen by 3).safeMap { i =>
+        str.substring(i, i + 3).asInstanceOf[ColumnView]
+      }.toArray
+      withResource(substrs) { _ =>
+        withResource(Scalar.fromString(",")) { sep =>
+          withResource(Scalar.fromString("")) { narep =>
+            withResource(ColumnVector.stringConcatenate(sep, narep, substrs)) { res =>
+              removeExtraCommas(res)
+            }
           }
         }
       }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2369,14 +2369,6 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     }
   }
 
-  private def negativeCheck(cv: ColumnVector): ColumnVector = {
-    withResource(cv.castTo(DType.STRING)) { cvStr =>
-      withResource(Scalar.fromString("-")) { negativeSign =>
-        cvStr.startsWith(negativeSign)
-      }
-    }
-  }
-
   private def removeExtraCommas(str: ColumnVector): ColumnVector = {
     withResource(Scalar.fromString(",")) { comma =>
       str.rstrip(comma)
@@ -2392,18 +2384,18 @@ case class GpuFormatNumber(x: Expression, d: Expression)
         }
       }
     }
-    val sepCol = withResource(Scalar.fromString(",")) { sep =>
-      ColumnVector.fromScalar(sep, str.getRowCount.toInt)
+    if (maxstrlen <= 3) {
+      return str.incRefCount()
     }
-    val substrs = closeOnExcept(sepCol) { _ =>
-      (0 until maxstrlen by 3).safeMap { i =>
-        str.substring(i, i + 3).asInstanceOf[ColumnView]
-      }.toArray
-    }
+    val substrs = (0 until maxstrlen by 3).safeMap { i =>
+      str.substring(i, i + 3).asInstanceOf[ColumnView]
+    }.toArray
     withResource(substrs) { _ =>
-      withResource(sepCol) { _ =>
-        withResource(ColumnVector.stringConcatenate(substrs, sepCol)) { res =>
-          removeExtraCommas(res)
+      withResource(Scalar.fromString(",")) { sep =>
+        withResource(Scalar.fromString("")) { narep =>
+          withResource(ColumnVector.stringConcatenate(sep, narep, substrs)) { res =>
+            removeExtraCommas(res)
+          }
         }
       }
     }
@@ -2412,65 +2404,77 @@ case class GpuFormatNumber(x: Expression, d: Expression)
   private def formatNumberNonKernel(cv: ColumnVector, d: Int): ColumnVector = {
     val (integerPart, decimalPart) = getParts(cv, d)
     // reverse integer part for adding commas
-    val resWithDecimalPart = withResource(decimalPart) { _ =>
-      val reversedIntegerPart = withResource(integerPart) { intPart =>
-        intPart.reverseStringsOrLists()
-      }
-      val reversedIntegerPartWithCommas = withResource(reversedIntegerPart) { _ =>
-        addCommas(reversedIntegerPart)
-      }
-      // reverse result back
-      val reverseBack = withResource(reversedIntegerPartWithCommas) { r =>
-        r.reverseStringsOrLists()
-      }
-      d match {
-        case 0 => {
-          // d == 0, only return integer part
-          reverseBack
+    val integerWithCommas = closeOnExcept(decimalPart) { _ =>
+      withResource(integerPart) { _ =>
+        val reversed = integerPart.reverseStringsOrLists()
+        val reversedWithCommas = withResource(reversed) { _ =>
+          addCommas(reversed)
         }
-        case _ => {
-          // d > 0, append decimal part to result
-          withResource(reverseBack) { _ =>
-            withResource(Scalar.fromString(".")) { point =>
-              withResource(Scalar.fromString("")) { empty =>
-                ColumnVector.stringConcatenate(point, empty, Array(reverseBack, decimalPart))
+        withResource(reversedWithCommas) { _ =>
+          reversedWithCommas.reverseStringsOrLists()
+        }
+      }
+    }
+    val signCol = closeOnExcept(decimalPart) { _ =>
+      closeOnExcept(integerWithCommas) { _ =>
+        withResource(cv.castTo(DType.FLOAT64)) { cvDouble =>
+          withResource(Scalar.fromDouble(0.0)) { zero =>
+            withResource(cvDouble.lessThan(zero)) { isNeg =>
+              withResource(Scalar.fromString("-")) { neg =>
+                withResource(Scalar.fromString("")) { empty =>
+                  isNeg.ifElse(neg, empty)
+                }
               }
             }
           }
         }
       }
     }
-    // add negative sign back
-    val negCv = withResource(Scalar.fromString("-")) { negativeSign =>
-      ColumnVector.fromScalar(negativeSign, cv.getRowCount.toInt)
-    }
-    val formated = withResource(resWithDecimalPart) { _ =>
-      val resWithNeg = withResource(negCv) { _ =>
-        ColumnVector.stringConcatenate(Array(negCv, resWithDecimalPart))
-      }
-      withResource(negativeCheck(cv)) { isNegative =>
-        withResource(resWithNeg) { _ =>
-          isNegative.ifElse(resWithNeg, resWithDecimalPart)
-        }
-      }
-    }
-    // handle null case
-    val anyNull = closeOnExcept(formated) { _ =>
-      cv.getNullCount > 0
-    }
-    val formatedWithNull = anyNull match {
-      case true => {
-        withResource(formated) { _ =>
-          withResource(cv.isNull) { isNull =>
-            withResource(Scalar.fromNull(DType.STRING)) { nullScalar =>
-              isNull.ifElse(nullScalar, formated)
+    // single concatenation pass for sign + integer [+ "." + decimal]
+    val formatted = d match {
+      case 0 =>
+        withResource(decimalPart) { _ =>
+          withResource(signCol) { _ =>
+            withResource(integerWithCommas) { _ =>
+              ColumnVector.stringConcatenate(
+                Array[ColumnView](signCol, integerWithCommas))
             }
           }
         }
-      }
-      case false => formated
+      case _ =>
+        // join integer and decimal with ".", then prepend sign
+        val intDotDec = withResource(integerWithCommas) { _ =>
+          withResource(decimalPart) { _ =>
+            withResource(Scalar.fromString(".")) { dot =>
+              withResource(Scalar.fromString("")) { narep =>
+                ColumnVector.stringConcatenate(dot, narep,
+                  Array[ColumnView](integerWithCommas, decimalPart))
+              }
+            }
+          }
+        }
+        withResource(signCol) { _ =>
+          withResource(intDotDec) { _ =>
+            ColumnVector.stringConcatenate(
+              Array[ColumnView](signCol, intDotDec))
+          }
+        }
     }
-    formatedWithNull
+    // handle null case
+    val anyNull = closeOnExcept(formatted) { _ =>
+      cv.getNullCount > 0
+    }
+    anyNull match {
+      case true =>
+        withResource(formatted) { _ =>
+          withResource(cv.isNull) { isNull =>
+            withResource(Scalar.fromNull(DType.STRING)) { nullScalar =>
+              isNull.ifElse(nullScalar, formatted)
+            }
+          }
+        }
+      case false => formatted
+    }
   }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {


### PR DESCRIPTION
### Description

Contributes to #14588.

This change optimizes the implementation of `format_number` originally introduced in https://github.com/NVIDIA/spark-rapids/pull/9281. The optimizations were found by Claude after it was tasked with optimizing this implementation against microbenchmarks.

The optimizations are as follows:
- Use a scalar "," separator with the [scalar stringConcatenate API](https://docs.rapids.ai/api/cudf-java/legacy/ai/rapids/cudf/columnvector#stringConcatenate(ai.rapids.cudf.Scalar,ai.rapids.cudf.Scalar,ai.rapids.cudf.ColumnView%5B%5D)) instead of allocating a full column.
- Use numeric sign detection by casting to float, rather than a string conversion + string pattern match to look for a negative sign.
- Use a small `signCol` that is conditionally prepended to negative numbers, instead of allocating a fully copy of the column with "-" prepended.

#### Performance

Note that this operator does not appear in NDS/NDS-H, so I have the following microbenchmarks for a targeted performance diff.

Generated data:
```bash
cat << 'EOF' | SPARK_HOME=/opt/spark-3.5.5 /opt/spark-3.5.5/bin/spark-shell \
  --jars datagen/target/datagen_2.12-26.06.0-SNAPSHOT-spark355.jar \
  --master "local[*]"
import org.apache.spark.sql.tests.datagen._
val types = Seq("long", "int", "short", "byte", "DECIMAL(38,10)")
for (t <- types) {
  DBGen().addTable("data", s"a $t", 10000000)
    .toDF(spark).write.mode("overwrite")
    .parquet(s"/tmp/format_number_bench/${t.replaceAll("[^a-zA-Z0-9]", "_")}")
}
println("done")
:quit
EOF
```

Benchmark runs:
```bash
cat << 'EOF' | SPARK_HOME=/opt/spark-3.5.5 /opt/spark-3.5.5/bin/spark-shell \
  --jars $PLUGIN_JAR \
  --conf spark.plugins=com.nvidia.spark.SQLPlugin \
  --master "local[*]"
val types = Seq(
  ("long",    "/tmp/format_number_bench/long"),
  ("int",     "/tmp/format_number_bench/int"),
  ("short",   "/tmp/format_number_bench/short"),
  ("byte",    "/tmp/format_number_bench/byte"),
  ("decimal", "/tmp/format_number_bench/DECIMAL_38_10_")
)
for ((name, path) <- types) {
  val df = spark.read.parquet(path)
  // warmup
  df.selectExpr("COUNT(format_number(a, 0))", "COUNT(format_number(a, 5))").collect()
  df.selectExpr("COUNT(format_number(a, 0))", "COUNT(format_number(a, 5))").collect()
  // timed
  for (i <- 1 to 3) {
    print(s"${name}_run${i}: ")
    spark.time(df.selectExpr("COUNT(format_number(a, 0))", "COUNT(format_number(a, 5))").collect())
  }
}
:quit
EOF
```

Results:
| dtype | main | this change | speedup |
|-----------|-----------------|-----------|---------|
| long | 540 ms | 380 ms | **1.42x** |
| int | 362 ms | 285 ms | **1.27x** |
| short | 378 ms | 238 ms | **1.59x** |
| byte | 244 ms | 186 ms | **1.31x** |
| decimal(38,10) | 921 ms | 551 ms | **1.67x** |


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
