### PR TITLE
[AutoSparkUT] Add RapidsDataFrameWindowFramesSuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameWindowFramesSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameWindowFramesSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameWindowFramesSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameWindowFramesSuite
+  extends DataFrameWindowFramesSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -30,6 +30,7 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsApproximatePercentileQuerySuite]
     .exclude("percentile_approx(col, ...), input rows contains null, with group by", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14634"))
     .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
+  enableSuite[RapidsDataFrameWindowFramesSuite]
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]


### PR DESCRIPTION
Contributes to #14657.

## Summary

Migrates Spark 3.3.0 `DataFrameWindowFramesSuite` (21 tests) to the RAPIDS plugin as `RapidsDataFrameWindowFramesSuite` using the minimal-inheritance pattern. All 21 tests pass on the GPU path with no exclusions. Closes the coverage gap described in #14657 for window-frame semantics on GPU (rows/range between, bounded/unbounded, sliding, reverse, frame validation).

## Changes

| File | Change |
|---|---|
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameWindowFramesSuite.scala` | New — minimal inheritance from `DataFrameWindowFramesSuite` with `RapidsSQLTestsTrait` |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala` | Register suite via `enableSuite[RapidsDataFrameWindowFramesSuite]` |

## Local validation (Maven)

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -s jenkins/settings.xml -P mirror-apache-to-urm \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsDataFrameWindowFramesSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Result:

```
RapidsDataFrameWindowFramesSuite:
- rows between should accept int/long values as boundary (and other bounded/unbounded variants)
- range between should accept at most one ORDER BY expression when unbounded
- range between should accept numeric values only when bounded
- range between should accept int/long values as boundary
- unbounded rows/range between with aggregation
- unbounded preceding/following rows between with aggregation
- reverse unbounded preceding/following rows between with aggregation
- unbounded preceding/following range between with aggregation
- reverse preceding/following range between with aggregation
- sliding rows between with aggregation
- reverse sliding rows between with aggregation
- sliding range between with aggregation
- reverse sliding range between with aggregation
- SPARK-24033: Analysis Failure of OffsetWindowFunction
Run completed in 23 seconds, 264 milliseconds.
Tests: succeeded 21, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

## Per-test traceability

All 21 tests inherit 1:1 from the parent `DataFrameWindowFramesSuite` in Spark 3.3.0 ([`v3.3.0` permalink](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala) · [master reference](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala)). No test bodies are overridden; `RapidsSQLTestsTrait` routes `checkAnswer` through the GPU path and verifies CPU/GPU parity.

---

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required