### PR TITLE
Add DECIMAL value coverage for transform_values (#14641)

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -723,7 +723,8 @@ def test_map_element_at_ansi_null(data_gen):
 
 
 @disable_ansi_mode  # ANSI mode failures are tested separately.
-@pytest.mark.parametrize('data_gen', map_gens_sample + maps_with_binary_value, ids=idfn)
+@pytest.mark.parametrize('data_gen', map_gens_sample + maps_with_binary_value +
+    decimal_128_map_gens + decimal_64_map_gens, ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_transform_values(data_gen):
     def do_it(spark):
@@ -734,7 +735,8 @@ def test_transform_values(data_gen):
                    'transform_values(a, (key, value) -> key) as indexed',
                    'transform_values(a, (key, value) -> b) as b_val']
         value_type = data_gen.data_type.valueType
-        # decimal types can grow too large so we are avoiding those here for now
+        # Arithmetic expansions below can overflow decimal precision, so they
+        # run only on IntegralType values.
         if isinstance(value_type, IntegralType):
             columns.extend([
                 'transform_values(a, (key, value) -> value + 1) as add',


### PR DESCRIPTION
## Summary
Closes #14641.

Extends `test_transform_values` in `integration_tests/src/main/python/map_test.py` to parametrize over `decimal_128_map_gens + decimal_64_map_gens` in addition to the existing `map_gens_sample + maps_with_binary_value`. `test_transform_keys` already covers those decimal map gens — this brings `test_transform_values` to parity.

## Why

The prior exclusion comment ("decimal types can grow too large so we are avoiding those here for now") applied only to the arithmetic expansions (`value + 1`, `value + value`, `value + b`) which are already gated behind `if isinstance(value_type, IntegralType)`. Decimal values skip that branch and only hit the identity / null / 1 / key / b lambdas, which don't overflow. The rewritten comment now correctly narrates the IntegralType gating.

Pure test addition — no plugin code changes.

## Verification

Local run on Spark 3.5.4 + buildver=354:

```
pytest -k test_transform_values
================ 20 passed, 687 deselected in 48.35s ================
```

## Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

## Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

## Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required