### PR TITLE
Use scalar extractListElement index instead of column in regex extract

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1656,11 +1656,7 @@ case class GpuRegExpExtractAll(
                 val maxSizeInt = maxSize.getInt
                 val stringCols = Range(0, maxSizeInt, 1).safeMap {
                   i =>
-                    withResource(Scalar.fromInt(i)) { scalarIndex =>
-                      withResource(ColumnVector.fromScalar(scalarIndex, rowCount.toInt)) {
-                        index => allExtracted.extractListElement(index)
-                      }
-                    }
+                    allExtracted.extractListElement(i)
                 }
                 withResource(stringCols) { _ =>
                   ColumnVector.makeList(rowCount, DType.STRING, stringCols: _*)


### PR DESCRIPTION
Contributes to #14588.

### Description

This is a small local change in regex extract to prefer the scalar index API rather than replicating as a full column. Existing regex extract tests (e.g., [regexp_test.py](https://github.com/NVIDIA/spark-rapids/blob/main/integration_tests/src/main/python/regexp_test.py#L848-L885)) cover this change.

Using the scalar index API can be ~30% faster. 

<details>
<summary>Nanobenchmark comparing the two APIs</summary>

```scala
import ai.rapids.cudf.{ColumnVector, Cuda, DType, Rmm, RmmAllocationMode, Scalar}

object ExtractListElementBench {
  val NumRows = 100000
  val MaxListSize = 5
  val Warmup = 5
  val Measured = 20

  def main(args: Array[String]): Unit = {
    Rmm.initialize(RmmAllocationMode.POOL, null, Cuda.memGetInfo().free / 2 & ~255L)

    withResource(buildListColumn()) { listCol =>
      for (_ <- 0 until Warmup) {
        scalarBroadcast(listCol).foreach(_.close())
        intDirect(listCol).foreach(_.close())
      }
      val timesA = (0 until Measured).map { _ =>
        val t = System.nanoTime()
        scalarBroadcast(listCol).foreach(_.close())
        System.nanoTime() - t
      }
      val timesB = (0 until Measured).map { _ =>
        val t = System.nanoTime()
        intDirect(listCol).foreach(_.close())
        System.nanoTime() - t
      }
      println(f"Col index median: ${timesA.sorted.apply(Measured / 2) / 1e6}%.3f ms")
      println(f"Scalar index median: ${timesB.sorted.apply(Measured / 2) / 1e6}%.3f ms")
    }
  }

  def scalarBroadcast(listCol: ColumnVector): Seq[ColumnVector] =
    (0 until MaxListSize).map { i =>
      withResource(Scalar.fromInt(i)) { idx =>
        withResource(ColumnVector.fromScalar(idx, NumRows)) { bcast =>
          listCol.extractListElement(bcast)
        }
      }
    }

  def intDirect(listCol: ColumnVector): Seq[ColumnVector] =
    (0 until MaxListSize).map(i => listCol.extractListElement(i))

  def buildListColumn(): ColumnVector = {
    val cols = (0 until MaxListSize).map { i =>
      withResource(Scalar.fromString(s"elem_$i")) { s =>
        ColumnVector.fromScalar(s, NumRows)
      }
    }
    try ColumnVector.makeList(NumRows.toLong, DType.STRING, cols: _*)
    finally cols.foreach(_.close())
  }
}
```

</details>

```text
Col index median: 0.904 ms
Scalar index median: 0.676 ms
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
