### PR TITLE
[AutoSparkUT] Add 7 all-pass Spark suites (batch: SelfJoin / WindowFrames / TimeWindow / SessionWindow / Stat / TypedImperativeAgg / DatasetAggregator)

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSelfJoinSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSelfJoinSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameSelfJoinSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameSelfJoinSuite
+  extends DataFrameSelfJoinSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSessionWindowingSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSessionWindowingSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameSessionWindowingSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameSessionWindowingSuite
+  extends DataFrameSessionWindowingSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameStatSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameStatSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameStatSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameStatSuite
+  extends DataFrameStatSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameTimeWindowingSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameTimeWindowingSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameTimeWindowingSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameTimeWindowingSuite
+  extends DataFrameTimeWindowingSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameWindowFramesSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameWindowFramesSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DataFrameWindowFramesSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDataFrameWindowFramesSuite
+  extends DataFrameWindowFramesSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDatasetAggregatorSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDatasetAggregatorSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.DatasetAggregatorSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsDatasetAggregatorSuite
+  extends DatasetAggregatorSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTypedImperativeAggregateSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTypedImperativeAggregateSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.suites
+
+import org.apache.spark.sql.TypedImperativeAggregateSuite
+import org.apache.spark.sql.rapids.utils.RapidsSQLTestsTrait
+
+class RapidsTypedImperativeAggregateSuite
+  extends TypedImperativeAggregateSuite with RapidsSQLTestsTrait {
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -30,6 +30,13 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsApproximatePercentileQuerySuite]
     .exclude("percentile_approx(col, ...), input rows contains null, with group by", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14634"))
     .exclude("SPARK-32908: maximum target error in percentile_approx", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14635"))
+  enableSuite[RapidsDataFrameSelfJoinSuite]
+  enableSuite[RapidsDataFrameWindowFramesSuite]
+  enableSuite[RapidsDataFrameTimeWindowingSuite]
+  enableSuite[RapidsDataFrameSessionWindowingSuite]
+  enableSuite[RapidsDataFrameStatSuite]
+  enableSuite[RapidsTypedImperativeAggregateSuite]
+  enableSuite[RapidsDatasetAggregatorSuite]
   enableSuite[RapidsArithmeticExpressionSuite]
   enableSuite[RapidsBitwiseExpressionsSuite]
   enableSuite[RapidsComplexTypeSuite]


### PR DESCRIPTION
Contributes to #14655, #14657, #14661, #14663, #14665, #14667, #14670.

## Summary

Batched migration of 7 Spark 3.3.0 test suites to the RAPIDS plugin using the minimal-inheritance pattern. All 131 active tests pass on the GPU path with **no RAPIDS-specific exclusions**. Each new suite is a trivial `extends SparkSuite with RapidsSQLTestsTrait` wrapper — no test bodies are overridden. `RapidsSQLTestsTrait` routes `checkAnswer` through the GPU path and verifies CPU/GPU parity.

This PR supersedes 7 individual PRs (see "Supersedes" section below) which have been closed in favor of this batched submission. The rationale: purely additive, minimal-inheritance test coverage has no meaningful review pressure split across 7 separate PRs.

## Suites added (in registration order)

| Suite | Tests | Coverage issue |
|---|---:|---|
| `RapidsDataFrameSelfJoinSuite` | 19 | #14655 |
| `RapidsDataFrameWindowFramesSuite` | 21 | #14657 |
| `RapidsDataFrameTimeWindowingSuite` | 22 | #14661 |
| `RapidsDataFrameSessionWindowingSuite` | 20 | #14663 |
| `RapidsDataFrameStatSuite` | 21 | #14665 |
| `RapidsTypedImperativeAggregateSuite` | 11 | #14667 |
| `RapidsDatasetAggregatorSuite` | 17 | #14670 |
| **Total** | **131** | |

## Changes

| File | Change |
|---|---|
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSelfJoinSuite.scala` | New |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameWindowFramesSuite.scala` | New |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameTimeWindowingSuite.scala` | New |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameSessionWindowingSuite.scala` | New |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDataFrameStatSuite.scala` | New |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsTypedImperativeAggregateSuite.scala` | New |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsDatasetAggregatorSuite.scala` | New |
| `tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala` | Register 7 suites (one `enableSuite[...]` line each, no exclusions) |

## Local validation (single combined Maven run)

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -s jenkins/settings.xml -P mirror-apache-to-urm \
  -DwildcardSuites='org.apache.spark.sql.rapids.suites.RapidsDataFrameSelfJoinSuite,org.apache.spark.sql.rapids.suites.RapidsDataFrameWindowFramesSuite,org.apache.spark.sql.rapids.suites.RapidsDataFrameTimeWindowingSuite,org.apache.spark.sql.rapids.suites.RapidsDataFrameSessionWindowingSuite,org.apache.spark.sql.rapids.suites.RapidsDataFrameStatSuite,org.apache.spark.sql.rapids.suites.RapidsTypedImperativeAggregateSuite,org.apache.spark.sql.rapids.suites.RapidsDatasetAggregatorSuite' \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Result:

```
RapidsDataFrameSelfJoinSuite:
RapidsDataFrameWindowFramesSuite:
RapidsDataFrameTimeWindowingSuite:
RapidsDataFrameSessionWindowingSuite:
RapidsDataFrameStatSuite:
RapidsTypedImperativeAggregateSuite:
RapidsDatasetAggregatorSuite:
Run completed in 1 minute, 5 seconds.
Tests: succeeded 131, failed 0, canceled 0, ignored 1, pending 0
BUILD SUCCESS
```

The one ignored test (`approx quantile 4: test for Int overflow` in `RapidsDataFrameStatSuite`) is ignored in upstream Spark itself (`ignore(...)` in `DataFrameStatSuite.scala` 3.3.0), not by RAPIDS.

## Per-test traceability

All 131 active tests inherit 1:1 from their parent Spark 3.3.0 suites:

- [`DataFrameSelfJoinSuite`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala) ([master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala))
- [`DataFrameWindowFramesSuite`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala) ([master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala))
- [`DataFrameTimeWindowingSuite`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala) ([master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala))
- [`DataFrameSessionWindowingSuite`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala) ([master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala))
- [`DataFrameStatSuite`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala) ([master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala))
- [`TypedImperativeAggregateSuite`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/TypedImperativeAggregateSuite.scala) ([master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/TypedImperativeAggregateSuite.scala))
- [`DatasetAggregatorSuite`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala) ([master](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala))

## Supersedes

Closed in favor of this batched PR: #14656, #14658, #14662, #14664, #14666, #14668, #14671.

---

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required