### PR TITLE
[AutoSparkUT] Add RapidsDataFrameSessionWindowingSuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSessionWindowingSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSessionWindowingSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameSessionWindowingSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameSessionWindowingSuite
+  extends DataFrameSessionWindowingSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -30,6 +30,7 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsApproximatePercentileQuerySuite]
     .exclude("percentile_approx(col, ...), input rows contains null, with group by", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14634"))
     .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
+  enableSuite[RapidsDataFrameSessionWindowingSuite]
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]


### PR DESCRIPTION
Contributes to #14663.

## Summary

Migrates Spark 3.3.0 `DataFrameSessionWindowingSuite` (20 tests) to the RAPIDS plugin as `RapidsDataFrameSessionWindowingSuite` using the minimal-inheritance pattern. All 20 tests pass on the GPU path with no exclusions. Closes the coverage gap in #14663 for end-to-end SessionWindow expression on GPU (static/dynamic gaps, UDF gaps, conditional gaps, invalid-gap filtering, TimestampNTZ).

## Changes

| File | Change |
|---|---|
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSessionWindowingSuite.scala` | New — minimal inheritance from `DataFrameSessionWindowingSuite` with `RapidsSQLTestsTrait` |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala` | Register suite via `enableSuite[RapidsDataFrameSessionWindowingSuite]` |

## Local validation (Maven)

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -s jenkins/settings.xml -P mirror-apache-to-urm \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsDataFrameSessionWindowingSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Result:

```
RapidsDataFrameSessionWindowingSuite:
Run completed in 25 seconds, 43 milliseconds.
Tests: succeeded 20, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

## Per-test traceability

All 20 tests inherit 1:1 from the parent `DataFrameSessionWindowingSuite` in Spark 3.3.0 ([`v3.3.0` permalink](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala) · [master reference](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala)). No test bodies are overridden; `RapidsSQLTestsTrait` routes `checkAnswer` through the GPU path and verifies CPU/GPU parity.

---

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required