### PR TITLE
[DOC] call out know issue 14574 in download page [skip ci]

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -123,7 +123,7 @@ For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
 
 ### Known Issues
-* PERFILE reader may return incorrect counts for zero-column Delta scans with deletion vectors ([#14574](https://github.com/NVIDIA/spark-rapids/issues/14574)). Triggered when all of the following apply: the Delta table has deletion vectors enabled (`delta.enableDeletionVectors=true`), `spark.rapids.sql.format.parquet.reader.type=PERFILE`, `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=true`, and the query reads zero data columns (e.g. `SELECT COUNT(*) ... WHERE <partition predicate>`). Workaround: use the default `MULTITHREADED`/`COALESCING` reader, or set `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=false`.
+* PERFILE reader may return incorrect counts for zero-column Delta scans with deletion vectors ([#14574](https://github.com/NVIDIA/spark-rapids/issues/14574)). Triggered when all of the following apply: the Delta table has deletion vector files created for the latest snapshot, `spark.rapids.sql.format.parquet.reader.type=PERFILE`, `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=true`, and the query reads zero data columns (e.g. `SELECT COUNT(*) ... WHERE <partition predicate>`). Workaround: use the default reader (`AUTO`). 
 
 ## Archived releases
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -123,7 +123,7 @@ For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
 
 ### Known Issues
-* PERFILE reader may return incorrect counts for zero-column Delta scans with deletion vectors ([#14574](https://github.com/NVIDIA/spark-rapids/issues/14574)). Triggered when all of the following apply: the Delta table has deletion vector files created for the latest snapshot, `spark.rapids.sql.format.parquet.reader.type=PERFILE`, `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=true`, and the query reads zero data columns (e.g. `SELECT COUNT(*) ... WHERE <partition predicate>`). Workaround: use the default reader (`AUTO`). 
+* PERFILE reader may return incorrect counts for zero-column Delta scans with deletion vectors ([#14574](https://github.com/NVIDIA/spark-rapids/issues/14574)). This can be triggered when all of the following apply: the Delta table has deletion vector files created for the latest snapshot, `spark.rapids.sql.format.parquet.reader.type=PERFILE`, `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=true`, and the query reads zero data columns (e.g. `SELECT COUNT(*) ... WHERE <partition predicate>`). Workaround: use the default reader (`AUTO`). 
 
 ## Archived releases
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -122,6 +122,9 @@ The output of signature verify:
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
 
+### Known Issues
+* PERFILE reader may return incorrect counts for zero-column Delta scans with deletion vectors ([#14574](https://github.com/NVIDIA/spark-rapids/issues/14574)). Workaround: use the default `MULTITHREADED`/`COALESCING` reader.
+
 ## Archived releases
 
 As new releases come out, previous ones will still be available in [archived releases](./archive.md).

--- a/docs/download.md
+++ b/docs/download.md
@@ -123,7 +123,7 @@ For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
 
 ### Known Issues
-* PERFILE reader may return incorrect counts for zero-column Delta scans with deletion vectors ([#14574](https://github.com/NVIDIA/spark-rapids/issues/14574)). Workaround: use the default `MULTITHREADED`/`COALESCING` reader.
+* PERFILE reader may return incorrect counts for zero-column Delta scans with deletion vectors ([#14574](https://github.com/NVIDIA/spark-rapids/issues/14574)). Triggered when all of the following apply: the Delta table has deletion vectors enabled (`delta.enableDeletionVectors=true`), `spark.rapids.sql.format.parquet.reader.type=PERFILE`, `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=true`, and the query reads zero data columns (e.g. `SELECT COUNT(*) ... WHERE <partition predicate>`). Workaround: use the default `MULTITHREADED`/`COALESCING` reader, or set `spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled=false`.
 
 ## Archived releases
 


### PR DESCRIPTION
See #14574.

### Description

Doc-only change: call out known issue [#14574](https://github.com/NVIDIA/spark-rapids/issues/14574) in the v26.04.0 download page so users hitting the `PERFILE` reader + Delta deletion-vector zero-column scan bug can find the workaround.

No code changes; `[skip ci]` is set in the title.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required