### PR TITLE
Add footer cache for iceberg

### DIFF
--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
@@ -59,7 +59,7 @@ class GpuIcebergParquetAppender(
   override def close(): Unit = {
     if (!closed) {
       inner.close()
-      footer = withResource(IcebergPartitionedFile(fileIO.newInputFile(inner.path)).newReader) {
+      footer = withResource(IcebergPartitionedFile(fileIO.newInputFile(inner.path)).newReader()) {
         reader =>
           // TODO: Remove the read after https://github.com/rapidsai/cudf/issues/18886 got fixed.
           reader.getFooter

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/converter/ToIcebergShaded.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/converter/ToIcebergShaded.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.iceberg.parquet.converter
+
+import java.nio.ByteBuffer
+
+import org.apache.iceberg.shaded.org.apache.parquet.io.{InputFile => ShadedInputFile, SeekableInputStream => ShadedSeekableInputStream}
+import org.apache.parquet.io.{InputFile, SeekableInputStream}
+
+/**
+ * Adapters from the non-shaded parquet `InputFile` / `SeekableInputStream` to their shaded
+ * equivalents under `org.apache.iceberg.shaded.org.apache.parquet.io`.
+ */
+object ToIcebergShaded {
+  def shade(inputFile: InputFile): ShadedInputFile = {
+    if (inputFile == null) {
+      return null
+    }
+    new ShadedInputFile {
+      override def getLength: Long = inputFile.getLength
+      override def newStream(): ShadedSeekableInputStream = shade(inputFile.newStream())
+      override def toString: String = inputFile.toString
+    }
+  }
+
+  def shade(inputStream: SeekableInputStream): ShadedSeekableInputStream = {
+    if (inputStream == null) {
+      return null
+    }
+    new ShadedSeekableInputStream {
+      override def getPos: Long = inputStream.getPos
+      override def seek(newPos: Long): Unit = inputStream.seek(newPos)
+      override def read(): Int = inputStream.read()
+      override def read(bytes: Array[Byte], start: Int, len: Int): Int =
+        inputStream.read(bytes, start, len)
+      override def readFully(bytes: Array[Byte]): Unit = inputStream.readFully(bytes)
+      override def readFully(bytes: Array[Byte], start: Int, len: Int): Unit =
+        inputStream.readFully(bytes, start, len)
+      override def read(buf: ByteBuffer): Int = inputStream.read(buf)
+      override def readFully(buf: ByteBuffer): Unit = inputStream.readFully(buf)
+      override def close(): Unit = inputStream.close()
+    }
+  }
+}

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/reader.scala
@@ -61,9 +61,9 @@ case class IcebergPartitionedFile(
     GpuIcebergParquetReader.buildReaderOptions(file.getDelegate, split)
   }
 
-  def newReader: ParquetFileReader = {
+  def newReader(metrics: Map[String, GpuMetric] = Map.empty): ParquetFileReader = {
     try {
-      ParquetFileReader.open(GpuParquetIO.file(file.getDelegate), parquetReadOptions)
+      GpuParquetIO.openReader(file, path, parquetReadOptions, metrics)
     } catch {
       case e: IOException =>
         throw new UncheckedIOException(s"Failed to newInputFile Parquet file: " +
@@ -196,7 +196,7 @@ trait GpuIcebergParquetReader extends Iterator[ColumnarBatch] with AutoCloseable
 
   def filterParquetBlocks(file: IcebergPartitionedFile,
       requiredSchema: Schema): (ParquetFileInfoWithBlockMeta, ShadedMessageType) = {
-    withResource(file.newReader) { reader =>
+    withResource(file.newReader(conf.metrics)) { reader =>
       val fileSchema = reader.getFileMetaData.getSchema
 
       val rowGroupFirstRowIndices = new Array[Long](reader.getRowGroups.size())

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/testutils/AddEqDeletes.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/testutils/AddEqDeletes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/testutils/AddEqDeletes.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/testutils/AddEqDeletes.scala
@@ -147,7 +147,7 @@ object AddEqDeletes extends Logging {
     (parquetFile)))
 
     val tableSchema = table.schema
-    withResource(icebergPartitionedFile.newReader) { reader =>
+    withResource(icebergPartitionedFile.newReader()) { reader =>
       logDebug(s"Reading eq delete parquet file $parquetFile, " +
         s"schema:\n${reader.getFileMetaData.getSchema}")
       val colNames = reader

--- a/iceberg/common/src/main/scala/org/apache/iceberg/parquet/GpuParquetIO.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/parquet/GpuParquetIO.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,171 @@
 
 package org.apache.iceberg.parquet
 
+import java.io.EOFException
+import java.nio.ByteBuffer
+
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.GpuMetric
+import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
+import com.nvidia.spark.rapids.parquet.ParquetFooterUtils
+import org.apache.hadoop.fs.Path
 import org.apache.iceberg.io.InputFile
-import org.apache.iceberg.shaded.org.apache.parquet.io.{InputFile => ShadedInputFile}
+import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
+import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.iceberg.shaded.org.apache.parquet.io.{InputFile => ShadedInputFile, SeekableInputStream => ShadedSeekableInputStream}
+import org.apache.parquet.hadoop.ParquetFileWriter.MAGIC
 
 object GpuParquetIO {
   def file(file: InputFile): ShadedInputFile = {
     ParquetIO.file(file)
+  }
+
+  /**
+   * Open a shaded `ParquetFileReader` with its footer tail served from the Rapids file cache when
+   * possible. On a cache hit no remote IO happens for the footer; on a miss the tail is read from
+   * the Iceberg `InputFile` and handed to `FileCache` for future reads.
+   *
+   * The cached bytes are wrapped around the real input file so `ParquetFileReader.open` still uses
+   * its normal initialization path — no version-specific parquet API is required.
+   */
+  def openReader(
+      inputFile: IcebergInputFile,
+      filePath: Path,
+      options: ParquetReadOptions,
+      metrics: Map[String, GpuMetric]): ParquetFileReader = {
+    val framedTail = withResource(ParquetFooterUtils.getFooterBuffer(
+      inputFile, metrics,
+      ParquetFooterUtils.readFooterBufferFromInputFile(inputFile, filePath))) { hmb =>
+      ParquetFooterUtils.readBytesFromBuffer(hmb, 0, hmb.getLength.toInt)
+    }
+    // framedTail is MAGIC + <file tail bytes starting at footerStart>; the leading MAGIC is
+    // synthetic so ParquetFileReader.readFooter can operate on it standalone elsewhere.
+    val realShadedFile = file(inputFile.getDelegate)
+    val wrapped = new FooterCachedShadedInputFile(realShadedFile, framedTail, MAGIC.length)
+    ParquetFileReader.open(wrapped, options)
+  }
+}
+
+/**
+ * Shaded `InputFile` wrapper that serves reads in the footer tail region from an in-memory byte
+ * array and delegates everything else to the real file. The wrapper is scoped to a single
+ * `ParquetFileReader` open call; closing the reader closes the underlying stream.
+ *
+ * @param realFile      the real shaded input file (used for data reads outside the footer)
+ * @param framedTail    bytes of the form `<synthetic prefix> + <real file tail bytes>`; real file
+ *                      tail starts at index `tailPrefixLen` within this array
+ * @param tailPrefixLen number of synthetic bytes at the start of `framedTail` (not part of the
+ *                      real file); usually `MAGIC.length`
+ */
+private class FooterCachedShadedInputFile(
+    realFile: ShadedInputFile,
+    framedTail: Array[Byte],
+    tailPrefixLen: Int) extends ShadedInputFile {
+
+  private val fileLen: Long = realFile.getLength
+  private val cachedBytes: Int = framedTail.length - tailPrefixLen
+  private val cachedStart: Long = fileLen - cachedBytes
+
+  override def getLength: Long = fileLen
+
+  override def newStream(): ShadedSeekableInputStream = new ShadedSeekableInputStream {
+    private var pos: Long = 0L
+    private var realStream: ShadedSeekableInputStream = _
+
+    private def realAt(p: Long): ShadedSeekableInputStream = {
+      if (realStream == null) {
+        realStream = realFile.newStream()
+      }
+      realStream.seek(p)
+      realStream
+    }
+
+    override def getPos: Long = pos
+
+    override def seek(newPos: Long): Unit = {
+      pos = newPos
+    }
+
+    override def read(): Int = {
+      if (pos >= fileLen) {
+        -1
+      } else if (pos >= cachedStart) {
+        val b = framedTail((pos - cachedStart).toInt + tailPrefixLen) & 0xff
+        pos += 1
+        b
+      } else {
+        val rs = realAt(pos)
+        val b = rs.read()
+        if (b >= 0) {
+          pos += 1
+        }
+        b
+      }
+    }
+
+    override def read(dst: Array[Byte], off: Int, len: Int): Int = {
+      if (pos >= fileLen || len == 0) {
+        if (len == 0) 0 else -1
+      } else if (pos >= cachedStart) {
+        val avail = (fileLen - pos).toInt
+        val toCopy = math.min(len, avail)
+        System.arraycopy(framedTail, (pos - cachedStart).toInt + tailPrefixLen, dst, off, toCopy)
+        pos += toCopy
+        toCopy
+      } else {
+        val cap = math.min(len.toLong, cachedStart - pos).toInt
+        val rs = realAt(pos)
+        val n = rs.read(dst, off, cap)
+        if (n > 0) {
+          pos += n
+        }
+        n
+      }
+    }
+
+    override def readFully(dst: Array[Byte]): Unit = readFully(dst, 0, dst.length)
+
+    override def readFully(dst: Array[Byte], off: Int, len: Int): Unit = {
+      var total = 0
+      while (total < len) {
+        val n = read(dst, off + total, len - total)
+        if (n < 0) {
+          throw new EOFException(s"Reached end of file at pos $pos while reading $len bytes")
+        }
+        total += n
+      }
+    }
+
+    override def read(buf: ByteBuffer): Int = {
+      if (pos >= fileLen) {
+        return -1
+      }
+      val want = math.min(buf.remaining.toLong, fileLen - pos).toInt
+      val tmp = new Array[Byte](want)
+      var total = 0
+      while (total < want) {
+        val n = read(tmp, total, want - total)
+        if (n < 0) {
+          if (total == 0) return -1 else return total
+        }
+        total += n
+      }
+      buf.put(tmp, 0, total)
+      total
+    }
+
+    override def readFully(buf: ByteBuffer): Unit = {
+      val need = buf.remaining
+      val tmp = new Array[Byte](need)
+      readFully(tmp, 0, need)
+      buf.put(tmp)
+    }
+
+    override def close(): Unit = {
+      if (realStream != null) {
+        realStream.close()
+        realStream = null
+      }
+    }
   }
 }

--- a/iceberg/iceberg-1-10-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-10-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.parquet
+
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.GpuMetric
+import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
+import com.nvidia.spark.rapids.iceberg.parquet.converter.ToIcebergShaded
+import com.nvidia.spark.rapids.parquet.{HMBInputFile, ParquetFooterUtils}
+import org.apache.hadoop.fs.Path
+import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
+import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
+
+/**
+ * Iceberg 1.10.x shim: reads the footer via `FileCache` and injects it into `ParquetFileReader`
+ * through the 4-arg `(InputFile, ParquetMetadata, ParquetReadOptions, SeekableInputStream)`
+ * constructor that is available from iceberg 1.10.x.
+ */
+object GpuParquetIOShim {
+  def openReader(
+      inputFile: IcebergInputFile,
+      filePath: Path,
+      options: ParquetReadOptions,
+      metrics: Map[String, GpuMetric]): ParquetFileReader = {
+    val metadata = withResource(ParquetFooterUtils.getFooterBuffer(
+        inputFile, metrics,
+        ParquetFooterUtils.readFooterBufferFromInputFile(inputFile, filePath))) { hmb =>
+      val shadedHmbFile = ToIcebergShaded.shade(new HMBInputFile(hmb))
+      withResource(shadedHmbFile.newStream()) { hmbStream =>
+        ParquetFileReader.readFooter(shadedHmbFile, options, hmbStream)
+      }
+    }
+    val realFile = GpuParquetIO.file(inputFile.getDelegate)
+    closeOnExcept(realFile.newStream()) { stream =>
+      new ParquetFileReader(realFile, metadata, options, stream)
+    }
+  }
+}

--- a/iceberg/iceberg-1-6-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-6-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,27 +19,21 @@ package org.apache.iceberg.parquet
 import com.nvidia.spark.rapids.GpuMetric
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import org.apache.hadoop.fs.Path
-import org.apache.iceberg.io.InputFile
 import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
-import org.apache.iceberg.shaded.org.apache.parquet.io.{InputFile => ShadedInputFile}
 
-object GpuParquetIO {
-  def file(file: InputFile): ShadedInputFile = {
-    ParquetIO.file(file)
-  }
-
-  /**
-   * Open a shaded `ParquetFileReader`. Footer caching is version-dependent and handled by the
-   * per-iceberg-version [[GpuParquetIOShim]]: the 1.10.x shim caches via `FileCache`, while the
-   * 1.6.x / 1.9.x shims open without caching (their shaded parquet has no way to inject a
-   * pre-parsed footer).
-   */
+/**
+ * Iceberg 1.6.x shim: footer caching is not supported because the shaded `ParquetFileReader` in
+ * 1.6.x has no public API to inject pre-parsed footer metadata. This opens the reader via the
+ * plain `open(InputFile, ParquetReadOptions)` path and always reads the footer from the file.
+ */
+object GpuParquetIOShim {
   def openReader(
       inputFile: IcebergInputFile,
       filePath: Path,
       options: ParquetReadOptions,
       metrics: Map[String, GpuMetric]): ParquetFileReader = {
-    GpuParquetIOShim.openReader(inputFile, filePath, options, metrics)
+    val _ = (filePath, metrics)
+    ParquetFileReader.open(GpuParquetIO.file(inputFile.getDelegate), options)
   }
 }

--- a/iceberg/iceberg-1-6-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-6-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
@@ -16,7 +16,9 @@
 
 package org.apache.iceberg.parquet
 
-import com.nvidia.spark.rapids.GpuMetric
+import scala.annotation.nowarn
+
+import com.nvidia.spark.rapids.{GpuMetric, NoopMetric}
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import org.apache.hadoop.fs.Path
 import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
@@ -26,14 +28,16 @@ import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
  * Iceberg 1.6.x shim: footer caching is not supported because the shaded `ParquetFileReader` in
  * 1.6.x has no public API to inject pre-parsed footer metadata. This opens the reader via the
  * plain `open(InputFile, ParquetReadOptions)` path and always reads the footer from the file.
+ * The footer-miss counter is bumped on every call so dashboards see non-zero activity instead
+ * of silently interpreting "all zeros" as "everything was cached".
  */
 object GpuParquetIOShim {
   def openReader(
       inputFile: IcebergInputFile,
-      filePath: Path,
+      _filePath: Path,
       options: ParquetReadOptions,
       metrics: Map[String, GpuMetric]): ParquetFileReader = {
-    val _ = (filePath, metrics)
+    metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES, NoopMetric) += 1
     ParquetFileReader.open(GpuParquetIO.file(inputFile.getDelegate), options)
   }
 }

--- a/iceberg/iceberg-1-6-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-6-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
@@ -16,8 +16,6 @@
 
 package org.apache.iceberg.parquet
 
-import scala.annotation.nowarn
-
 import com.nvidia.spark.rapids.{GpuMetric, NoopMetric}
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import org.apache.hadoop.fs.Path

--- a/iceberg/iceberg-1-9-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-9-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,27 +19,21 @@ package org.apache.iceberg.parquet
 import com.nvidia.spark.rapids.GpuMetric
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import org.apache.hadoop.fs.Path
-import org.apache.iceberg.io.InputFile
 import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
 import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
-import org.apache.iceberg.shaded.org.apache.parquet.io.{InputFile => ShadedInputFile}
 
-object GpuParquetIO {
-  def file(file: InputFile): ShadedInputFile = {
-    ParquetIO.file(file)
-  }
-
-  /**
-   * Open a shaded `ParquetFileReader`. Footer caching is version-dependent and handled by the
-   * per-iceberg-version [[GpuParquetIOShim]]: the 1.10.x shim caches via `FileCache`, while the
-   * 1.6.x / 1.9.x shims open without caching (their shaded parquet has no way to inject a
-   * pre-parsed footer).
-   */
+/**
+ * Iceberg 1.9.x shim: footer caching is not supported because the shaded `ParquetFileReader` in
+ * 1.9.x has no public API to inject pre-parsed footer metadata. This opens the reader via the
+ * plain `open(InputFile, ParquetReadOptions)` path and always reads the footer from the file.
+ */
+object GpuParquetIOShim {
   def openReader(
       inputFile: IcebergInputFile,
       filePath: Path,
       options: ParquetReadOptions,
       metrics: Map[String, GpuMetric]): ParquetFileReader = {
-    GpuParquetIOShim.openReader(inputFile, filePath, options, metrics)
+    val _ = (filePath, metrics)
+    ParquetFileReader.open(GpuParquetIO.file(inputFile.getDelegate), options)
   }
 }

--- a/iceberg/iceberg-1-9-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-9-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
@@ -16,7 +16,9 @@
 
 package org.apache.iceberg.parquet
 
-import com.nvidia.spark.rapids.GpuMetric
+import scala.annotation.nowarn
+
+import com.nvidia.spark.rapids.{GpuMetric, NoopMetric}
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import org.apache.hadoop.fs.Path
 import org.apache.iceberg.shaded.org.apache.parquet.ParquetReadOptions
@@ -26,14 +28,16 @@ import org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader
  * Iceberg 1.9.x shim: footer caching is not supported because the shaded `ParquetFileReader` in
  * 1.9.x has no public API to inject pre-parsed footer metadata. This opens the reader via the
  * plain `open(InputFile, ParquetReadOptions)` path and always reads the footer from the file.
+ * The footer-miss counter is bumped on every call so dashboards see non-zero activity instead
+ * of silently interpreting "all zeros" as "everything was cached".
  */
 object GpuParquetIOShim {
   def openReader(
       inputFile: IcebergInputFile,
-      filePath: Path,
+      _filePath: Path,
       options: ParquetReadOptions,
       metrics: Map[String, GpuMetric]): ParquetFileReader = {
-    val _ = (filePath, metrics)
+    metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES, NoopMetric) += 1
     ParquetFileReader.open(GpuParquetIO.file(inputFile.getDelegate), options)
   }
 }

--- a/iceberg/iceberg-1-9-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
+++ b/iceberg/iceberg-1-9-x/src/main/scala/org/apache/iceberg/parquet/GpuParquetIOShim.scala
@@ -16,8 +16,6 @@
 
 package org.apache.iceberg.parquet
 
-import scala.annotation.nowarn
-
 import com.nvidia.spark.rapids.{GpuMetric, NoopMetric}
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile
 import org.apache.hadoop.fs.Path

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -636,39 +636,10 @@ protected case class GpuParquetFileFilterHandler(
     //noinspection ScalaDeprecation
     NvtxRegistry.PARQUET_READ_FOOTER {
       val inputFile = fileIO.newInputFile(filePath)
-      FileCache.get.getFooter(inputFile).map { hmb =>
-        withResource(hmb) { _ =>
-          metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_HITS, NoopMetric) += 1
-          metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_HITS_SIZE, NoopMetric) += hmb.getLength
-          ParquetFileReader.readFooter(new HMBInputFile(hmb),
-            ParquetMetadataConverter.range(file.start, file.start + file.length))
-        }
-      }.getOrElse {
-        metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES, NoopMetric) += 1
-        // footer was not cached, so try to cache it
-        // If we get a filecache token then we can complete the caching by providing the data.
-        // If something goes wrong before completing the caching then the token must be canceled.
-        // If we do not get a token then we should not cache this data.
-        val cacheToken = FileCache.get.startFooterCache(inputFile)
-        cacheToken.map { token =>
-          var needTokenCancel = true
-          try {
-            withResource(readFooterBuffer(fileIO, filePath, conf)) { hmb =>
-              metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES_SIZE, NoopMetric) += hmb.getLength
-              token.complete(hmb.slice(0, hmb.getLength))
-              needTokenCancel = false
-              ParquetFileReader.readFooter(new HMBInputFile(hmb),
-                ParquetMetadataConverter.range(file.start, file.start + file.length))
-            }
-          } finally {
-            if (needTokenCancel) {
-              token.cancel()
-            }
-          }
-        }.getOrElse {
-          ParquetFileReader.readFooter(conf, filePath,
-            ParquetMetadataConverter.range(file.start, file.start + file.length))
-        }
+      withResource(ParquetFooterUtils.getFooterBuffer(inputFile, metrics,
+          readFooterBuffer(fileIO, filePath, conf))) { hmb =>
+        ParquetFileReader.readFooter(new HMBInputFile(hmb),
+          ParquetMetadataConverter.range(file.start, file.start + file.length))
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -21,7 +21,6 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.channels.SeekableByteChannel
 import java.nio.charset.StandardCharsets
-import java.util
 import java.util.{Collections, Locale}
 
 import scala.annotation.tailrec
@@ -488,7 +487,6 @@ protected case class GpuParquetFileFilterHandler(
 
   private val PARQUET_ENCRYPTION_CONFS = Seq("parquet.encryption.kms.client.class",
     "parquet.encryption.kms.client.class", "parquet.crypto.factory.class")
-  private val PARQUET_MAGIC_ENCRYPTED = "PARE".getBytes(StandardCharsets.US_ASCII)
 
   private def isParquetTimeInInt96(parquetType: Type): Boolean = {
     parquetType match {
@@ -534,27 +532,10 @@ protected case class GpuParquetFileFilterHandler(
       conf: Configuration,
       metrics: Map[String, GpuMetric]): HostMemoryBuffer = {
     val inputFile = fileIO.newInputFile(filePath)
-    FileCache.get.getFooter(inputFile).map { hmb =>
-      withResource(hmb) { _ =>
-        metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_HITS, NoopMetric) += 1
-        metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_HITS_SIZE, NoopMetric) += hmb.getLength
-        // buffer includes header and trailing length and magic, stripped here
-        hmb.slice(MAGIC.length, hmb.getLength - Integer.BYTES - MAGIC.length)
-      }
-    }.getOrElse {
-      metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES, NoopMetric) += 1
-      withResource(readFooterBuffer(fileIO, filePath, conf)) { hmb =>
-        metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES_SIZE, NoopMetric) += hmb.getLength
-        // footer was not cached, so try to cache it
-        // If we get a filecache token then we can complete the caching by providing the data.
-        // If we do not get a token then we should not cache this data.
-        val cacheToken = FileCache.get.startFooterCache(inputFile)
-        cacheToken.foreach { t =>
-          t.complete(hmb.slice(0, hmb.getLength))
-        }
-        // buffer includes header and trailing length and magic, stripped here
-        hmb.slice(MAGIC.length, hmb.getLength - Integer.BYTES - MAGIC.length)
-      }
+    withResource(ParquetFooterUtils.getFooterBuffer(inputFile, metrics,
+        readFooterBuffer(fileIO, filePath, conf))) { hmb =>
+      // buffer includes header and trailing length and magic, stripped here
+      hmb.slice(MAGIC.length, hmb.getLength - Integer.BYTES - MAGIC.length)
     }
   }
 
@@ -619,17 +600,7 @@ protected case class GpuParquetFileFilterHandler(
 
 
   private def verifyParquetMagic(filePath: Path, magic: Array[Byte]): Unit = {
-    if (!util.Arrays.equals(MAGIC, magic)) {
-      if (util.Arrays.equals(PARQUET_MAGIC_ENCRYPTED, magic)) {
-        throw new RuntimeException("The GPU does not support reading encrypted Parquet " +
-          "files. To read encrypted or columnar encrypted files, disable the GPU Parquet " +
-          s"reader via ${RapidsConf.ENABLE_PARQUET_READ.key}.")
-      } else {
-        throw new RuntimeException(s"$filePath is not a Parquet file. " +
-          s"Expected magic number at tail ${util.Arrays.toString(MAGIC)} " +
-          s"but found ${util.Arrays.toString(magic)}")
-      }
-    }
+    ParquetFooterUtils.verifyParquetMagic(filePath, magic)
   }
 
   private def readAndFilterFooter(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetFooterUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetFooterUtils.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.parquet
+
+import java.nio.charset.StandardCharsets
+import java.util.Arrays
+
+import ai.rapids.cudf.HostMemoryBuffer
+import com.nvidia.spark.rapids.{GpuMetric, NoopMetric, RapidsConf}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.filecache.FileCache
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.IOUtils
+import org.apache.parquet.bytes.BytesUtils.readIntLittleEndian
+import org.apache.parquet.hadoop.ParquetFileWriter.MAGIC
+
+/**
+ * Shared helpers for reading and caching Parquet footer bytes.
+ *
+ * The buffer produced here is framed as `MAGIC + footer + footerLen + MAGIC`, i.e. a self-contained
+ * mini Parquet tail that can be fed directly to `ParquetFileReader.readFooter` via an
+ * `HMBInputFile`.
+ */
+object ParquetFooterUtils {
+  val FooterLengthSize: Int = java.lang.Integer.BYTES
+  private val ParquetMagicEncrypted = "PARE".getBytes(StandardCharsets.US_ASCII)
+
+  def verifyParquetMagic(filePath: Path, magic: Array[Byte]): Unit = {
+    if (!Arrays.equals(MAGIC, magic)) {
+      if (Arrays.equals(ParquetMagicEncrypted, magic)) {
+        throw new RuntimeException("The GPU does not support reading encrypted Parquet files. " +
+          s"To read encrypted or columnar encrypted files, disable the GPU Parquet reader via " +
+          s"${RapidsConf.ENABLE_PARQUET_READ.key}.")
+      } else {
+        throw new RuntimeException(s"$filePath is not a Parquet file. Expected magic number " +
+          s"at tail ${Arrays.toString(MAGIC)} but found ${Arrays.toString(magic)}")
+      }
+    }
+  }
+
+  def readBytesFromBuffer(buffer: HostMemoryBuffer, offset: Long, length: Int): Array[Byte] = {
+    val bytes = new Array[Byte](length)
+    buffer.getBytes(bytes, 0, offset, length)
+    bytes
+  }
+
+  def footerIndex(
+      filePath: Path,
+      fileLen: Long,
+      footerLength: Int,
+      footerLengthSize: Int): Long = {
+    val footerLengthIndex = fileLen - footerLengthSize - MAGIC.length
+    val idx = footerLengthIndex - footerLength
+    if (idx < MAGIC.length || idx >= footerLengthIndex) {
+      throw new RuntimeException(s"corrupted file $filePath: the footer index is not within " +
+        s"the file: $idx")
+    }
+    idx
+  }
+
+  /**
+   * Read the Parquet footer bytes directly from a `RapidsInputFile` into a framed
+   * `MAGIC + footer + footerLen + MAGIC` `HostMemoryBuffer`.
+   */
+  def readFooterBufferFromInputFile(
+      inputFile: RapidsInputFile,
+      filePath: Path): HostMemoryBuffer = {
+    val fileLen = inputFile.getLength
+    if (fileLen < MAGIC.length + FooterLengthSize + MAGIC.length) {
+      throw new RuntimeException(s"$filePath is not a Parquet file (too small length: $fileLen )")
+    }
+    val footerLengthIndex = fileLen - FooterLengthSize - MAGIC.length
+    withResource(inputFile.open()) { inputStream =>
+      inputStream.seek(footerLengthIndex)
+      val footerLength = readIntLittleEndian(inputStream)
+      val magic = new Array[Byte](MAGIC.length)
+      IOUtils.readFully(inputStream, magic, 0, magic.length)
+      verifyParquetMagic(filePath, magic)
+      val fIdx = footerIndex(filePath, fileLen, footerLength, FooterLengthSize)
+      val tailBytes = (fileLen - fIdx).toInt
+      closeOnExcept(HostMemoryBuffer.allocate(tailBytes + MAGIC.length, false)) { outBuffer =>
+        outBuffer.setBytes(0, MAGIC, 0, MAGIC.length)
+        inputStream.seek(fIdx)
+        val tmp = new Array[Byte](4096)
+        var written = MAGIC.length.toLong
+        var bytesLeft = tailBytes
+        while (bytesLeft > 0) {
+          val toRead = math.min(bytesLeft, tmp.length)
+          IOUtils.readFully(inputStream, tmp, 0, toRead)
+          outBuffer.setBytes(written, tmp, 0, toRead)
+          written += toRead
+          bytesLeft -= toRead
+        }
+        outBuffer
+      }
+    }
+  }
+
+  /**
+   * Return a framed footer buffer (`MAGIC + footer + footerLen + MAGIC`) for `inputFile`,
+   * serving from `FileCache` when present and populating the cache on miss. The `readFooterBuffer`
+   * thunk is only evaluated on a miss and must return a buffer with the same framing.
+   */
+  def getFooterBuffer(
+      inputFile: RapidsInputFile,
+      metrics: Map[String, GpuMetric],
+      readFooterBuffer: => HostMemoryBuffer): HostMemoryBuffer = {
+    FileCache.get.getFooter(inputFile).map { footer =>
+      metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_HITS, NoopMetric) += 1
+      metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_HITS_SIZE, NoopMetric) += footer.getLength
+      footer
+    }.getOrElse {
+      metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES, NoopMetric) += 1
+      val cacheToken = FileCache.get.startFooterCache(inputFile)
+      cacheToken.map { token =>
+        var needTokenCancel = true
+        try {
+          closeOnExcept(readFooterBuffer) { footer =>
+            metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES_SIZE, NoopMetric) +=
+              footer.getLength
+            token.complete(footer.slice(0, footer.getLength))
+            needTokenCancel = false
+            footer
+          }
+        } finally {
+          if (needTokenCancel) {
+            token.cancel()
+          }
+        }
+      }.getOrElse {
+        val footer = readFooterBuffer
+        metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES_SIZE, NoopMetric) += footer.getLength
+        footer
+      }
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetFooterUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetFooterUtils.scala
@@ -143,9 +143,11 @@ object ParquetFooterUtils {
           }
         }
       }.getOrElse {
-        val footer = readFooterBuffer
-        metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES_SIZE, NoopMetric) += footer.getLength
-        footer
+        closeOnExcept(readFooterBuffer) { footer =>
+          metrics.getOrElse(GpuMetric.FILECACHE_FOOTER_MISSES_SIZE, NoopMetric) +=
+            footer.getLength
+          footer
+        }
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetFooterUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetFooterUtils.scala
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Arrays
 
 import ai.rapids.cudf.HostMemoryBuffer
-import com.nvidia.spark.rapids.{GpuMetric, NoopMetric, RapidsConf}
+import com.nvidia.spark.rapids.{GpuMetric, NoopMetric, NvtxRegistry, RapidsConf}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.filecache.FileCache
 import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile
@@ -86,27 +86,29 @@ object ParquetFooterUtils {
     }
     val footerLengthIndex = fileLen - FooterLengthSize - MAGIC.length
     withResource(inputFile.open()) { inputStream =>
-      inputStream.seek(footerLengthIndex)
-      val footerLength = readIntLittleEndian(inputStream)
-      val magic = new Array[Byte](MAGIC.length)
-      IOUtils.readFully(inputStream, magic, 0, magic.length)
-      verifyParquetMagic(filePath, magic)
-      val fIdx = footerIndex(filePath, fileLen, footerLength, FooterLengthSize)
-      val tailBytes = (fileLen - fIdx).toInt
-      closeOnExcept(HostMemoryBuffer.allocate(tailBytes + MAGIC.length, false)) { outBuffer =>
-        outBuffer.setBytes(0, MAGIC, 0, MAGIC.length)
-        inputStream.seek(fIdx)
-        val tmp = new Array[Byte](4096)
-        var written = MAGIC.length.toLong
-        var bytesLeft = tailBytes
-        while (bytesLeft > 0) {
-          val toRead = math.min(bytesLeft, tmp.length)
-          IOUtils.readFully(inputStream, tmp, 0, toRead)
-          outBuffer.setBytes(written, tmp, 0, toRead)
-          written += toRead
-          bytesLeft -= toRead
+      NvtxRegistry.PARQUET_READ_FOOTER_BYTES {
+        inputStream.seek(footerLengthIndex)
+        val footerLength = readIntLittleEndian(inputStream)
+        val magic = new Array[Byte](MAGIC.length)
+        IOUtils.readFully(inputStream, magic, 0, magic.length)
+        verifyParquetMagic(filePath, magic)
+        val fIdx = footerIndex(filePath, fileLen, footerLength, FooterLengthSize)
+        val tailBytes = Math.toIntExact(fileLen - fIdx)
+        closeOnExcept(HostMemoryBuffer.allocate(tailBytes + MAGIC.length, false)) { outBuffer =>
+          outBuffer.setBytes(0, MAGIC, 0, MAGIC.length)
+          inputStream.seek(fIdx)
+          val tmp = new Array[Byte](4096)
+          var written = MAGIC.length.toLong
+          var bytesLeft = tailBytes
+          while (bytesLeft > 0) {
+            val toRead = math.min(bytesLeft, tmp.length)
+            IOUtils.readFully(inputStream, tmp, 0, toRead)
+            outBuffer.setBytes(written, tmp, 0, toRead)
+            written += toRead
+            bytesLeft -= toRead
+          }
+          outBuffer
         }
-        outBuffer
       }
     }
   }


### PR DESCRIPTION

Fixes #14064 

### Description

Allow iceberg's parquet reader to utilize footer cache. Since in older version of parquet, the `ParquetFileReader` constructor with `ParquetMetadata` is not available, we actually ignored the footer cache in iceberg 1.6.x and 1.9.x shim, and it's only available in iceberg 1.10  shim.

### Checklists


Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance

- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

For the reason mentioned in pr description, we should only do perf test against iceberg 1.10 shim
