### PR TITLE
Fix UC table scan on DB-17.3 by using filesWithAbsolutePaths [databricks]

### DIFF
--- a/sql-plugin/src/main/spark400db173/scala/com/nvidia/spark/rapids/shims/Spark400PlusDBShims.scala
+++ b/sql-plugin/src/main/spark400db173/scala/com/nvidia/spark/rapids/shims/Spark400PlusDBShims.scala
@@ -42,6 +42,6 @@ trait Spark400PlusDBShims extends Spark341PlusDBShims {
   }
 
   override def getPartitionFiles(partition: FilePartition): Seq[PartitionedFile] = {
-    partition.innerFiles
+    partition.filesWithAbsolutePaths
   }
 }

--- a/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/execution/rapids/shims/FilePartitionShims.scala
+++ b/sql-plugin/src/main/spark400db173/scala/org/apache/spark/sql/execution/rapids/shims/FilePartitionShims.scala
@@ -31,7 +31,7 @@ object FilePartitionShims extends SplitFiles {
     }
   }
 
-  def getFiles(p: FilePartition): Array[PartitionedFile] = p.innerFiles
+  def getFiles(p: FilePartition): Array[PartitionedFile] = p.filesWithAbsolutePaths
 
   def copyWithFiles(p: FilePartition, newFiles: Array[PartitionedFile]): FilePartition = {
     p.copy(innerFiles = newFiles)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14607

### Description
- Fixes Unity Catalog managed table scans failing with `Path must be absolute` on Databricks 17.3
- Changes `FilePartition.innerFiles` to `FilePartition.filesWithAbsolutePaths` in two read-path locations in the `400db173` shim
- `copyWithFiles` correctly continues to use `innerFiles` (write path — files are already resolved)

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
