### PR TITLE
Increase Databricks cluster create wait from 60 to 150 iterations [skip ci]

### DIFF
--- a/jenkins/databricks/clusterutils.py
+++ b/jenkins/databricks/clusterutils.py
@@ -82,7 +82,7 @@ class ClusterUtils(object):
             print(clusterid + " state:" + current_state, file=printLoc)
             if current_state in ['RUNNING']:
                 break
-            if current_state in ['INTERNAL_ERROR', 'SKIPPED', 'TERMINATED'] or p >= 60:
+            if current_state in ['INTERNAL_ERROR', 'SKIPPED', 'TERMINATED'] or p >= 150:
                 if p >= retries:
                    print("Waited %d times already, stopping" % p)
                 # Output the cluster ID to stdout so a calling script can get it easily

--- a/jenkins/databricks/clusterutils.py
+++ b/jenkins/databricks/clusterutils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
To reduce cluster creation timeouts caused by waiting for GPU resources on AWS/Azure clusters.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
