### PR TITLE
Fix BloomFilterAggregate buffer conversion on DB runtimes[databricks]

### DIFF
--- a/jenkins/databricks/install_deps.py
+++ b/jenkins/databricks/install_deps.py
@@ -66,6 +66,8 @@ def define_deps(spark_version, scala_version):
             f'{spark_prefix}--common--network-shuffle--network-shuffle-{spark_suffix}_deploy.jar'),
         Artifact('org.apache.spark', f'spark-unsafe_{scala_version}',
             f'{spark_prefix}--common--unsafe--unsafe-{spark_suffix}_deploy.jar'),
+        Artifact('org.apache.spark', f'spark-sketch_{scala_version}',
+            f'{spark_prefix}--common--sketch--sketch-{spark_suffix}_deploy.jar'),
         Artifact('org.apache.spark', f'spark-launcher_{scala_version}',
                  f'{spark_prefix}--launcher--launcher-{spark_suffix}_deploy.jar'),
         Artifact('org.apache.spark', f'spark-sql_{scala_version}',

--- a/scala2.13/shim-deps/databricks/pom.xml
+++ b/scala2.13/shim-deps/databricks/pom.xml
@@ -160,6 +160,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sketch_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-ast_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/shim-deps/databricks/pom.xml
+++ b/shim-deps/databricks/pom.xml
@@ -160,6 +160,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sketch_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-ast_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
@@ -54,10 +54,7 @@ import com.nvidia.spark.rapids.shims.BloomFilterConstantsShims
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
-import org.apache.spark.sql.internal.SQLConf.{
-  RUNTIME_BLOOM_FILTER_MAX_NUM_BITS,
-  RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS
-}
+import org.apache.spark.sql.internal.SQLConf.{RUNTIME_BLOOM_FILTER_MAX_NUM_BITS, RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.aggregate.GpuBloomFilterAggregate.optimalNumOfHashFunctions
 import org.apache.spark.sql.types.{BinaryType, DataType}

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
@@ -46,8 +46,6 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.aggregate
 
-import java.io.{ByteArrayOutputStream, DataOutputStream}
-
 import ai.rapids.cudf.{ColumnVector, DType, GroupByAggregation, HostColumnVector, Scalar, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuLiteral
@@ -56,12 +54,13 @@ import com.nvidia.spark.rapids.shims.BloomFilterConstantsShims
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
-import org.apache.spark.sql.internal.SQLConf.{RUNTIME_BLOOM_FILTER_MAX_NUM_BITS, RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS}
+import org.apache.spark.sql.internal.SQLConf.{
+  RUNTIME_BLOOM_FILTER_MAX_NUM_BITS,
+  RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS
+}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.aggregate.GpuBloomFilterAggregate.optimalNumOfHashFunctions
 import org.apache.spark.sql.types.{BinaryType, DataType}
-import org.apache.spark.util.sketch.{BloomFilter => SparkBloomFilter}
-
 case class GpuBloomFilterAggregate(
     child: Expression,
     estimatedNumItemsRequested: Long,
@@ -121,6 +120,30 @@ object GpuBloomFilterAggregate {
   private def optimalNumOfHashFunctions(n: Long, m: Long): Int = {
     // (m / n) * log(2), but avoid truncation due to division!
     Math.max(1, Math.round(m.toDouble / n * Math.log(2)).toInt)
+  }
+
+  // Use the JNI BloomFilter API here instead of Spark's BloomFilter implementation because
+  // some Databricks runtimes do not expose org.apache.spark.util.sketch.BloomFilter on the
+  // compile/runtime classpath. This path still needs to produce Spark-compatible serialized
+  // bloom filter bytes for the rare GPU-to-CPU aggregate buffer bridge case.
+  def createEmptyBloomFilterBytes(
+      effectiveEstimatedNumItems: Long,
+      effectiveNumBits: Long,
+      version: Int,
+      seed: Int): Array[Byte] = {
+    val numHashes = optimalNumOfHashFunctions(effectiveEstimatedNumItems, effectiveNumBits)
+    withResource(BloomFilter.create(version, numHashes, effectiveNumBits, seed)) { bloomFilter =>
+      withResource(bloomFilter.getListAsColumnView) { bloomFilterView =>
+        withResource(bloomFilterView.copyToHost()) { hostBloomFilter =>
+          val byteCount = Math.toIntExact(hostBloomFilter.getRowCount)
+          val bytes = new Array[Byte](byteCount)
+          if (byteCount > 0) {
+            hostBloomFilter.getData.getBytes(bytes, 0, 0, byteCount)
+          }
+          bytes
+        }
+      }
+    }
   }
 }
 
@@ -185,27 +208,25 @@ case class CpuToGpuBloomFilterBufferTransition(override val child: Expression)
 }
 
 case class GpuToCpuBloomFilterBufferConverter(
-    estimatedNumItems: Long,
-    numBits: Long) extends GpuToCpuAggregateBufferConverter {
+    effectiveEstimatedNumItems: Long,
+    effectiveNumBits: Long,
+    version: Int = BloomFilterConstantsShims.BLOOM_FILTER_FORMAT_VERSION,
+    seed: Int = BloomFilter.DEFAULT_SEED) extends GpuToCpuAggregateBufferConverter {
   override def createExpression(child: Expression): GpuToCpuBufferTransition =
-    GpuToCpuBloomFilterBufferTransition(child, estimatedNumItems, numBits)
+    GpuToCpuBloomFilterBufferTransition(
+      child, effectiveEstimatedNumItems, effectiveNumBits, version, seed)
 }
 
 case class GpuToCpuBloomFilterBufferTransition(
     override val child: Expression,
-    estimatedNumItems: Long,
-    numBits: Long) extends GpuToCpuBufferTransition {
+    effectiveEstimatedNumItems: Long,
+    effectiveNumBits: Long,
+    version: Int,
+    seed: Int) extends GpuToCpuBufferTransition {
 
-  private lazy val emptyBloomFilterBytes: Array[Byte] = {
-    val bloomFilter = SparkBloomFilter.create(estimatedNumItems, numBits)
-    withResource(new ByteArrayOutputStream()) { out =>
-      withResource(new DataOutputStream(out)) { dataOut =>
-        bloomFilter.writeTo(dataOut)
-        dataOut.flush()
-        out.toByteArray
-      }
-    }
-  }
+  private lazy val emptyBloomFilterBytes: Array[Byte] =
+    GpuBloomFilterAggregate.createEmptyBloomFilterBytes(
+      effectiveEstimatedNumItems, effectiveNumBits, version, seed)
 
   override def eval(input: InternalRow): Any = {
     val buffer = child.eval(input)

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
@@ -46,6 +46,8 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.aggregate
 
+import java.io.{ByteArrayOutputStream, DataOutputStream}
+
 import ai.rapids.cudf.{ColumnVector, DType, GroupByAggregation, HostColumnVector, Scalar, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuLiteral
@@ -58,6 +60,8 @@ import org.apache.spark.sql.internal.SQLConf.{RUNTIME_BLOOM_FILTER_MAX_NUM_BITS,
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.aggregate.GpuBloomFilterAggregate.optimalNumOfHashFunctions
 import org.apache.spark.sql.types.{BinaryType, DataType}
+import org.apache.spark.util.sketch.{BloomFilter => SparkBloomFilter}
+
 case class GpuBloomFilterAggregate(
     child: Expression,
     estimatedNumItemsRequested: Long,
@@ -117,30 +121,6 @@ object GpuBloomFilterAggregate {
   private def optimalNumOfHashFunctions(n: Long, m: Long): Int = {
     // (m / n) * log(2), but avoid truncation due to division!
     Math.max(1, Math.round(m.toDouble / n * Math.log(2)).toInt)
-  }
-
-  // Use the JNI BloomFilter API here instead of Spark's BloomFilter implementation because
-  // some Databricks runtimes do not expose org.apache.spark.util.sketch.BloomFilter on the
-  // compile/runtime classpath. This path still needs to produce Spark-compatible serialized
-  // bloom filter bytes for the rare GPU-to-CPU aggregate buffer bridge case.
-  def createEmptyBloomFilterBytes(
-      effectiveEstimatedNumItems: Long,
-      effectiveNumBits: Long,
-      version: Int,
-      seed: Int): Array[Byte] = {
-    val numHashes = optimalNumOfHashFunctions(effectiveEstimatedNumItems, effectiveNumBits)
-    withResource(BloomFilter.create(version, numHashes, effectiveNumBits, seed)) { bloomFilter =>
-      withResource(bloomFilter.getListAsColumnView) { bloomFilterView =>
-        withResource(bloomFilterView.copyToHost()) { hostBloomFilter =>
-          val byteCount = Math.toIntExact(hostBloomFilter.getRowCount)
-          val bytes = new Array[Byte](byteCount)
-          if (byteCount > 0) {
-            hostBloomFilter.getData.getBytes(bytes, 0, 0, byteCount)
-          }
-          bytes
-        }
-      }
-    }
   }
 }
 
@@ -205,25 +185,27 @@ case class CpuToGpuBloomFilterBufferTransition(override val child: Expression)
 }
 
 case class GpuToCpuBloomFilterBufferConverter(
-    effectiveEstimatedNumItems: Long,
-    effectiveNumBits: Long,
-    version: Int = BloomFilterConstantsShims.BLOOM_FILTER_FORMAT_VERSION,
-    seed: Int = BloomFilter.DEFAULT_SEED) extends GpuToCpuAggregateBufferConverter {
+    estimatedNumItems: Long,
+    numBits: Long) extends GpuToCpuAggregateBufferConverter {
   override def createExpression(child: Expression): GpuToCpuBufferTransition =
-    GpuToCpuBloomFilterBufferTransition(
-      child, effectiveEstimatedNumItems, effectiveNumBits, version, seed)
+    GpuToCpuBloomFilterBufferTransition(child, estimatedNumItems, numBits)
 }
 
 case class GpuToCpuBloomFilterBufferTransition(
     override val child: Expression,
-    effectiveEstimatedNumItems: Long,
-    effectiveNumBits: Long,
-    version: Int,
-    seed: Int) extends GpuToCpuBufferTransition {
+    estimatedNumItems: Long,
+    numBits: Long) extends GpuToCpuBufferTransition {
 
-  private lazy val emptyBloomFilterBytes: Array[Byte] =
-    GpuBloomFilterAggregate.createEmptyBloomFilterBytes(
-      effectiveEstimatedNumItems, effectiveNumBits, version, seed)
+  private lazy val emptyBloomFilterBytes: Array[Byte] = {
+    val bloomFilter = SparkBloomFilter.create(estimatedNumItems, numBits)
+    withResource(new ByteArrayOutputStream()) { out =>
+      withResource(new DataOutputStream(out)) { dataOut =>
+        bloomFilter.writeTo(dataOut)
+        dataOut.flush()
+        out.toByteArray
+      }
+    }
+  }
 
   override def eval(input: InternalRow): Any = {
     val buffer = child.eval(input)


### PR DESCRIPTION
Fixes #14614.

### Description
Install `spark-sketch` for DB envs.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

Made with [Cursor](https://cursor.com)