### PR TITLE
[AutoSparkUT] Fix GpuCreateMap empty-map eval; RowToColumnar NullType (#14140, #14108)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -124,7 +124,10 @@ object GpuRowToColumnConverter {
       case (MapType(k, v, vcn), false) =>
         NotNullMapConverter(getConverterForType(k, nullable = false),
           getConverterForType(v, vcn))
-      case (NullType, true) =>
+      case (NullType, _) =>
+        // nullable=false appears only as a synthetic child of empty nested
+        // containers (e.g. MapType(NullType, NullType) from an empty map),
+        // where no row is ever appended, so NullConverter is safe either way.
         NullConverter
       // check special Shims types, such as DayTimeIntervalType
       case (otherType, nullable) if GpuTypeShims.hasConverterForType(otherType) =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -16,7 +16,9 @@
 
 package org.apache.spark.sql.rapids
 
-import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
+import java.util.{List => JList}
+
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType, HostColumnVector}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuMapUtils}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.{AutoCloseableProducingSeq, ReallyAGpuExpression}
@@ -104,8 +106,18 @@ case class GpuCreateMap(
     GpuCreateMap.exceptionOnDupKeys || super.hasSideEffects
 
   override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    val numRows = batch.numRows()
+    if (children.isEmpty) {
+      // cudf's ColumnVector.makeList cannot construct a 0-element list column
+      // when the element DType is nested (STRUCT here). For map(), fall back
+      // to fromLists with an explicit schema, which mirrors how literal empty
+      // maps are built in literals.scala.
+      val colType = GpuColumnVector.convertFrom(dataType, nullable)
+      val emptyRow: JList[HostColumnVector.StructData] = java.util.Collections.emptyList()
+      val rows = Seq.fill(numRows)(emptyRow)
+      return GpuColumnVector.from(ColumnVector.fromLists(colType, rows: _*), dataType)
+    }
     withResource(new Array[ColumnVector](children.size)) { columns =>
-      val numRows = batch.numRows()
       children.indices.foreach { index =>
         columns(index) = children(index).columnarEval(batch).getBase
       }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -33,7 +33,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]
-    .exclude("CreateMap", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14140"))
   enableSuite[RapidsConditionalExpressionSuite]
   enableSuite[RapidsHashExpressionsSuite]
   enableSuite[RapidsIntervalExpressionsSuite]
@@ -217,7 +216,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("external sorting updates peak execution memory", WONT_FIX_ISSUE("Memory metrics implementation differs on GPU"))
     .exclude("run sql directly on files", ADJUST_UT("Replaced by testRapids version that expects \"Path does not exist\" instead of \"Hive built-in ORC data source must be used with Hive support\" because there's a spark-hive jar in the CLASSPATH in our UT running"))
     .exclude("Common subexpression elimination", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14106"))
-    .exclude("SPARK-27619: When spark.sql.legacy.allowHashOnMapType is true, hash can be used on Maptype", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14108"))
     .exclude("SPARK-31594: Do not display the seed of rand/randn with no argument in output schema", ADJUST_UT("Replaced by testRapids version with a correct regex expression to match the projectExplainOutput, randn isn't supported now. See https://github.com/NVIDIA/spark-rapids/issues/11613"))
     .exclude("SPARK-33593: Vector reader got incorrect data with binary partition value", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14118"))
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL -- jar contains udf class", ADJUST_UT("Replaced by testRapids version that uses testFile() to access Spark test resources instead of getContextClassLoader"))


### PR DESCRIPTION
Fixes #14140.
Fixes #14108.

### Description

`GpuCreateMap.columnarEval` called `ColumnVector.makeList(numRows, DType.STRUCT, <empty>)` when `children.isEmpty` (i.e. `map()`). cuDF rejects constructing a 0-element list column whose element DType is nested, so the plain `map()` path (#14140) and SPARK-27619's `xxhash64(map())` path (#14108) both crashed with `IllegalArgumentException: Creating an empty list column of nested types is not currently supported`.

**Fix 1 — `complexTypeCreator.scala`**
When `children.isEmpty`, build the result via `ColumnVector.fromLists(colType, rows: _*)` with an explicit `HostColumnVector.DataType`. This mirrors how literal empty maps are constructed in `literals.scala:213`.

**Fix 2 — `GpuRowToColumnarExec.scala`**
`spark.createDataset(Map() :: Nil)` produces rows of `MapType(NullType, NullType)`. `MapConverter` recurses into the key converter with `nullable = false`, which previously fell through to `UnsupportedOperationException: Type NullType not supported`. Extended the `NullType` match to accept both nullability modes — safe because the converter is only ever instantiated as a synthetic child of an empty nested container and no row is ever appended through it.

### Per-test traceability

| RAPIDS test | Spark original | Spark 3.3.0 source | Maven evidence |
|---|---|---|---|
| `RapidsComplexTypeSuite :: CreateMap` | `CreateMap` in `ComplexTypeSuite` | `sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala:262-310` | Tests: succeeded 19, failed 0, ignored 0 |
| `RapidsSQLQuerySuite :: SPARK-27619: When spark.sql.legacy.allowHashOnMapType is true, hash can be used on Maptype` | Same | `sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala:2067-2076` | Tests: succeeded 222, failed 0, ignored 12 |

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required