### PR TITLE
Add aggregate reduction path coverage tests [release/26.04]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -523,14 +523,14 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       "collect_list/collect_set reduction non-null",
       reductionNonNullDf,
       skipCanonicalizationCheck = true) {
-    frame => frame.agg(collect_list("b"), sort_array(collect_set("b")))
+    frame => frame.agg(sort_array(collect_list("b")), sort_array(collect_set("b")))
   }
 
   IGNORE_ORDER_testMatrixSparkResultsAreEqual(
       "collect_list/collect_set reduction mixed nulls",
       reductionMixedNullDf,
       skipCanonicalizationCheck = true) {
-    frame => frame.agg(collect_list("b"), sort_array(collect_set("b")))
+    frame => frame.agg(sort_array(collect_list("b")), sort_array(collect_set("b")))
   }
 
   IGNORE_ORDER_testMatrixSparkResultsAreEqual("distinct", datesCsvDf, conf = enableCsvConf()) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -448,6 +448,91 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       avg(col("more_longs") + lit("10")))
   }
 
+  /*
+   * REDUCTION PATH TESTS (no groupBy)
+   *
+   * GPU aggregate functions have separate code paths for reduction vs groupBy.
+   * These tests ensure the reduction path (df.agg(...) without groupBy) is correct.
+   * Motivated by https://github.com/NVIDIA/spark-rapids/issues/14168 where first()
+   * reduction returned null due to a valueSet flag bug.
+   * Tracked by https://github.com/NVIDIA/spark-rapids/issues/14560
+   */
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "last reduction ignoreNulls=false",
+      reductionNonNullDf,
+      skipCanonicalizationCheck = true) {
+    frame => frame.agg(last("b", ignoreNulls = false))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "first reduction ignoreNulls=true",
+      reductionMixedNullDf,
+      skipCanonicalizationCheck = true) {
+    frame => frame.agg(first("b", ignoreNulls = true))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "last reduction ignoreNulls=true",
+      reductionMixedNullDf,
+      skipCanonicalizationCheck = true) {
+    frame => frame.agg(last("b", ignoreNulls = true))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "first/last reduction mixed nulls",
+      reductionMixedNullDf,
+      skipCanonicalizationCheck = true) {
+    frame => frame.agg(
+      first("b", ignoreNulls = false),
+      last("b", ignoreNulls = false),
+      first("b", ignoreNulls = true),
+      last("b", ignoreNulls = true))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "min/max reduction non-null",
+      reductionNonNullDf) {
+    frame => frame.agg(min("a"), max("a"), min("c"), max("c"))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "min/max reduction mixed nulls",
+      reductionMixedNullDf) {
+    frame => frame.agg(min("a"), max("a"), min("c"), max("c"))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "sum/avg/count reduction non-null",
+      reductionNonNullDf,
+      conf = floatAggConf) {
+    frame => frame.agg(sum("a"), avg("a"), count("a"), sum("c"), avg("c"), count("*"))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "sum/avg/count reduction mixed nulls",
+      reductionMixedNullDf,
+      conf = floatAggConf) {
+    frame => frame.agg(sum("a"), avg("a"), count("a"), sum("c"), avg("c"), count("*"))
+  }
+
+  // Note: variance/stddev reduction is NOT supported on GPU (falls back to CPU).
+  // GroupBy variance/stddev is GPU-accelerated and tested elsewhere.
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "collect_list/collect_set reduction non-null",
+      reductionNonNullDf,
+      skipCanonicalizationCheck = true) {
+    frame => frame.agg(collect_list("b"), sort_array(collect_set("b")))
+  }
+
+  IGNORE_ORDER_testMatrixSparkResultsAreEqual(
+      "collect_list/collect_set reduction mixed nulls",
+      reductionMixedNullDf,
+      skipCanonicalizationCheck = true) {
+    frame => frame.agg(collect_list("b"), sort_array(collect_set("b")))
+  }
+
   IGNORE_ORDER_testMatrixSparkResultsAreEqual("distinct", datesCsvDf, conf = enableCsvConf()) {
     frame => frame.distinct()
   }
@@ -1113,6 +1198,32 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
     val schema = FuzzerUtils.createSchema(Seq(DataTypes.StringType, dataType))
     FuzzerUtils.generateDataFrame(spark, schema, rowCount = 1000,
       options = FuzzerOptions(maxStringLen = 2))
+  }
+
+  // Test data for reduction path tests (no groupBy).
+  // All non-null: catches bugs where null results mask incorrect behavior (e.g. first() #14168).
+  private def reductionNonNullDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq(
+      (2, "z", 1000.0),
+      (5, "x", 1500.0),
+      (3, "y", 1200.0),
+      (1, "w", 800.0),
+      (4, "v", 2000.0)
+    ).toDF("a", "b", "c")
+  }
+
+  // Mixed nulls: null at first row, middle, and last row.
+  private def reductionMixedNullDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq[(java.lang.Integer, java.lang.String, java.lang.Double)](
+      (null, null, null),
+      (5, "x", 1500.0),
+      (null, "y", null),
+      (1, null, 800.0),
+      (4, "v", 2000.0),
+      (null, null, null)
+    ).toDF("a", "b", "c")
   }
 
   FLOAT_TEST_testMatrixSparkResultsAreEqual("empty df: reduction count", floatCsvDf,


### PR DESCRIPTION
Upmerge of #14570 to release/26.04.

Fixes #14560.

### Description

GPU aggregate functions have separate code paths for **reduction** (no `groupBy`) vs **groupBy** aggregation, but existing tests overwhelmingly cover only the groupBy path. Issue #14168 proved this gap is real: `first()` had extensive groupBy tests yet a reduction-path bug (`inputProjection` flag inversion) shipped undetected and was caught by an external user.

This PR adds 10 new reduction-path tests in `HashAggregatesSuite` covering all major aggregate functions that run on GPU in reduction mode. Each test uses `frame.agg(...)` without `groupBy` to exercise the reduction code path specifically.

**Functions covered:**
- `first` / `last` (with `ignoreNulls=false` and `ignoreNulls=true`)
- `min` / `max`
- `sum` / `avg` / `count`
- `collect_list` / `collect_set`

**Data patterns (orthogonal to function):**
- All non-null rows — catches bugs where null results mask incorrect behavior
- Mixed nulls (null at first, middle, and last positions)

**Note:** `variance` / `stddev` / `var_pop` / `stddev_pop` reduction is not supported on GPU (correctly falls back to CPU). This is documented in a code comment but not tested here since the CPU fallback is not a correctness concern.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required