### PR TITLE
[DOC] add missing release notes to 26.04 download page [skip ci]

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -113,7 +113,8 @@ The output of signature verify:
 
 ### Release Notes
 * Databricks 17.3 ML LTS (Spark 4.0) support (Delta Lake fallback to CPU); Databricks 12.2 ML LTS no longer supported ([#14518](https://github.com/NVIDIA/spark-rapids/pull/14518))
-* Iceberg 1.10.1 support with Spark 4.0.2 ([#14459](https://github.com/NVIDIA/spark-rapids/pull/14459))
+* Delta Lake deletion vector support on Databricks 14.3
+* Iceberg 1.9.2 and 1.10.1 support for Spark 3.5.4–3.5.8 ([#14401](https://github.com/NVIDIA/spark-rapids/pull/14401)); Iceberg 1.10.1 support with Spark 4.0.2 ([#14459](https://github.com/NVIDIA/spark-rapids/pull/14459))
 * Bloom filter v2 support on Databricks ([#14406](https://github.com/NVIDIA/spark-rapids/pull/14406))
 * Parquet GPU reader: defer resource collection until close ([#14490](https://github.com/NVIDIA/spark-rapids/pull/14490)); row-to-column per-batch retry for OOM recovery ([#14428](https://github.com/NVIDIA/spark-rapids/pull/14428))
 * Shuffle and spilling: shuffle fanout OOM fix ([#14525](https://github.com/NVIDIA/spark-rapids/pull/14525)), thread-safe shuffle unregister ([#14513](https://github.com/NVIDIA/spark-rapids/pull/14513)), bounded retry logging for shuffle coalesce ([#14537](https://github.com/NVIDIA/spark-rapids/pull/14537))

--- a/docs/download.md
+++ b/docs/download.md
@@ -113,7 +113,7 @@ The output of signature verify:
 
 ### Release Notes
 * Databricks 17.3 ML LTS (Spark 4.0) support (Delta Lake fallback to CPU); Databricks 12.2 ML LTS no longer supported ([#14518](https://github.com/NVIDIA/spark-rapids/pull/14518))
-* Delta Lake deletion vector support on Databricks 14.3
+* Deletion vector read support for open source Delta Lake 3.3+ and 4.0+. 
 * Iceberg 1.9.2 and 1.10.1 support for Spark 3.5.4–3.5.8 ([#14401](https://github.com/NVIDIA/spark-rapids/pull/14401)); Iceberg 1.10.1 support with Spark 4.0.2 ([#14459](https://github.com/NVIDIA/spark-rapids/pull/14459))
 * Bloom filter v2 support on Databricks ([#14406](https://github.com/NVIDIA/spark-rapids/pull/14406))
 * Parquet GPU reader: defer resource collection until close ([#14490](https://github.com/NVIDIA/spark-rapids/pull/14490)); row-to-column per-batch retry for OOM recovery ([#14428](https://github.com/NVIDIA/spark-rapids/pull/14428))


### PR DESCRIPTION
See #14626.

### Description

Doc-only follow-up on top of #14629 / #14626 review feedback. Adds/updates two bullets in the v26.04.0 Release Notes on `docs/download.md` that were missing or needed refining:

* Iceberg **1.9.2** and **1.10.1** support for **Spark 3.5.4–3.5.8** (#14401), in addition to the already-listed Iceberg 1.10.1 + Spark 4.0.2 (#14459).
* Deletion vector **read** support for **open source Delta Lake 3.3+ and 4.0+** (new in 26.04). Wording matches the co-authored suggestion applied in #14626 (commit 89cefca).

Keeps `release/26.04`'s `docs/download.md` in sync with the corresponding gh-pages update (#14626) so the next gh-pages merge doesn't regress these notes.

`[skip ci]` because this is doc-only.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required