### PR TITLE
[AutoSparkUT] Fix SPARK-39177 map ANSI error query context (#14123)

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -31,6 +31,7 @@ import com.nvidia.spark.rapids.shims.{GetSequenceSize, NullIntolerantShim, ShimE
 
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.{ElementAt, ExpectsInputTypes, Expression, ImplicitCastInputTypes, NamedExpression, RowOrdering, Sequence, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.util.{GenericArrayData, TypeUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
@@ -446,14 +447,17 @@ object GpuElementAtMeta {
           } else {
             in.failOnError
           }
-          GpuElementAt(lhs, rhs, failOnError)
+          GpuElementAt(lhs, rhs, failOnError)(in.origin)
         }
       })
   }
 }
 
-case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolean)
+case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolean)(
+    override val origin: Origin = CurrentOrigin.get)
   extends GpuBinaryExpression with ExpectsInputTypes {
+
+  override def otherCopyArgs: Seq[AnyRef] = origin :: Nil
 
   override def hasSideEffects: Boolean = super.hasSideEffects || failOnError || {
     right match {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -27,6 +27,7 @@ import com.nvidia.spark.rapids.shims._
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.util.{quoteIdentifier, TypeUtils}
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, ArrayType, BooleanType, DataType, IntegralType, LongType, MapType, StructField, StructType}
@@ -200,8 +201,11 @@ case class GpuGetArrayItem(child: Expression, ordinal: Expression, failOnError: 
   }
 }
 
-case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boolean)
+case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boolean)(
+    override val origin: Origin = CurrentOrigin.get)
   extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerantShim {
+
+  override def otherCopyArgs: Seq[AnyRef] = origin :: Nil
 
   private def keyType = child.dataType.asInstanceOf[MapType].keyType
 

--- a/sql-plugin/src/main/spark321/scala/com/nvidia/spark/rapids/shims/GetMapValueMeta.scala
+++ b/sql-plugin/src/main/spark321/scala/com/nvidia/spark/rapids/shims/GetMapValueMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,5 +42,5 @@ abstract class GetMapValueMeta (
   extends BinaryExprMeta[GetMapValue](expr, conf, parent, rule) {
 
     override def convertToGpu(map: Expression, key: Expression): GpuExpression =
-        GpuGetMapValue(map, key, expr.failOnError)
+        GpuGetMapValue(map, key, expr.failOnError)(expr.origin)
 }

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GetMapValueMeta.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GetMapValueMeta.scala
@@ -59,5 +59,5 @@ abstract class GetMapValueMeta (
   extends BinaryExprMeta[GetMapValue](expr, conf, parent, rule) {
 
     override def convertToGpu(map: Expression, key: Expression): GpuExpression =
-        GpuGetMapValue(map, key, false)
+        GpuGetMapValue(map, key, false)(expr.origin)
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -221,7 +221,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-33482: Fix FileScan canonicalization", ADJUST_UT("Replaced by testRapids version using V1 sources with AQE and broadcast disabled to assert ReusedExchangeExec directly"))
     .exclude("SPARK-36093: RemoveRedundantAliases should not change expression's name", ADJUST_UT("Replaced by testRapids version that checks the partition column name of the GpuInsertIntoHadoopFsRelationCommand"))
     .exclude("SPARK-39175: Query context of Cast should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))
-    .exclude("SPARK-39177: Query context of getting map value should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))
     .exclude("SPARK-39190,SPARK-39208,SPARK-39210: Query context of decimal overflow error should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))
 }
 // scalastyle:on line.size.limit


### PR DESCRIPTION
Refs #14123. Recovers SPARK-39177 (1 of the 3 remaining excluded tests from #14123). SPARK-39175 (Cast) is recovered in #14637; SPARK-39190/39208/39210 (decimal overflow) remain excluded and will be addressed in a follow-up PR.

### Description

Follow-up to #14440, which recovered SPARK-39166 (arithmetic overflow) by adding an `override val origin` second-parameter list to GPU arithmetic classes. This PR applies the same pattern to `GpuGetMapValue` and `GpuElementAt` to recover SPARK-39177 (\"Query context of getting map value should be serialized to executors when WSCG is off\").

#### Root cause

The CPU `TreeNode.origin` is captured from `CurrentOrigin.get` at construction time but is not a constructor parameter, so AQE's `TreeNode.makeCopy` (reflective constructor call) loses it during plan re-optimization. On the executor side the ANSI error message built from `origin.context` is empty, so `msg.contains(query)` fails.

#### Fix

Same pattern introduced in #14440 for arithmetic expressions:

1. Add `(override val origin: Origin = CurrentOrigin.get)` as a second parameter list. In Scala 2 only the first parameter list participates in auto-generated `equals`/`hashCode`/`unapply`, so origin is excluded from expression identity without custom equality overrides.
2. Add `override def otherCopyArgs: Seq[AnyRef] = origin :: Nil` so `makeCopy` passes origin to the reflective constructor call.
3. Callers (`GetMapValueMeta.convertToGpu` and the `ElementAt` meta in `collectionOperations.scala`) pass `expr.origin` explicitly, threading the CPU origin through regardless of whether the `CurrentOrigin.withOrigin` wrapper in `BaseExprMeta.convertToGpu` is active.

Both classes already throw via `RapidsErrorUtils.mapKeyNotExistError(..., origin)` which feeds `origin.context` into `QueryExecutionErrors.mapKeyNotExistError`, so no throw-site changes are required.

#### Deferred

SPARK-39175 (Cast) is addressed in #14637. SPARK-39190/39208/39210 (decimal overflow), both tracked by the same #14123, involves many throw sites across the decimal aggregate/divide paths and will be addressed in a separate PR.

### Existing test covered

The recovered inherited Spark test:

| RAPIDS test | Spark original test | Spark source file | Lines | Source link |
|---|---|---|---|---|
| `RapidsSQLQuerySuite` (inherited) | `SPARK-39177: Query context of getting map value should be serialized to executors when WSCG is off` | `sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala` | 4407-4424 | [v3.3.0 pinned](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala#L4407-L4424) |

### Validation

`mvn package -pl tests -am -Dbuildver=330 -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsSQLQuerySuite` (full `RapidsSQLQuerySuite`, Spark 3.3.0, CUDA 12).

Before (3 exclusions removed, no plugin fix — baseline):
```
Tests: succeeded 221, failed 3, canceled 0, ignored 10, pending 0
```
Failures: SPARK-39175, SPARK-39177, SPARK-39190.

After (this PR — only SPARK-39177 exclusion removed + origin plumbing):
```
Tests: succeeded 222, failed 0, canceled 0, ignored 12, pending 0
```
SPARK-39177 passes; SPARK-39175 and SPARK-39190 remain excluded (as intended).

### Performance

Pure cold-path / error-path change; same reasoning as #14440.

- **Plan conversion**: extra `Origin` field per GPU node — `Origin` is a case class with seven `Option[Int]`/`Option[String]` fields; negligible memory cost.
- **Serialization**: `Origin` is fully serializable; cost is a few bytes per serialized expression. Spark's own `TreeNode.origin` has never been `@transient`.
- **Hot path**: `origin` is never read in `doColumnar`. cuDF `getMapValue` / `extractListElement` paths are unchanged.
- **Error path only**: when the map key is missing in ANSI mode, the thrown `SparkNoSuchElementException` now includes the SQL query context — same character of change as #14440.

Benchmark not required.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required