### PR TITLE
Add FLOAT/DECIMAL coverage for asinh/atanh/cbrt math functions (#14638)

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -68,6 +68,15 @@ _arith_decimal_gens_high_precision = _arith_decimal_gens_high_precision_no_neg_s
     _decimal_gen_36_neg5, _decimal_gen_38_neg10
 ]
 
+# Gens covering the full accepted input-type set for math-unary functions
+# (asinh/atanh/cbrt/...): Spark auto-casts FLOAT/DECIMAL to DOUBLE before
+# applying these, but the cast+op code path is worth exercising end-to-end.
+_math_unary_input_gens = [double_gen, FloatGen(), decimal_gen_64bit]
+
+# DECIMAL input requires GPU decimal->double cast (off by default for
+# precision-loss reasons).
+_math_unary_conf = {'spark.rapids.sql.castDecimalToFloat.enabled': 'true'}
+
 _arith_data_gens_diff_precision_scale_and_no_neg_scale = \
     _arith_data_gens_diff_precision_scale_and_no_neg_scale_no_38_0 + [_decimal_gen_38_0]
 
@@ -854,10 +863,11 @@ def test_bround_ansi_overflow_integral(data_gen, scale):
         error_message="ArithmeticException")
 
 @approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', _math_unary_input_gens, ids=idfn)
 def test_cbrt(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('cbrt(a)'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('cbrt(a)'),
+            conf=_math_unary_conf)
 
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
 def test_bit_and(data_gen):
@@ -988,10 +998,11 @@ def test_asin(data_gen):
             lambda spark : unary_op_df(spark, data_gen).selectExpr('asin(a)'))
 
 @approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', _math_unary_input_gens, ids=idfn)
 def test_asinh(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('asinh(a)'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('asinh(a)'),
+            conf=_math_unary_conf)
 
 # The default approximate is 1e-6 or 1 in a million
 # in some cases we need to adjust this because the algorithm is different
@@ -1017,10 +1028,11 @@ def test_atan(data_gen):
             lambda spark : unary_op_df(spark, data_gen).selectExpr('atan(a)'))
 
 @approximate_float
-@pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', _math_unary_input_gens, ids=idfn)
 def test_atanh(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('atanh(a)'))
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('atanh(a)'),
+            conf=_math_unary_conf)
 
 @approximate_float
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)


### PR DESCRIPTION
## Summary
Closes #14638.

Adds FLOAT and DECIMAL input coverage to `test_asinh`, `test_atanh`, and `test_cbrt` in `integration_tests/src/main/python/arithmetic_ops_test.py` by switching their `parametrize('data_gen', ...)` from the single-entry `double_gens` to a new module-level `_math_unary_input_gens = [double_gen, FloatGen(), decimal_gen_64bit]`.

## Why

These three math-unary functions are declared to accept DOUBLE / FLOAT / DECIMAL per `supported_ops.md`, but existing IT only exercised DOUBLE. Spark auto-casts FLOAT/DECIMAL inputs to DOUBLE before applying; this PR verifies the `cast + math_unary` code path on GPU produces the same results as CPU. Pure test addition — no plugin code changes.

## Note on DECIMAL conf

GPU decimal → double cast is off by default (for precision-loss reasons). DECIMAL cases enable it via `spark.rapids.sql.castDecimalToFloat.enabled=true` through a new `_math_unary_conf`. Without this, the plan falls back to Spark's non-columnar `ProjectExec` for the cast, failing the test harness's columnar-only assertion.

## Verification

Local run on Spark 3.5.4 + buildver=354:

```
pytest -k "test_asinh or test_atanh or test_cbrt"
================ 9 passed, 1476 deselected in 8.01s ================
```

3 tests × 3 gens (DOUBLE/FLOAT/DECIMAL) = 9 cases, all pass.

## Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

## Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

## Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required