### PR TITLE
[AutoSparkUT] Add RapidsDataFrameTimeWindowingSuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameTimeWindowingSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameTimeWindowingSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameTimeWindowingSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameTimeWindowingSuite
+  extends DataFrameTimeWindowingSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -30,6 +30,7 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsApproximatePercentileQuerySuite]
     .exclude("percentile_approx(col, ...), input rows contains null, with group by", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14634"))
     .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
+  enableSuite[RapidsDataFrameTimeWindowingSuite]
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]


### PR DESCRIPTION
Contributes to #14661.

## Summary

Migrates Spark 3.3.0 `DataFrameTimeWindowingSuite` (22 tests) to the RAPIDS plugin as `RapidsDataFrameTimeWindowingSuite` using the minimal-inheritance pattern. All 22 tests pass on the GPU path with no exclusions. Closes the coverage gap in #14661 for end-to-end TimeWindow expression on GPU (tumbling / sliding windows, TimestampNTZ, nullability, negative-start handling).

## Changes

| File | Change |
|---|---|
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameTimeWindowingSuite.scala` | New — minimal inheritance from `DataFrameTimeWindowingSuite` with `RapidsSQLTestsTrait` |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala` | Register suite via `enableSuite[RapidsDataFrameTimeWindowingSuite]` |

## Local validation (Maven)

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -s jenkins/settings.xml -P mirror-apache-to-urm \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsDataFrameTimeWindowingSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Result:

```
RapidsDataFrameTimeWindowingSuite:
Run completed in 29 seconds, 550 milliseconds.
Tests: succeeded 22, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

## Per-test traceability

All 22 tests inherit 1:1 from the parent `DataFrameTimeWindowingSuite` in Spark 3.3.0 ([`v3.3.0` permalink](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala) · [master reference](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala)). No test bodies are overridden; `RapidsSQLTestsTrait` routes `checkAnswer` through the GPU path and verifies CPU/GPU parity.

---

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required