### PR TITLE
[AutoSparkUT] Add RapidsApproximatePercentileQuerySuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsApproximatePercentileQuerySuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsApproximatePercentileQuerySuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.ApproximatePercentileQuerySuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsApproximatePercentileQuerySuite
+  extends ApproximatePercentileQuerySuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -27,6 +27,9 @@ import org.apache.spark.sql.rapids.suites._
 
 class RapidsTestSettings extends BackendTestSettings {
 
+  enableSuite[RapidsApproximatePercentileQuerySuite]
+    .exclude("percentile_approx(col, ...), input rows contains null, with group by", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14634"))
+    .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]


### PR DESCRIPTION
Refs #14634, #14635.

## Summary

Migrates Spark 3.3.0 `ApproximatePercentileQuerySuite` (17 tests) to the
RAPIDS plugin as `RapidsApproximatePercentileQuerySuite`.

- 15 tests run green on GPU.
- 2 tests excluded with KNOWN_ISSUE evidence (new issues filed upstream).

This is the first migration closing L3 Data-Correctness gap **B-2**
(ApproximatePercentile — previously 0/26 triples covered, no Python IT).

## Changes

| File | Change |
|---|---|
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsApproximatePercentileQuerySuite.scala` | New — minimal inheritance from `ApproximatePercentileQuerySuite` with `RapidsSQLTestsTrait` |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala` | Register suite + two `.exclude()` entries with issue URLs |

## Local validation (Maven)

Command:
```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -s jenkins/settings.xml -P mirror-apache-to-urm \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsApproximatePercentileQuerySuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Result:
```
Tests: succeeded 15, failed 0, canceled 0, ignored 2, pending 0
BUILD SUCCESS
```

## Excluded tests (with evidence)

### 1. `percentile_approx(col, ...), input rows contains null, with group by` → #14634

`ApproxPercentileFromTDigestExpr.columnarEval` trips a cuDF
`AssertionError: Column has non-empty nulls` when the grouped input
contains a null group-key. Crash path:

```
ai.rapids.cudf.AssertEmptyNulls.assertNullsAreEmpty(AssertEmptyNulls.java:22)
ai.rapids.cudf.ColumnView.approxPercentile(ColumnView.java:2013)
org.apache.spark.sql.rapids.aggregate.ApproxPercentileFromTDigestExpr
  .columnarEval(GpuApproximatePercentile.scala:145)
com.nvidia.spark.rapids.GpuProjectExec$.project(basicPhysicalOperators.scala:133)
com.nvidia.spark.rapids.GpuAggFinalPassIterator$
  .$anonfun$makeIter$3(GpuAggregateExec.scala:835)
```

### 2. `SPARK-32908: maximum target error in percentile_approx` → #14635

GPU t-digest diverges from CPU quantile-summary at the lowest accuracy
bucket:

| accuracy | CPU | GPU |
|---|---|---|
| 1000    | 18 | **17** |
| 10000   | 17 | 17 |
| 100000  | 17 | 17 |
| 1000000 | 17 | 17 |

Confirmed via spark-shell repro (`RAPIDS Enabled = YES`,
`Plugins Loaded = YES`, full 32 configs).

## Per-test traceability

All 17 tests correspond 1:1 with the parent
`ApproximatePercentileQuerySuite` in Spark 3.3.0
(`spark/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala`).
No test bodies are overridden; the minimal-inheritance pattern reuses
the Spark test harness via `RapidsSQLTestsTrait`.

---

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required