### PR TITLE
Fix "Range is out of bounds" crash from GpuArraysZip when receiving a 0-row batch

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -1250,7 +1250,7 @@ case class GpuArraysZip(children: Seq[Expression]) extends GpuExpression with Sh
    */
   private def padArraysToMaxLength(inputs: Seq[ColumnVector]): Seq[ColumnVector] = {
     if (inputs.head.getRowCount == 0) {
-      return inputs.map(_.incRefCount())
+      return inputs.safeMap(_.incRefCount())
     }
     // Compute max size of input arrays for each row, this is to know how we need to pad things.
     //

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -1249,6 +1249,9 @@ case class GpuArraysZip(children: Seq[Expression]) extends GpuExpression with Sh
    * same offsets and the same validity. This assumes that the validity on the inputs all match.
    */
   private def padArraysToMaxLength(inputs: Seq[ColumnVector]): Seq[ColumnVector] = {
+    if (inputs.head.getRowCount == 0) {
+      return inputs.map(_.incRefCount())
+    }
     // Compute max size of input arrays for each row, this is to know how we need to pad things.
     //
     // input1: [[A, B, C], [D, E], null, [G]]


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14592.

### Description

This pr adds a check for empty `inputs` in `padArraysToMaxLength` to fix a cuDF crash from arrays_zip.

With this pr, the crash that was reproduced in #14592 disappeared.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
