### PR TITLE
optimize iceberg read

### DIFF
--- a/iceberg/common/src/main/java/com/nvidia/spark/rapids/fileio/iceberg/IcebergFileIO.java
+++ b/iceberg/common/src/main/java/com/nvidia/spark/rapids/fileio/iceberg/IcebergFileIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ package com.nvidia.spark.rapids.fileio.iceberg;
 import com.nvidia.spark.rapids.jni.fileio.RapidsFileIO;
 import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import com.nvidia.spark.rapids.jni.fileio.RapidsOutputFile;
+import org.apache.iceberg.aws.s3.IcebergS3InputFile;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -36,8 +38,9 @@ public class IcebergFileIO implements RapidsFileIO {
   /**
    * Constructs an IcebergFileIO with the given Iceberg FileIO delegate.
    *
-   * @param delegate the Iceberg FileIO to delegate to. It's the caller's responsibility to ensure
-   *                 that the delegate is closed when no longer used, e.g., iceberg table/catalog close.
+   * @param delegate the Iceberg FileIO to delegate to. It's the caller's responsibility to
+   *                 ensure that the delegate is closed when no longer used, e.g.,
+   *                 iceberg table/catalog close.
    */
   public IcebergFileIO(FileIO delegate) {
     Objects.requireNonNull(delegate, "delegate can't be null");
@@ -47,7 +50,8 @@ public class IcebergFileIO implements RapidsFileIO {
 
   @Override
   public IcebergInputFile newInputFile(String path) throws IOException {
-    return new IcebergInputFile(delegate.newInputFile(path));
+    InputFile inputFile = delegate.newInputFile(path);
+    return IcebergS3InputFile.maybeCreate(inputFile, delegate);
   }
 
   @Override

--- a/iceberg/common/src/main/java/com/nvidia/spark/rapids/fileio/iceberg/IcebergFileIO.java
+++ b/iceberg/common/src/main/java/com/nvidia/spark/rapids/fileio/iceberg/IcebergFileIO.java
@@ -49,9 +49,19 @@ public class IcebergFileIO implements RapidsFileIO {
 
 
   @Override
-  public IcebergInputFile newInputFile(String path) throws IOException {
+  public RapidsInputFile newInputFile(String path) throws IOException {
     InputFile inputFile = delegate.newInputFile(path);
     return IcebergS3InputFile.maybeCreate(inputFile, delegate);
+  }
+
+  /**
+   * Always returns a plain {@link IcebergInputFile}, bypassing the S3 PerfIO
+   * fast-path. Use this from internal call sites that need the iceberg
+   * {@link InputFile} accessor on the read side (e.g. writers re-reading the
+   * footer of a just-written file) and do not benefit from PerfIO.
+   */
+  public IcebergInputFile newIcebergInputFile(String path) throws IOException {
+    return new IcebergInputFile(delegate.newInputFile(path));
   }
 
   @Override

--- a/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/IcebergShimUtils.java
+++ b/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/IcebergShimUtils.java
@@ -20,6 +20,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
 
 import java.util.Map;
 
@@ -51,4 +52,17 @@ public interface IcebergShimUtils {
      *         type-to-Spark type conversion, which differs across Iceberg versions.
      */
     Map<Integer, ?> constantsMap(FileScanTask task, Schema readSchema, Table table);
+
+    /**
+     * Returns the per-prefix credential overlays from a {@link FileIO} that implements
+     * Iceberg's {@code SupportsStorageCredentials} interface (1.7+). Each entry is a
+     * storage prefix (e.g. {@code "s3://bucket/path/"}) → property overlay map (the
+     * vended credentials Iceberg's REST catalog merges into the base FileIO properties
+     * for clients targeting that prefix).
+     *
+     * <p>1.6.x predates {@code SupportsStorageCredentials} entirely and returns an empty
+     * map. Keeping this resolution behind the shim lets {@code iceberg/common} compile
+     * against 1.6.x without hard-referencing the missing interface.
+     */
+    Map<String, Map<String, String>> storageCredentialOverlays(FileIO fileIO);
 }

--- a/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/ShimUtils.java
+++ b/iceberg/common/src/main/java/com/nvidia/spark/rapids/iceberg/ShimUtils.java
@@ -22,6 +22,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
 
 import java.util.Map;
 
@@ -51,5 +52,9 @@ public class ShimUtils {
     public static Map<Integer, ?> constantsMap(FileScanTask task, Schema readSchema,
                                                     Table table) {
         return IMPL.constantsMap(task, readSchema, table);
+    }
+
+    public static Map<String, Map<String, String>> storageCredentialOverlays(FileIO fileIO) {
+        return IMPL.storageCredentialOverlays(fileIO);
     }
 }

--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
@@ -19,12 +19,13 @@ package org.apache.iceberg.aws.s3;
 import ai.rapids.cudf.HostMemoryBuffer;
 import com.nvidia.spark.rapids.IcebergS3RangeCopier;
 import com.nvidia.spark.rapids.IcebergS3RangeCopier.IcebergS3Client;
-import com.nvidia.spark.rapids.PerfIOConf;
+import com.nvidia.spark.rapids.fileio.RapidsInputFiles;
 import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile;
 import com.nvidia.spark.rapids.iceberg.ShimUtils;
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
+import com.nvidia.spark.rapids.jni.fileio.SeekableInputStream;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
-import org.apache.spark.SparkEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,31 +33,34 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.OptionalLong;
 
 /**
- * S3-backed {@link IcebergInputFile} that delegates byte-range reads to
+ * S3-backed {@link RapidsInputFile} that delegates byte-range reads to
  * {@link IcebergS3RangeCopier}. The supplied {@link FileIO} is only used for
  * its property map and any per-prefix storage-credential overlays.
  *
  * <p>This class lives in {@code org.apache.iceberg.aws.s3} for the package-private
  * {@link BaseS3File} access used to extract the bucket/key URI.
  */
-public final class IcebergS3InputFile extends IcebergInputFile {
+public final class IcebergS3InputFile implements RapidsInputFile {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergS3InputFile.class);
 
+  private final IcebergInputFile delegate;
   private final URI s3Uri;
   private final IcebergS3Client icebergS3Client;
 
-  private IcebergS3InputFile(InputFile delegate, URI s3Uri, IcebergS3Client icebergS3Client) {
-    super(delegate);
+  private IcebergS3InputFile(
+      IcebergInputFile delegate, URI s3Uri, IcebergS3Client icebergS3Client) {
+    this.delegate = delegate;
     this.s3Uri = s3Uri;
     this.icebergS3Client = icebergS3Client;
   }
 
-  public static IcebergInputFile maybeCreate(InputFile inputFile, FileIO fileIO) {
+  public static RapidsInputFile maybeCreate(InputFile inputFile, FileIO fileIO) {
     // When the gating conf is off (or the file is not an S3 file), return the
     // default IcebergInputFile so the standard Iceberg SeekableInputStream path is used.
-    if (!isPerfioS3Enabled() || !(inputFile instanceof BaseS3File)) {
+    if (!RapidsInputFiles.isS3PerfEnabled() || !(inputFile instanceof BaseS3File)) {
       return new IcebergInputFile(inputFile);
     }
     BaseS3File s3File = (BaseS3File) inputFile;
@@ -79,7 +83,36 @@ public final class IcebergS3InputFile extends IcebergInputFile {
         fileIO.properties(),
         ShimUtils.storageCredentialOverlays(fileIO));
     LOG.debug("IcebergS3RangeCopier path active for {}", s3Uri);
-    return new IcebergS3InputFile(inputFile, s3Uri, icebergS3Client);
+    return new IcebergS3InputFile(new IcebergInputFile(inputFile), s3Uri, icebergS3Client);
+  }
+
+  @Override
+  public String path() {
+    return delegate.path();
+  }
+
+  @Override
+  public long getLength() throws IOException {
+    return delegate.getLength();
+  }
+
+  @Override
+  public OptionalLong getLastModificationTime() throws IOException {
+    return delegate.getLastModificationTime();
+  }
+
+  @Override
+  public SeekableInputStream open() throws IOException {
+    return delegate.open();
+  }
+
+  /**
+   * Returns the underlying Iceberg {@link InputFile}, matching
+   * {@link IcebergInputFile#getDelegate()} for use by iceberg-internal
+   * code paths that need direct access to the iceberg API.
+   */
+  public InputFile getDelegate() {
+    return delegate.getDelegate();
   }
 
   @Override
@@ -91,8 +124,7 @@ public final class IcebergS3InputFile extends IcebergInputFile {
   /**
    * Issue a single suffix-range {@code GetObject} ({@code Range: bytes=-N}) for
    * the last {@code length} bytes. Avoids the {@code getLength()} round-trip the
-   * default {@link com.nvidia.spark.rapids.jni.fileio.RapidsInputFile#readTail}
-   * would make.
+   * default {@link RapidsInputFile#readTail} would make.
    */
   @Override
   public void readTail(long length, HostMemoryBuffer output) throws IOException {
@@ -103,13 +135,5 @@ public final class IcebergS3InputFile extends IcebergInputFile {
       throw new IllegalArgumentException("length must be non-negative");
     }
     IcebergS3RangeCopier.copyTailToHMB(icebergS3Client, output, s3Uri, length, /*dstOffset*/ 0L);
-  }
-
-  private static boolean isPerfioS3Enabled() {
-    SparkEnv env = SparkEnv.get();
-    if (env == null) {
-      return false;
-    }
-    return env.conf().getBoolean(PerfIOConf.S3PERF_ENABLED().key(), false);
   }
 }

--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.aws.s3;
+
+import ai.rapids.cudf.HostMemoryBuffer;
+import com.nvidia.spark.rapids.IcebergS3RangeCopier;
+import com.nvidia.spark.rapids.IcebergS3RangeCopier.IcebergS3Client;
+import com.nvidia.spark.rapids.PerfIOConf;
+import com.nvidia.spark.rapids.fileio.iceberg.IcebergInputFile;
+import com.nvidia.spark.rapids.iceberg.ShimUtils;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.spark.SparkEnv;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+/**
+ * S3-backed {@link IcebergInputFile} that delegates byte-range reads to
+ * {@link IcebergS3RangeCopier}. The supplied {@link FileIO} is only used for
+ * its property map and any per-prefix storage-credential overlays.
+ *
+ * <p>This class lives in {@code org.apache.iceberg.aws.s3} for the package-private
+ * {@link BaseS3File} access used to extract the bucket/key URI.
+ */
+public final class IcebergS3InputFile extends IcebergInputFile {
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergS3InputFile.class);
+
+  private final URI s3Uri;
+  private final IcebergS3Client icebergS3Client;
+
+  private IcebergS3InputFile(InputFile delegate, URI s3Uri, IcebergS3Client icebergS3Client) {
+    super(delegate);
+    this.s3Uri = s3Uri;
+    this.icebergS3Client = icebergS3Client;
+  }
+
+  public static IcebergInputFile maybeCreate(InputFile inputFile, FileIO fileIO) {
+    // When the gating conf is off (or the file is not an S3 file), return the
+    // default IcebergInputFile so the standard Iceberg SeekableInputStream path is used.
+    if (!isPerfioS3Enabled() || !(inputFile instanceof BaseS3File)) {
+      return new IcebergInputFile(inputFile);
+    }
+    BaseS3File s3File = (BaseS3File) inputFile;
+    S3URI uri = s3File.uri();
+    // Use the 4-arg URI constructor so the (raw, un-percent-encoded) bucket and
+    // key are encoded per-component. URI.create / new URI(String) would treat the
+    // input as an already-encoded URI string and throw on partition values that
+    // contain spaces, '#', or other reserved characters (e.g. partition=hello world).
+    URI s3Uri;
+    try {
+      s3Uri = new URI("s3", uri.bucket(), "/" + uri.key(), null);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(
+          "Invalid S3 URI for bucket=" + uri.bucket() + " key=" + uri.key(), e);
+    }
+    // Iceberg < 1.7 does not have SupportsStorageCredentials; ShimUtils returns
+    // the per-prefix credential overlays (or an empty map on 1.6).
+    IcebergS3Client icebergS3Client = IcebergS3RangeCopier.resolveClient(
+        s3Uri.toString(),
+        fileIO.properties(),
+        ShimUtils.storageCredentialOverlays(fileIO));
+    LOG.debug("IcebergS3RangeCopier path active for {}", s3Uri);
+    return new IcebergS3InputFile(inputFile, s3Uri, icebergS3Client);
+  }
+
+  @Override
+  public void readVectored(HostMemoryBuffer output, List<CopyRange> copyRanges)
+      throws IOException {
+    IcebergS3RangeCopier.copyToHMB(icebergS3Client, output, s3Uri, copyRanges);
+  }
+
+  /**
+   * Issue a single suffix-range {@code GetObject} ({@code Range: bytes=-N}) for
+   * the last {@code length} bytes. Avoids the {@code getLength()} round-trip the
+   * default {@link com.nvidia.spark.rapids.jni.fileio.RapidsInputFile#readTail}
+   * would make.
+   */
+  @Override
+  public void readTail(long length, HostMemoryBuffer output) throws IOException {
+    if (length == 0) {
+      return;
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException("length must be non-negative");
+    }
+    IcebergS3RangeCopier.copyTailToHMB(icebergS3Client, output, s3Uri, length, /*dstOffset*/ 0L);
+  }
+
+  private static boolean isPerfioS3Enabled() {
+    SparkEnv env = SparkEnv.get();
+    if (env == null) {
+      return false;
+    }
+    return env.conf().getBoolean(PerfIOConf.S3PERF_ENABLED().key(), false);
+  }
+}

--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/parquet/GpuIcebergParquetAppender.scala
@@ -59,7 +59,8 @@ class GpuIcebergParquetAppender(
   override def close(): Unit = {
     if (!closed) {
       inner.close()
-      footer = withResource(IcebergPartitionedFile(fileIO.newInputFile(inner.path)).newReader()) {
+      footer = withResource(
+          IcebergPartitionedFile(fileIO.newIcebergInputFile(inner.path)).newReader()) {
         reader =>
           // TODO: Remove the read after https://github.com/rapidsai/cudf/issues/18886 got fixed.
           reader.getFooter

--- a/iceberg/iceberg-1-10-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg110x/ShimUtilsImpl.java
+++ b/iceberg/iceberg-1-10-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg110x/ShimUtilsImpl.java
@@ -18,10 +18,15 @@ package com.nvidia.spark.rapids.iceberg.iceberg110x;
 
 import com.nvidia.spark.rapids.iceberg.IcebergShimUtils;
 import org.apache.iceberg.*;
-import org.apache.iceberg.util.PartitionUtil;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PartitionUtil;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /** Iceberg 1.10.x shim: uses {@code SparkUtil::internalToSpark}. */
@@ -41,5 +46,17 @@ public class ShimUtilsImpl implements IcebergShimUtils {
         } else {
             return PartitionUtil.constantsMap(task, SparkUtil::internalToSpark);
         }
+    }
+
+    @Override
+    public Map<String, Map<String, String>> storageCredentialOverlays(FileIO fileIO) {
+        if (!(fileIO instanceof SupportsStorageCredentials)) {
+            return Collections.emptyMap();
+        }
+        Map<String, Map<String, String>> result = new HashMap<>();
+        for (StorageCredential sc : ((SupportsStorageCredentials) fileIO).credentials()) {
+            result.put(sc.prefix(), sc.config());
+        }
+        return result;
     }
 }

--- a/iceberg/iceberg-1-6-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg16x/ShimUtilsImpl.java
+++ b/iceberg/iceberg-1-6-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg16x/ShimUtilsImpl.java
@@ -18,10 +18,12 @@ package com.nvidia.spark.rapids.iceberg.iceberg16x;
 
 import com.nvidia.spark.rapids.iceberg.IcebergShimUtils;
 import org.apache.iceberg.*;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.spark.source.GpuBaseReader;
-import org.apache.iceberg.util.PartitionUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PartitionUtil;
 
+import java.util.Collections;
 import java.util.Map;
 
 /** Iceberg 1.6.x shim: uses {@code ContentFile.path()} and {@code GpuBaseReader::convertConstant}. */
@@ -41,5 +43,11 @@ public class ShimUtilsImpl implements IcebergShimUtils {
         } else {
             return PartitionUtil.constantsMap(task, GpuBaseReader::convertConstant);
         }
+    }
+
+    /** Iceberg 1.6.x predates {@code SupportsStorageCredentials} — no per-prefix overlays. */
+    @Override
+    public Map<String, Map<String, String>> storageCredentialOverlays(FileIO fileIO) {
+        return Collections.emptyMap();
     }
 }

--- a/iceberg/iceberg-1-9-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg19x/ShimUtilsImpl.java
+++ b/iceberg/iceberg-1-9-x/src/main/java/com/nvidia/spark/rapids/iceberg/iceberg19x/ShimUtilsImpl.java
@@ -19,11 +19,16 @@ package com.nvidia.spark.rapids.iceberg.iceberg19x;
 import com.nvidia.spark.rapids.iceberg.IcebergShimUtils;
 import org.apache.iceberg.*;
 import org.apache.iceberg.data.IdentityPartitionConverters;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.spark.source.GpuStructInternalRow;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PartitionUtil;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /** Iceberg 1.9.x shim: uses {@code IdentityPartitionConverters::convertConstant}. */
@@ -54,5 +59,17 @@ public class ShimUtilsImpl implements IcebergShimUtils {
             return PartitionUtil.constantsMap(task,
                     ShimUtilsImpl::convertConstant);
         }
+    }
+
+    @Override
+    public Map<String, Map<String, String>> storageCredentialOverlays(FileIO fileIO) {
+        if (!(fileIO instanceof SupportsStorageCredentials)) {
+            return Collections.emptyMap();
+        }
+        Map<String, Map<String, String>> result = new HashMap<>();
+        for (StorageCredential sc : ((SupportsStorageCredentials) fileIO).credentials()) {
+            result.put(sc.prefix(), sc.config());
+        }
+        return result;
     }
 }

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/RapidsInputFiles.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/RapidsInputFiles.java
@@ -27,29 +27,15 @@ public final class RapidsInputFiles {
     private RapidsInputFiles() {}
 
     /**
-     * Cached value of {@code spark.rapids.perfio.s3.enabled}. The conf is marked
-     * startupOnly, so caching after the first non-null {@link SparkEnv} read is
-     * safe and avoids repeated {@link SparkEnv}/conf lookups on every input-file
-     * factory call.
-     */
-    private static volatile Boolean s3PerfEnabledCache;
-
-    /**
      * True iff {@code spark.rapids.perfio.s3.enabled} is set to {@code true} on
      * the active SparkConf. Returns false when no {@link SparkEnv} is initialized
      * (e.g. before driver bring-up) so callers default to the non-PerfIO path.
      */
     public static boolean isS3PerfEnabled() {
-        Boolean cached = s3PerfEnabledCache;
-        if (cached != null) {
-            return cached;
-        }
         SparkEnv env = SparkEnv.get();
         if (env == null) {
             return false;
         }
-        boolean enabled = env.conf().getBoolean(PerfIOConf.S3PERF_ENABLED().key(), false);
-        s3PerfEnabledCache = enabled;
-        return enabled;
+        return env.conf().getBoolean(PerfIOConf.S3PERF_ENABLED().key(), false);
     }
 }

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/RapidsInputFiles.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/RapidsInputFiles.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.fileio;
+
+import com.nvidia.spark.rapids.PerfIOConf;
+import org.apache.spark.SparkEnv;
+
+/**
+ * Static helpers shared by {@link com.nvidia.spark.rapids.jni.fileio.RapidsInputFile}
+ * implementations.
+ */
+public final class RapidsInputFiles {
+    private RapidsInputFiles() {}
+
+    /**
+     * Cached value of {@code spark.rapids.perfio.s3.enabled}. The conf is marked
+     * startupOnly, so caching after the first non-null {@link SparkEnv} read is
+     * safe and avoids repeated {@link SparkEnv}/conf lookups on every input-file
+     * factory call.
+     */
+    private static volatile Boolean s3PerfEnabledCache;
+
+    /**
+     * True iff {@code spark.rapids.perfio.s3.enabled} is set to {@code true} on
+     * the active SparkConf. Returns false when no {@link SparkEnv} is initialized
+     * (e.g. before driver bring-up) so callers default to the non-PerfIO path.
+     */
+    public static boolean isS3PerfEnabled() {
+        Boolean cached = s3PerfEnabledCache;
+        if (cached != null) {
+            return cached;
+        }
+        SparkEnv env = SparkEnv.get();
+        if (env == null) {
+            return false;
+        }
+        boolean enabled = env.conf().getBoolean(PerfIOConf.S3PERF_ENABLED().key(), false);
+        s3PerfEnabledCache = enabled;
+        return enabled;
+    }
+}

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/hadoop/HadoopFileIO.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/fileio/hadoop/HadoopFileIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.fileio.hadoop;
 
+import com.nvidia.spark.rapids.fileio.RapidsInputFiles;
 import com.nvidia.spark.rapids.jni.fileio.RapidsFileIO;
 import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import com.nvidia.spark.rapids.jni.fileio.RapidsOutputFile;
@@ -40,12 +41,16 @@ public class HadoopFileIO implements RapidsFileIO {
     }
 
     @Override
-    public HadoopInputFile newInputFile(String path) throws IOException {
+    public RapidsInputFile newInputFile(String path) throws IOException {
         return this.newInputFile(new Path(path));
     }
 
     @Override
-    public HadoopInputFile newInputFile(Path path) throws IOException {
+    public RapidsInputFile newInputFile(Path path) throws IOException {
+        String scheme = path.toUri().getScheme();
+        if (scheme != null && scheme.startsWith("s3") && RapidsInputFiles.isS3PerfEnabled()) {
+            return S3InputFile.create(path, hadoopConf.value());
+        }
         return HadoopInputFile.create(path, hadoopConf.value());
     }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1784,6 +1784,39 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .booleanConf
     .createWithDefault(true)
 
+  val ICEBERG_S3_ASYNC_MAX_CONCURRENCY =
+    conf("spark.rapids.iceberg.s3.async.max-concurrency")
+      .doc("Max concurrent connections for the AwsCrtAsyncHttpClient used by the " +
+        "spark-rapids Iceberg S3 byte-range reader. Used only when the Iceberg " +
+        "FileIO property `s3.crt.max-concurrency` is not set.")
+      .startupOnly()
+      .integerConf
+      .createWithDefault(200)
+
+  val ICEBERG_S3_ASYNC_CONNECTION_MAX_IDLE_MS =
+    conf("spark.rapids.iceberg.s3.async.connection-max-idle-time-ms")
+      .doc("Connection-max-idle-time (ms) for the AwsCrtAsyncHttpClient used by the " +
+        "spark-rapids Iceberg S3 byte-range reader. No equivalent Iceberg property.")
+      .startupOnly()
+      .longConf
+      .createWithDefault(5L * 60 * 1000)
+
+  val ICEBERG_S3_ASYNC_TCP_KEEPALIVE_INTERVAL_MS =
+    conf("spark.rapids.iceberg.s3.async.tcp-keepalive-interval-ms")
+      .doc("TCP keep-alive probe interval (ms) for the AwsCrtAsyncHttpClient used by " +
+        "the spark-rapids Iceberg S3 byte-range reader. No equivalent Iceberg property.")
+      .startupOnly()
+      .longConf
+      .createWithDefault(60L * 1000)
+
+  val ICEBERG_S3_ASYNC_TCP_KEEPALIVE_TIMEOUT_MS =
+    conf("spark.rapids.iceberg.s3.async.tcp-keepalive-timeout-ms")
+      .doc("TCP keep-alive probe timeout (ms) for the AwsCrtAsyncHttpClient used by " +
+        "the spark-rapids Iceberg S3 byte-range reader. No equivalent Iceberg property.")
+      .startupOnly()
+      .longConf
+      .createWithDefault(30L * 1000)
+
   val ENABLE_HIVE_TEXT: ConfEntryWithDefault[Boolean] =
     conf("spark.rapids.sql.format.hive.text.enabled")
       .doc("When set to false disables Hive text table acceleration. " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/fileio/hadoop/S3InputFile.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/fileio/hadoop/S3InputFile.scala
@@ -58,7 +58,9 @@ class S3InputFile private (
     val ranges = copyRanges.asScala.map { r =>
       IntRangeWithOffset(r.getInputOffset, r.getLength, r.getOutputOffset)
     }.toSeq
-    PerfIO.readToHostMemory(hadoopConf, output, fileUri, ranges)
+    require(
+      PerfIO.readToHostMemory(hadoopConf, output, fileUri, ranges).isDefined,
+      "expected to use PerfIO to read")
   }
 
   /**
@@ -75,7 +77,9 @@ class S3InputFile private (
       throw new IllegalArgumentException("length must be non-negative")
     }
     val ranges = Seq[RangeWithOffset](SuffixRangeWithOffset(length, /*destOffset*/ 0L))
-    PerfIO.readToHostMemory(hadoopConf, output, fileUri, ranges)
+    require(
+      PerfIO.readToHostMemory(hadoopConf, output, fileUri, ranges).isDefined,
+      "expected to use PerfIO to read")
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/fileio/hadoop/S3InputFile.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/fileio/hadoop/S3InputFile.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.fileio.hadoop
+
+import java.io.IOException
+import java.net.URI
+import java.util.OptionalLong
+
+import scala.collection.JavaConverters._
+
+import ai.rapids.cudf.HostMemoryBuffer
+import com.nvidia.spark.rapids.{IntRangeWithOffset, PerfIO, RangeWithOffset, SuffixRangeWithOffset}
+import com.nvidia.spark.rapids.jni.fileio.{RapidsInputFile, SeekableInputStream}
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+/**
+ * S3-backed {@link RapidsInputFile} for Hadoop-conf-driven (non-iceberg) reads.
+ * {@code readVectored} issues batched byte-range GETs through the optimized
+ * vectored-read path; the other operations delegate to the standard
+ * {@link HadoopInputFile}.
+ */
+class S3InputFile private (
+    delegate: HadoopInputFile,
+    fileUri: URI,
+    hadoopConf: Configuration)
+  extends RapidsInputFile {
+
+  override def path(): String = delegate.path()
+
+  @throws[IOException]
+  override def getLength(): Long = delegate.getLength()
+
+  @throws[IOException]
+  override def getLastModificationTime(): OptionalLong = delegate.getLastModificationTime()
+
+  @throws[IOException]
+  override def open(): SeekableInputStream = delegate.open()
+
+  @throws[IOException]
+  override def readVectored(
+      output: HostMemoryBuffer,
+      copyRanges: java.util.List[RapidsInputFile.CopyRange]): Unit = {
+    val ranges = copyRanges.asScala.map { r =>
+      IntRangeWithOffset(r.getInputOffset, r.getLength, r.getOutputOffset)
+    }.toSeq
+    PerfIO.readToHostMemory(hadoopConf, output, fileUri, ranges)
+  }
+
+  /**
+   * Issue a single suffix-range {@code GetObject} ({@code Range: bytes=-N}) for
+   * the last {@code length} bytes. Avoids the {@code getLength()} round-trip the
+   * default {@link RapidsInputFile#readTail} would make.
+   */
+  @throws[IOException]
+  override def readTail(length: Long, output: HostMemoryBuffer): Unit = {
+    if (length == 0) {
+      return
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException("length must be non-negative")
+    }
+    val ranges = Seq[RangeWithOffset](SuffixRangeWithOffset(length, /*destOffset*/ 0L))
+    PerfIO.readToHostMemory(hadoopConf, output, fileUri, ranges)
+  }
+}
+
+object S3InputFile {
+  @throws[IOException]
+  def create(filePath: Path, conf: Configuration): S3InputFile = {
+    new S3InputFile(HadoopInputFile.create(filePath, conf), filePath.toUri, conf)
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/fileio/hadoop/S3InputFile.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/fileio/hadoop/S3InputFile.scala
@@ -25,7 +25,6 @@ import scala.collection.JavaConverters._
 import ai.rapids.cudf.HostMemoryBuffer
 import com.nvidia.spark.rapids.{IntRangeWithOffset, PerfIO, RangeWithOffset, SuffixRangeWithOffset}
 import com.nvidia.spark.rapids.jni.fileio.{RapidsInputFile, SeekableInputStream}
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.parquet
 
 import java.io.{Closeable, EOFException, FileNotFoundException, InputStream, IOException, OutputStream}
 import java.net.URI
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.channels.SeekableByteChannel
 import java.nio.charset.StandardCharsets
 import java.util.{Collections, Locale}
@@ -38,11 +38,12 @@ import com.nvidia.spark.rapids.RapidsConf.ParquetFooterReaderType
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
 import com.nvidia.spark.rapids.filecache.FileCache
-import com.nvidia.spark.rapids.fileio.hadoop.HadoopFileIO
+import com.nvidia.spark.rapids.fileio.hadoop.{HadoopFileIO, HadoopInputFile}
 import com.nvidia.spark.rapids.io.async._
 import com.nvidia.spark.rapids.jni.{DateTimeRebase, ParquetFooter, RmmSpark}
-import com.nvidia.spark.rapids.jni.fileio.{RapidsFileIO, RapidsInputFile, SeekableInputStream}
-import com.nvidia.spark.rapids.parquet.ParquetPartitionReader.{CopyRange, LocalCopy, PARQUET_MAGIC}
+import com.nvidia.spark.rapids.jni.fileio.{RapidsFileIO, RapidsInputFile}
+import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile.CopyRange
+import com.nvidia.spark.rapids.parquet.ParquetPartitionReader.{LocalCopy, PARQUET_MAGIC}
 import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, GpuParquetCrypto, GpuTypeShims, ShimFilePartitionReaderFactory, SparkShimImpl}
 import com.nvidia.spark.rapids.shims.parquet.{GpuParquetUtilsShims, ParquetLegacyNanoAsLongShims, ParquetSchemaClipShims, ParquetStringPredShims}
 import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
@@ -50,7 +51,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.IOUtils
 import org.apache.parquet.bytes.BytesUtils
-import org.apache.parquet.bytes.BytesUtils.readIntLittleEndian
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.format.Util
@@ -253,6 +253,30 @@ object GpuParquetScan {
           }
         case other => other
       }
+    }
+  }
+
+  /**
+   * Read the given byte ranges from `inputFile` into `output` using the
+   * vectored API. Returns the total number of bytes read.
+   *
+   * Wall time is accumulated to READ_FS_TIME. WRITE_BUFFER_TIME has no
+   * analog on this path -- readVectored writes directly into `output` in
+   * a single bundled call -- and remains scoped to the CPU decompress
+   * path in copyAndUncompressBlocksData.
+   */
+  private[parquet] def readRangesToHostMemory(
+      inputFile: RapidsInputFile,
+      output: HostMemoryBuffer,
+      ranges: Seq[CopyRange],
+      metrics: Map[String, GpuMetric]): Long = {
+    if (ranges.isEmpty) {
+      0L
+    } else {
+      metrics.getOrElse(READ_FS_TIME, NoopMetric).ns {
+        inputFile.readVectored(output, ranges.asJava)
+      }
+      ranges.map(_.getLength).sum
     }
   }
 
@@ -559,41 +583,47 @@ protected case class GpuParquetFileFilterHandler(
   private def readFooterBufUsingHadoop(fileIO: RapidsFileIO, filePath: Path): HostMemoryBuffer = {
     val inputFile = fileIO.newInputFile(filePath)
     // Much of this code came from the parquet_mr projects ParquetFileReader, and was modified
-    // to match our needs
+    // to match our needs.
     val fileLen = inputFile.getLength
     // MAGIC + data + footer + footerIndex + MAGIC
     if (fileLen < MAGIC.length + FOOTER_LENGTH_SIZE + MAGIC.length) {
       throw new RuntimeException(s"$filePath is not a Parquet file (too small length: $fileLen )")
     }
-    val footerLengthIndex = fileLen - FOOTER_LENGTH_SIZE - MAGIC.length
-    withResource(inputFile.open()) { inputStream =>
-      NvtxRegistry.PARQUET_READ_FOOTER_BYTES {
-        inputStream.seek(footerLengthIndex)
-        val footerLength = readIntLittleEndian(inputStream)
-        val magic = new Array[Byte](MAGIC.length)
-        IOUtils.readFully(inputStream, magic, 0, magic.length)
-        val footerIndex = footerLengthIndex - footerLength
-        verifyParquetMagic(filePath, magic)
-        if (footerIndex < MAGIC.length || footerIndex >= footerLengthIndex) {
-          throw new RuntimeException(s"corrupted file: the footer index is not within " +
-            s"the file: $footerIndex")
-        }
-        val hmbLength = (fileLen - footerIndex).toInt
-        closeOnExcept(HostMemoryBuffer.allocate(hmbLength + MAGIC.length, false)) { outBuffer =>
-          val out = new HostMemoryOutputStream(outBuffer)
-          out.write(MAGIC)
-          inputStream.seek(footerIndex)
-          // read the footer til the end of the file
-          val tmpBuffer = new Array[Byte](4096)
-          var bytesLeft = hmbLength
-          while (bytesLeft > 0) {
-            val readLength = Math.min(bytesLeft, tmpBuffer.length)
-            IOUtils.readFully(inputStream, tmpBuffer, 0, readLength)
-            out.write(tmpBuffer, 0, readLength)
-            bytesLeft -= readLength
-          }
-          outBuffer
-        }
+    NvtxRegistry.PARQUET_READ_FOOTER_BYTES {
+      // Step 1: read the trailing footer-length int + final MAGIC via readTail.
+      // For the IcebergS3InputFile path this is a single suffix-range GET
+      // (Range: bytes=-N) — no separate file-length round-trip beyond getLength
+      // above, no inputStream.seek + IOUtils.readFully loop. HadoopInputFile
+      // falls back to the default RapidsInputFile.readTail (open + seek + read).
+      val trailerLen = FOOTER_LENGTH_SIZE + MAGIC.length
+      val (footerLength, trailerMagic) = withResource(
+          HostAlloc.alloc(trailerLen, preferPinned = false)) { trailerBuf =>
+        inputFile.readTail(trailerLen, trailerBuf)
+        val view = trailerBuf.asByteBuffer(0, trailerLen).order(ByteOrder.LITTLE_ENDIAN)
+        val len = view.getInt()
+        val m = new Array[Byte](MAGIC.length)
+        view.get(m)
+        (len, m)
+      }
+      verifyParquetMagic(filePath, trailerMagic)
+      val footerLengthIndex = fileLen - trailerLen
+      val footerIndex = footerLengthIndex - footerLength
+      if (footerIndex < MAGIC.length || footerIndex >= footerLengthIndex) {
+        throw new RuntimeException(s"corrupted file: the footer index is not within " +
+          s"the file: $footerIndex")
+      }
+      val hmbLength = (fileLen - footerIndex).toInt
+      closeOnExcept(HostAlloc.alloc(hmbLength + MAGIC.length, preferPinned = false)) { outBuffer =>
+        // Buffer layout:
+        //   [MAGIC at offset 0] + [file[footerIndex .. fileLen) at offset MAGIC.length]
+        outBuffer.asByteBuffer(0, MAGIC.length).put(MAGIC)
+        // Step 2: vectored read of [footerIndex .. fileLen) into outBuffer at MAGIC.length.
+        // Routes through IcebergS3InputFile.readVectored on S3, using the tuned
+        // async client; HadoopInputFile uses the RapidsInputFile interface default.
+        val ranges = new java.util.ArrayList[CopyRange](1)
+        ranges.add(new CopyRange(footerIndex, hmbLength, MAGIC.length))
+        inputFile.readVectored(outBuffer, ranges)
+        outBuffer
       }
     }
   }
@@ -1623,35 +1653,6 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
     org.apache.parquet.format.Util.writeFileMetaData(meta, out)
   }
 
-  private def copyDataRange(
-      range: CopyRange,
-      in: SeekableInputStream,
-      out: HostMemoryOutputStream,
-      copyBuffer: Array[Byte]): Long = {
-    var readTime = 0L
-    var writeTime = 0L
-    if (in.getPos != range.offset) {
-      in.seek(range.offset)
-    }
-    out.seek(range.outputOffset)
-    var bytesLeft = range.length
-    while (bytesLeft > 0) {
-      // downcast is safe because copyBuffer.length is an int
-      val readLength = Math.min(bytesLeft, copyBuffer.length).toInt
-      val start = System.nanoTime()
-      IOUtils.readFully(in, copyBuffer, 0, readLength)
-      val mid = System.nanoTime()
-      out.write(copyBuffer, 0, readLength)
-      val end = System.nanoTime()
-      readTime += (mid - start)
-      writeTime += (end - mid)
-      bytesLeft -= readLength
-    }
-    execMetrics.get(READ_FS_TIME).foreach(_.add(readTime))
-    execMetrics.get(WRITE_BUFFER_TIME).foreach(_.add(writeTime))
-    range.length
-  }
-
   /**
    * Computes new block metadata to reflect where the blocks and columns will appear in the
    * computed Parquet file.
@@ -1733,7 +1734,7 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
           if (channel.isDefined) {
             localItems += LocalCopy(channel.get, columnSize, outputOffset)
           } else {
-            remoteItems += CopyRange(column.getStartingPos, columnSize, outputOffset)
+            remoteItems += new CopyRange(column.getStartingPos, columnSize, outputOffset)
           }
           totalBytesToCopy += columnSize
         }
@@ -2014,42 +2015,35 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
     }
 
     val coalescedRanges = coalesceReads(remoteCopies)
-
-    val totalBytesCopied = if (fileIO.isInstanceOf[HadoopFileIO]) {
-      // Fix this after https://github.com/NVIDIA/spark-rapids/issues/13306 is resolved
-      if (filePath.toUri.getScheme.startsWith("s3")) {
-        GpuTaskMetrics.get.recordPerfioS3BackendOnce()
-      }
-      PerfIO.readToHostMemory(
-        conf, out.buffer, filePath.toUri,
-        coalescedRanges.map(r => IntRangeWithOffset(r.offset, r.length, r.outputOffset))
-      ).getOrElse {
-        withResource(inputFile.open()) { in =>
-          val copyBuffer: Array[Byte] = new Array[Byte](copyBufferSize)
-          coalescedRanges.foldLeft(0L) { (acc, blockCopy) =>
-            acc + copyDataRange(blockCopy, in, out, copyBuffer)
-          }
+    if (filePath.toUri.getScheme.startsWith("s3")) {
+      GpuTaskMetrics.get.recordPerfioS3BackendOnce()
+    }
+    // HadoopInputFile S3 takes the optimized vectored-read path; other inputs
+    // fall through to the RapidsInputFile default via readVectored.
+    val totalBytesCopied = inputFile match {
+      case _: HadoopInputFile =>
+        val ranges = coalescedRanges.map { r =>
+          IntRangeWithOffset(r.getInputOffset, r.getLength, r.getOutputOffset)
         }
-      }
-    } else {
-      withResource(inputFile.open()) { in =>
-        val copyBuffer: Array[Byte] = new Array[Byte](copyBufferSize)
-        coalescedRanges.foldLeft(0L) { (acc, blockCopy) =>
-          acc + copyDataRange(blockCopy, in, out, copyBuffer)
+        val bytesRead = metrics.getOrElse(READ_FS_TIME, NoopMetric).ns {
+          PerfIO.readToHostMemory(conf, out.buffer, filePath.toUri, ranges)
         }
-      }
+        bytesRead.getOrElse(
+          GpuParquetScan.readRangesToHostMemory(inputFile, out.buffer, coalescedRanges, metrics))
+      case _ =>
+        GpuParquetScan.readRangesToHostMemory(inputFile, out.buffer, coalescedRanges, metrics)
     }
 
     // try to cache the remote ranges that were copied
     remoteCopies.foreach { range =>
       metrics.getOrElse(GpuMetric.FILECACHE_DATA_RANGE_MISSES, NoopMetric) += 1
-      metrics.getOrElse(GpuMetric.FILECACHE_DATA_RANGE_MISSES_SIZE, NoopMetric) += range.length
+      metrics.getOrElse(GpuMetric.FILECACHE_DATA_RANGE_MISSES_SIZE, NoopMetric) += range.getLength
       val cacheToken = FileCache.get.startDataRangeCache(
-        inputFile, range.offset, range.length)
+        inputFile, range.getInputOffset, range.getLength)
       // If we get a filecache token then we can complete the caching by providing the data.
       // If we do not get a token then we should not cache this data.
       cacheToken.foreach { token =>
-        token.complete(out.buffer.slice(range.outputOffset, range.length))
+        token.complete(out.buffer.slice(range.getOutputOffset, range.getLength))
       }
     }
     totalBytesCopied
@@ -2062,11 +2056,12 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
 
     def addCurrentRange(): Unit = {
       if (currentRange != null) {
-        val rangeLength = currentRangeEnd - currentRange.offset
-        if (rangeLength == currentRange.length) {
+        val rangeLength = currentRangeEnd - currentRange.getInputOffset
+        if (rangeLength == currentRange.getLength) {
           coalesced += currentRange
         } else {
-          coalesced += currentRange.copy(length = rangeLength)
+          coalesced += new CopyRange(
+            currentRange.getInputOffset, rangeLength, currentRange.getOutputOffset)
         }
         currentRange = null
         currentRangeEnd = 0L
@@ -2074,12 +2069,12 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
     }
 
     ranges.foreach { c =>
-      if (c.offset == currentRangeEnd) {
-        currentRangeEnd += c.length
+      if (c.getInputOffset == currentRangeEnd) {
+        currentRangeEnd += c.getLength
       } else {
         addCurrentRange()
         currentRange = c
-        currentRangeEnd = c.offset + c.length
+        currentRangeEnd = c.getInputOffset + c.getLength
       }
     }
     addCurrentRange()
@@ -3682,23 +3677,18 @@ object ParquetPartitionReader {
   private[parquet] val PARQUET_CREATOR = "RAPIDS Spark Plugin"
   private[parquet] val PARQUET_VERSION = 1
 
-  private[parquet] trait CopyItem {
-    val length: Long
-  }
-
+  // Remote-range reads use RapidsInputFile.CopyRange (the jni-side type) directly
+  // — no local case-class wrapper, no per-call conversion before readVectored.
+  // LocalCopy stays separate because it carries a SeekableByteChannel and is
+  // consumed by an entirely different code path (out-of-process file cache).
   private[parquet] case class LocalCopy(
       channel: SeekableByteChannel,
       length: Long,
-      outputOffset: Long) extends CopyItem with Closeable {
+      outputOffset: Long) extends Closeable {
     override def close(): Unit = {
       channel.close()
     }
   }
-
-  private[parquet] case class CopyRange(
-      offset: Long,
-      length: Long,
-      outputOffset: Long) extends CopyItem
 
   private[parquet] def computeOutputSize(
       blocks: Seq[BlockMetaData],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -38,7 +38,7 @@ import com.nvidia.spark.rapids.RapidsConf.ParquetFooterReaderType
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
 import com.nvidia.spark.rapids.filecache.FileCache
-import com.nvidia.spark.rapids.fileio.hadoop.{HadoopFileIO, HadoopInputFile}
+import com.nvidia.spark.rapids.fileio.hadoop.HadoopFileIO
 import com.nvidia.spark.rapids.io.async._
 import com.nvidia.spark.rapids.jni.{DateTimeRebase, ParquetFooter, RmmSpark}
 import com.nvidia.spark.rapids.jni.fileio.{RapidsFileIO, RapidsInputFile}
@@ -2018,21 +2018,8 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
     if (filePath.toUri.getScheme.startsWith("s3")) {
       GpuTaskMetrics.get.recordPerfioS3BackendOnce()
     }
-    // HadoopInputFile S3 takes the optimized vectored-read path; other inputs
-    // fall through to the RapidsInputFile default via readVectored.
-    val totalBytesCopied = inputFile match {
-      case _: HadoopInputFile =>
-        val ranges = coalescedRanges.map { r =>
-          IntRangeWithOffset(r.getInputOffset, r.getLength, r.getOutputOffset)
-        }
-        val bytesRead = metrics.getOrElse(READ_FS_TIME, NoopMetric).ns {
-          PerfIO.readToHostMemory(conf, out.buffer, filePath.toUri, ranges)
-        }
-        bytesRead.getOrElse(
-          GpuParquetScan.readRangesToHostMemory(inputFile, out.buffer, coalescedRanges, metrics))
-      case _ =>
-        GpuParquetScan.readRangesToHostMemory(inputFile, out.buffer, coalescedRanges, metrics)
-    }
+    val totalBytesCopied = GpuParquetScan.readRangesToHostMemory(
+      inputFile, out.buffer, coalescedRanges, metrics)
 
     // try to cache the remote ranges that were copied
     remoteCopies.foreach { range =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -571,7 +571,8 @@ protected case class GpuParquetFileFilterHandler(
       // We should remove this after https://github.com/NVIDIA/spark-rapids/issues/13306 is
       // implemented.
       val result = PerfIO.readParquetFooterBuffer(filePath, conf, verifyParquetMagic)
-      if (filePath.toUri.getScheme.startsWith("s3")) {
+      val scheme = filePath.toUri.getScheme
+      if (scheme != null && scheme.startsWith("s3")) {
         GpuTaskMetrics.get.recordPerfioS3BackendOnce()
       }
       result.getOrElse(readFooterBufUsingHadoop(fileIO, filePath))
@@ -2015,7 +2016,8 @@ trait ParquetPartitionReaderBase extends Logging with ScanWithMetrics
     }
 
     val coalescedRanges = coalesceReads(remoteCopies)
-    if (filePath.toUri.getScheme.startsWith("s3")) {
+    val scheme = filePath.toUri.getScheme
+    if (scheme != null && scheme.startsWith("s3")) {
       GpuTaskMetrics.get.recordPerfioS3BackendOnce()
     }
     val totalBytesCopied = GpuParquetScan.readRangesToHostMemory(


### PR DESCRIPTION
Fixes #14591

### Description

optimize iceberg read using perf io

### Depends
* private repo MR

### Perf test
Before this PR, testing on EMR, average time of 5 runs 477s
After    this PR, testing on EMR, average time of 5 runs ~390s

  | Pass    | Time (s) |
  | ------- | -------- | 
  | run_1   | 397      |
  | run_2   | 389      |
  | run_3   | 388      |
  | run_4   | 377      |
  | run_5   | 398      |
  | Average | 389.8    |

test config:
```
                   "--conf" "spark.rapids.perfio.s3.enabled=true"
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
