### PR TITLE
[AutoSparkUT] Add RapidsDataFrameSelfJoinSuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSelfJoinSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSelfJoinSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameSelfJoinSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameSelfJoinSuite
+  extends DataFrameSelfJoinSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -30,6 +30,7 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsApproximatePercentileQuerySuite]
     .exclude("percentile_approx(col, ...), input rows contains null, with group by", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14634"))
     .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
+  enableSuite[RapidsDataFrameSelfJoinSuite]
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]


### PR DESCRIPTION
Contributes to #14655.

## Summary

Migrates Spark 3.3.0 `DataFrameSelfJoinSuite` (19 tests) to the RAPIDS plugin as `RapidsDataFrameSelfJoinSuite` using the minimal-inheritance pattern. All 19 tests pass on the GPU path with no exclusions. Closes the coverage gap described in #14655 for self-join shuffle/broadcast behavior on GPU.

## Changes

| File | Change |
|---|---|
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSelfJoinSuite.scala` | New — minimal inheritance from `DataFrameSelfJoinSuite` with `RapidsSQLTestsTrait` |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala` | Register suite via `enableSuite[RapidsDataFrameSelfJoinSuite]` |

## Local validation (Maven)

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -s jenkins/settings.xml -P mirror-apache-to-urm \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsDataFrameSelfJoinSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Result:

```
RapidsDataFrameSelfJoinSuite:
- join - self join auto resolve ambiguity with case insensitivity
- join - using aliases after self join
- [SPARK-6231] join - self join auto resolve ambiguity
- SPARK-28344: fail ambiguous self join - column ref in join condition
- SPARK-28344: fail ambiguous self join - Dataset.colRegex as column ref
- SPARK-28344: fail ambiguous self join - Dataset.col with nested field
- SPARK-28344: fail ambiguous self join - column ref in Project
- SPARK-28344: fail ambiguous self join - join three tables
- SPARK-28344: don't fail if there is no ambiguous self join
- SPARK-33071/SPARK-33536: Avoid changing dataset_id of LogicalPlan in join() to not break DetectAmbiguousSelfJoin
- df.show() should also not change dataset_id of LogicalPlan
- SPARK-34200: ambiguous column reference should consider attribute availability
- SPARK-35454: __dataset_id and __col_position should be correctly set
- SPARK-35454: fail ambiguous self join - toDF
- SPARK-35454: fail ambiguous self join - join four tables
- SPARK-36874: DeduplicateRelations should copy dataset_id tag to avoid ambiguous self join
- SPARK-35937: GetDateFieldOperations should skip unresolved nodes
Run completed in 26 seconds, 107 milliseconds.
Tests: succeeded 19, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

## Per-test traceability

All 19 tests inherit 1:1 from the parent `DataFrameSelfJoinSuite` in Spark 3.3.0 ([`v3.3.0` permalink](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala) · [master reference](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala)). No test bodies are overridden; `RapidsSQLTestsTrait` overrides `checkAnswer` to run each query under the RAPIDS plugin and verify CPU/GPU parity.

---

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required