### PR TITLE
splitTargetSizeInHalfGpu by data size if not target size

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -140,7 +140,6 @@ abstract class AbstractGpuJoinIterator(
   private def nextCbFromGatherer(): Option[ColumnarBatch] = {
     NvtxIdWithMetrics(gatherNvtxId, joinTime) {
       val minTargetSize = Math.min(targetSize, 64L * 1024 * 1024)
-      val targetSizeWrapper = AutoCloseableTargetSize(targetSize, minTargetSize)
       val ret = gathererStore.map { gather =>
         // This withRetry block will always return an iterator with one ColumnarBatch.
         // The gatherer tracks how many rows we have used already.  The withRestoreOnRetry
@@ -148,6 +147,9 @@ abstract class AbstractGpuJoinIterator(
         // GpuSplitAndRetryOOM, we retry with a smaller (halved) targetSize, so we are taking
         // less from the gatherer, but because the gatherer tracks how much is used, the
         // next call to this function will start in the right place.
+        val estimatedDataSize = (gather.numRowsLeft * gather.realCheapPerRowSizeEstimate).toLong
+        val targetSizeWrapper = AutoCloseableTargetSize(targetSize, minTargetSize,
+          estimatedDataSize)
         gather.checkpoint()
         withRetry(targetSizeWrapper, splitTargetSizeInHalfGpu) { attempt =>
           withRestoreOnRetry(gather) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -152,10 +152,10 @@ object CoalesceReadOption extends Logging {
 object GpuShuffleCoalesceUtils {
   /**
    * Creates a split policy that divides a sequence of tables based on target byte size.
-   * Uses splitTargetSizeInHalfGpu to split the target size, then splits the tables
-   * sequence to match the new target size based on byte size. If it is unable to find
-   * a split, e.g. if the targetSize is larger than the full data size, it instead splits
-   * the sequence in half by number of elements.
+   * splitTargetSizeInHalfGpu uses dataSize/2 when dataSize is known and smaller than
+   * targetSize/2, ensuring the byte-size loop always finds a valid split point for 2+
+   * tables. Throws GpuSplitAndRetryOOM if the sequence cannot be split further (single
+   * table, or newTarget < minSize).
    */
   def createSplitPolicyByTargetSize[T <: AutoCloseable](
       tableOperator: SerializedTableOperator[T, _],
@@ -168,48 +168,24 @@ object GpuShuffleCoalesceUtils {
           s"GPU OutOfMemory: empty table sequence cannot be split!")
       }
 
-      // Don't close the wrapper here - withRetry will handle closing it.
-      // The split sequences need to reference the same table objects.
-      // First split the target size
-      val splitTargetSizes = splitTargetSizeInHalfGpu(wrapper.targetSize)
-      if (splitTargetSizes.isEmpty) {
-        throw new com.nvidia.spark.rapids.jni.GpuSplitAndRetryOOM(
-          s"GPU OutOfMemory: target size ${wrapper.targetSize.targetSize} " +
-              s"cannot be split further!")
-      }
-      val newTargetSize = splitTargetSizes.head
+      val newTargetSize = splitTargetSizeInHalfGpu(wrapper.targetSize).head
       val targetByteSize = newTargetSize.targetSize
 
-      // Split tables based on byte size to match the new target
       var currentSize = 0L
       var splitIndex = 0
-      var foundSplit = false
-
-      for (i <- tables.indices if !foundSplit) {
+      for (i <- tables.indices) {
         val tableSize = tableOperator.getDataLen(tables(i))
         if (currentSize + tableSize > targetByteSize && i > 0) {
           splitIndex = i
-          foundSplit = true
+          currentSize = Long.MaxValue  // stop iterating
         } else {
           currentSize += tableSize
         }
       }
 
-      if (!foundSplit) {
-        // If we can't split, check if we have at least 2 tables to split by count
-        if (tables.length <= 1) {
-          throw new com.nvidia.spark.rapids.jni.GpuSplitAndRetryOOM(
-            s"GPU OutOfMemory: a sequence of ${tables.length} tables cannot be split!")
-        }
-        splitIndex = tables.length / 2
-      }
-
       val firstHalfTables = tables.take(splitIndex)
       val secondHalfTables = tables.drop(splitIndex)
 
-      // Don't close the wrapper here - treat this as a logical split only.
-      // withRetry will handle closing the wrapper and the split sequences
-      // appropriately when each split sequence is processed.
       Seq(
         CloseableTableSeqWithTargetSize(firstHalfTables, newTargetSize),
         CloseableTableSeqWithTargetSize(secondHalfTables, newTargetSize)
@@ -561,8 +537,9 @@ abstract class CoalesceIteratorBase[T <: AutoCloseable : ClassTag, R <: AutoClos
       val tablesSeq = tables.toSeq
       splitPolicy match {
         case Some(policy) =>
-          // Create AutoCloseableTargetSize with targetBatchByteSize and minSplitSize
-          val targetSizeWrapper = AutoCloseableTargetSize(targetBatchByteSize, minSplitSizeForRetry)
+          val dataSize = tablesSeq.map(tableOperator.getDataLen).sum
+          val targetSizeWrapper = AutoCloseableTargetSize(targetBatchByteSize,
+            minSplitSizeForRetry, dataSize)
           val wrapper = CloseableTableSeqWithTargetSize(tablesSeq, targetSizeWrapper)
           val wrapperIter = Iterator(wrapper)
           inputIter = Some(wrapperIter)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -163,9 +163,9 @@ object GpuShuffleCoalesceUtils {
       Seq[CloseableTableSeqWithTargetSize[T]] = {
     (wrapper: CloseableTableSeqWithTargetSize[T]) => {
       val tables = wrapper
-      if (tables.isEmpty) {
+      if (tables.length <= 1) {
         throw new com.nvidia.spark.rapids.jni.GpuSplitAndRetryOOM(
-          s"GPU OutOfMemory: empty table sequence cannot be split!")
+          s"GPU OutOfMemory: a sequence of ${tables.length} tables cannot be split!")
       }
 
       val newTargetSize = splitTargetSizeInHalfGpu(wrapper.targetSize).head

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -173,10 +173,12 @@ object GpuShuffleCoalesceUtils {
 
       var currentSize = 0L
       var splitIndex = 0
+      var firstHalfSize = 0L
       for (i <- tables.indices) {
         val tableSize = tableOperator.getDataLen(tables(i))
         if (currentSize + tableSize > targetByteSize && i > 0) {
           splitIndex = i
+          firstHalfSize = currentSize
           currentSize = Long.MaxValue  // stop iterating
         } else {
           currentSize += tableSize
@@ -185,10 +187,13 @@ object GpuShuffleCoalesceUtils {
 
       val firstHalfTables = tables.take(splitIndex)
       val secondHalfTables = tables.drop(splitIndex)
+      val secondHalfSize = newTargetSize.dataSize - firstHalfSize
 
       Seq(
-        CloseableTableSeqWithTargetSize(firstHalfTables, newTargetSize),
-        CloseableTableSeqWithTargetSize(secondHalfTables, newTargetSize)
+        CloseableTableSeqWithTargetSize(firstHalfTables,
+          AutoCloseableTargetSize(targetByteSize, newTargetSize.minSize, firstHalfSize)),
+        CloseableTableSeqWithTargetSize(secondHalfTables,
+          AutoCloseableTargetSize(targetByteSize, newTargetSize.minSize, secondHalfSize))
       )
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -863,7 +863,7 @@ object RmmRapidsRetryIterator extends Logging {
       // If dataSize is known and smaller than targetSize/2, halving targetSize would still
       // exceed the data, making the retry a no-op. Use dataSize/2 instead to force
       // processing roughly half the data per attempt.
-      val newTarget = if (target.dataSize > 0 && target.dataSize < target.targetSize / 2) {
+      val newTarget = if (target.dataSize > 0 && target.dataSize <= target.targetSize / 2) {
         target.dataSize / 2
       } else {
         target.targetSize / 2
@@ -879,7 +879,7 @@ object RmmRapidsRetryIterator extends Logging {
                 s" minimum: ${target.minSize}")
         }
       }
-      Seq(AutoCloseableTargetSize(newTarget, target.minSize))
+      Seq(AutoCloseableTargetSize(newTarget, target.minSize, target.dataSize))
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -860,7 +860,14 @@ object RmmRapidsRetryIterator extends Logging {
   private def splitTargetSizeInHalfInternal(
       target: AutoCloseableTargetSize, isGpu: Boolean): Seq[AutoCloseableTargetSize] = {
     withResource(target) { _ =>
-      val newTarget = target.targetSize / 2
+      // If dataSize is known and smaller than targetSize/2, halving targetSize would still
+      // exceed the data, making the retry a no-op. Use dataSize/2 instead to force
+      // processing roughly half the data per attempt.
+      val newTarget = if (target.dataSize > 0 && target.dataSize < target.targetSize / 2) {
+        target.dataSize / 2
+      } else {
+        target.targetSize / 2
+      }
       if (newTarget < target.minSize) {
         if (isGpu) {
           throw new GpuSplitAndRetryOOM(
@@ -969,7 +976,9 @@ object RmmRapidsRetryIterator extends Logging {
  * `CpuSplitAndRetryOOM`, a split policy like `splitTargetSizeInHalfGpu` or
  * `splitTargetSizeInHalfCpu` can be used to retry the block with a smaller target size.
  */
-case class AutoCloseableTargetSize(targetSize: Long, minSize: Long) extends AutoCloseable {
+case class AutoCloseableTargetSize(targetSize: Long, minSize: Long,
+    dataSize: Long = 0) extends AutoCloseable {
+  def this(targetSize: Long, minSize: Long) = this(targetSize, minSize, 0)
   override def close(): Unit = ()
 }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
@@ -261,13 +261,11 @@ class GpuShuffleCoalesceSuite extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test("GPU kudo partitioning with deserialization and split retry") {
-    // Use a larger target size to allow coalescing multiple partitions.
-    // This ensures we have enough data to trigger a split when OOM is forced.
-    // Use a very small minSplitSize to allow the split retry to work with
-    // the target size of 100000.
+    // minSplitSize=1 so the split is not blocked by the minSize floor for small test data.
+    // In production minSplitSize defaults to 10MB; the split throws if dataSize/2 < minSize.
     runKudoShuffleTest(
       targetBatchSize = 100000,
-      minSplitSize = Some(1024L), // 1 KB - small enough to allow splitting
+      minSplitSize = Some(1L),
       forceSplitRetry = true)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
@@ -268,4 +268,5 @@ class GpuShuffleCoalesceSuite extends AnyFunSuite with BeforeAndAfterEach {
       minSplitSize = Some(1L),
       forceSplitRetry = true)
   }
+
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
@@ -265,6 +265,30 @@ class WithRetrySuite
     }
   }
 
+  test("splitTargetSizeInHalfGpu uses dataSize/2 as target when dataSize < targetSize/2") {
+    // When the actual data is smaller than the halved target, halving targetSize is a no-op:
+    // the retry would fetch the same data and OOM again. The fix is to use dataSize/2 instead,
+    // which forces the caller to process roughly half the data per retry.
+    val targetSize = 1000L
+    val minSize = 100L
+    val dataSize = 200L  // less than targetSize/2=500, so halving targetSize is a no-op
+    var doThrow = true
+    var splitTargetUsed = 0L
+    val myTarget = AutoCloseableTargetSize(targetSize, minSize, dataSize)
+    try {
+      withRetry(myTarget, splitTargetSizeInHalfGpu) { attempt =>
+        splitTargetUsed = attempt.targetSize
+        if (doThrow) {
+          doThrow = false
+          throw new GpuSplitAndRetryOOM("first attempt always fails")
+        }
+      }.toSeq
+    } finally {
+      // Should split to dataSize/2=100, not targetSize/2=500
+      assert(splitTargetUsed == dataSize / 2)
+    }
+  }
+
   test("splitTargetSizeInHalfGpu on AutoCloseableTargetSize throws if limit reached") {
     val initialValue = 20L
     val minValue = 5L

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
@@ -289,6 +289,32 @@ class WithRetrySuite
     }
   }
 
+  test("splitTargetSizeInHalfGpu uses per-child dataSize on second-level split") {
+    // After an uneven first split, the smaller child carries its own dataSize (e.g. 2 bytes)
+    // while its targetSize is the halved parent target (e.g. 100). Without per-child dataSize
+    // the child would see dataSize=200 (the parent total), compute newTarget=50 (targetSize/2),
+    // and fail to split [1-byte, 1-byte] tables. With the correct dataSize=2 the child uses
+    // dataSize/2=1, which is a valid split point.
+    val targetSize = 100L   // newTarget from the first split (parent dataSize/2)
+    val minSize = 1L
+    val childDataSize = 2L  // actual bytes in the smaller child; less than targetSize/2=50
+    var doThrow = true
+    var splitTargetUsed = 0L
+    val myTarget = AutoCloseableTargetSize(targetSize, minSize, childDataSize)
+    try {
+      withRetry(myTarget, splitTargetSizeInHalfGpu) { attempt =>
+        splitTargetUsed = attempt.targetSize
+        if (doThrow) {
+          doThrow = false
+          throw new GpuSplitAndRetryOOM("second-level OOM")
+        }
+      }.toSeq
+    } finally {
+      // Should use childDataSize/2=1, not targetSize/2=50
+      assert(splitTargetUsed == childDataSize / 2)
+    }
+  }
+
   test("splitTargetSizeInHalfGpu on AutoCloseableTargetSize throws if limit reached") {
     val initialValue = 20L
     val minValue = 5L


### PR DESCRIPTION
Fixes #14054.

### Description

`splitTargetSizeInHalfGpu` is used as the split policy in both the GPU shuffle coalesce path and the join gather path (`AbstractGpuJoinIterator`). When OOM occurs, it halves `targetSize` and retries — but if the actual data is already smaller than `targetSize/2`, this is a no-op and the retry will OOM again. The shuffle coalesce path had an element-count fallback for this case; the join path did not.

This change moves the fallback logic into the split policy so it can be handled in a consistent way for both shuffle coalesce and join.

In the join case, we cannot discretely divide by elements in the same way as we don't have the full collection ahead of time, so we take a different approach that still accomplishes approximately the same goal; if the target size / 2 is > the total estimated data size, when the split would have previously failed/been a no-op, we instead choose the new target to be the estimated total data size / 2 instead of target size / 2.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required