### PR TITLE
[AutoSparkUT] Add RapidsTypedImperativeAggregateSuite

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTypedImperativeAggregateSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTypedImperativeAggregateSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.TypedImperativeAggregateSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsTypedImperativeAggregateSuite
+  extends TypedImperativeAggregateSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -30,6 +30,7 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsApproximatePercentileQuerySuite]
     .exclude("percentile_approx(col, ...), input rows contains null, with group by", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14634"))
     .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
+  enableSuite[RapidsTypedImperativeAggregateSuite]
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]


### PR DESCRIPTION
Contributes to #14667.

## Summary

Migrates Spark 3.3.0 `TypedImperativeAggregateSuite` (11 tests) to the RAPIDS plugin as `RapidsTypedImperativeAggregateSuite` using the minimal-inheritance pattern. All 11 tests pass on the GPU path. Closes the coverage gap in #14667 for object-aggregate-buffer pathways on GPU.

## Changes

| File | Change |
|---|---|
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTypedImperativeAggregateSuite.scala` | New — minimal inheritance from `TypedImperativeAggregateSuite` with `RapidsSQLTestsTrait` |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala` | Register suite via `enableSuite[RapidsTypedImperativeAggregateSuite]` |

## Local validation (Maven)

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -s jenkins/settings.xml -P mirror-apache-to-urm \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsTypedImperativeAggregateSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Result:

```
RapidsTypedImperativeAggregateSuite:
Run completed in 19 seconds, 805 milliseconds.
Tests: succeeded 11, failed 0, canceled 0, ignored 0, pending 0
BUILD SUCCESS
```

## Per-test traceability

All 11 tests inherit 1:1 from the parent `TypedImperativeAggregateSuite` in Spark 3.3.0 ([`v3.3.0` permalink](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/TypedImperativeAggregateSuite.scala) · [master reference](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/TypedImperativeAggregateSuite.scala)). No test bodies are overridden.

---

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required