### PR TITLE
[DOC] Fix configs.md example: drop -SNAPSHOT jar name and swap conGPUTask conf [skip ci]

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -16,15 +16,19 @@ The following is the list of options that `rapids-plugin-4-spark` supports.
 On startup use: `--conf [conf key]=[conf value]`. For example:
 
 ```
-${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-26.04.1-SNAPSHOT-cuda12.jar \
+${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-<version>-cuda12.jar \
 --conf spark.plugins=com.nvidia.spark.SQLPlugin \
---conf spark.rapids.sql.concurrentGpuTasks=2
+--conf spark.rapids.sql.explain=NOT_ON_GPU
 ```
+
+Replace `<version>` with the RAPIDS Accelerator version you are using
+(for example, `26.04.0`). See the
+[Download page](./download.md) for the latest released versions.
 
 At runtime use: `spark.conf.set("[conf key]", [conf value])`. For example:
 
 ```
-scala> spark.conf.set("spark.rapids.sql.concurrentGpuTasks", 2)
+scala> spark.conf.set("spark.rapids.sql.explain", "NOT_ON_GPU")
 ```
 
  All configs can be set on startup, but some configs, especially for shuffle, will not

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -3057,15 +3057,19 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
         |On startup use: `--conf [conf key]=[conf value]`. For example:
         |
         |```
-        |${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-26.04.1-SNAPSHOT-cuda12.jar \
+        |${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-<version>-cuda12.jar \
         |--conf spark.plugins=com.nvidia.spark.SQLPlugin \
-        |--conf spark.rapids.sql.concurrentGpuTasks=2
+        |--conf spark.rapids.sql.explain=NOT_ON_GPU
         |```
+        |
+        |Replace `<version>` with the RAPIDS Accelerator version you are using
+        |(for example, `26.04.0`). See the
+        |[Download page](./download.md) for the latest released versions.
         |
         |At runtime use: `spark.conf.set("[conf key]", [conf value])`. For example:
         |
         |```
-        |scala> spark.conf.set("spark.rapids.sql.concurrentGpuTasks", 2)
+        |scala> spark.conf.set("spark.rapids.sql.explain", "NOT_ON_GPU")
         |```
         |
         | All configs can be set on startup, but some configs, especially for shuffle, will not


### PR DESCRIPTION
See #14626.

### Description

Follow-up to review feedback from @sameerz on #14626 — fix the root cause in the `RapidsConf.helpCommon` generator so the quick-start example in `docs/configs.md` no longer ships with:

1. A `-SNAPSHOT` jar name (`rapids-4-spark_2.12-26.04.1-SNAPSHOT-cuda12.jar`) — replaced with a generic `<version>` placeholder plus a pointer to `docs/download.md` for the latest released version. This also means future pom bumps on `release/26.04` / `main` will no longer silently drift the example out of date.
2. `spark.rapids.sql.concurrentGpuTasks` as the sample tunable — swapped to `spark.rapids.sql.explain=NOT_ON_GPU`, which is a more generally useful first-time-user knob.

Both changes apply to `sql-plugin/.../RapidsConf.scala`; `docs/configs.md` is regenerated in-tree so the two stay in sync.

This complements the manual fix applied to the gh-pages copy in #14626 — with this PR landed on `release/26.04`, the next regen won't regress Sameerz's feedback.

### Checklists

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Covered by the generated-docs consistency check already run in CI, which diffs the committed `docs/configs.md` against the output of `RapidsConf.helpCommon`. No new runtime behavior is introduced — the change is purely in the help-string literal.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required