### PR TITLE
Drop _V2 suffix from URM/Artifactory symbols [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -33,7 +33,7 @@ def TEMP_IMAGE_BUILD = true
 def CUDA_NAME = 'cuda12.0.1' // hardcode cuda version for docker build part
 def PREMERGE_DOCKERFILE = 'jenkins/Dockerfile-blossom.ubuntu'
 def IMAGE_PREMERGE // temp image for premerge test
-def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME_V2}/sw-spark-docker/spark:rapids-databricks-ubuntu22")
+def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks-ubuntu22")
 def PREMERGE_TAG
 def skipped = false
 def db_build = false
@@ -72,11 +72,11 @@ pipeline {
         LIBCUDF_KERNEL_CACHE_PATH = '/tmp/.cudf'
         GITHUB_TOKEN = credentials("github-token")
 
-        URM_URL = "https://${common.ARTIFACTORY_NAME_V2}/artifactory/sw-spark-maven"
+        URM_URL = "https://${common.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
         MVN_URM_MIRROR = '-s jenkins/settings.xml -P mirror-apache-to-urm'
         // v2 instance for CI images usage
-        URM_CREDS = credentials("urm_creds_v2")
-        ARTIFACTORY_NAME = "${common.ARTIFACTORY_NAME_V2}"
+        URM_CREDS = credentials("urm_creds")
+        ARTIFACTORY_NAME = "${common.ARTIFACTORY_NAME}"
 
         PVC = credentials("pvc")
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -27,7 +27,7 @@
 import ipp.blossom.*
 
 def githubHelper // blossom github helper
-def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME_V2}/sw-spark-docker/spark:rapids-databricks-ubuntu22")
+def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks-ubuntu22")
 
 pipeline {
     agent {


### PR DESCRIPTION
After the artifactory migrations,
Drop _V2 suffix from URM/Artifactory symbols, use default VARs.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
