### PR TITLE
[CHERRY-PICK] Fix unregister/remove path for wrapped shuffle resolver

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -69,7 +69,7 @@ class ShuffleHandleWithMetrics[K, V, C](
 }
 
 abstract class GpuShuffleBlockResolverBase(
-    protected val wrapped: ShuffleBlockResolver,
+    val wrapped: IndexShuffleBlockResolver,
     catalog: ShuffleBufferCatalog)
   extends ShuffleBlockResolver with Logging {
   override def getBlockData(blockId: BlockId, dirs: Option[Array[String]]): ManagedBuffer = {
@@ -2101,20 +2101,28 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
 
   override def unregisterShuffle(shuffleId: Int): Boolean = {
     unregisterGpuShuffle(shuffleId)
-    shuffleBlockResolver match {
-      case isbr: IndexShuffleBlockResolver =>
-        Option(taskIdMapsForShuffle.remove(shuffleId)).foreach { mapTaskIds =>
-          mapTaskIds.synchronized {
-            mapTaskIds.iterator.foreach { mapTaskId =>
-              isbr.removeDataByMap(shuffleId, mapTaskId)
-            }
-          }
-        }
-      case _: GpuShuffleBlockResolver => // noop
+    // We need to remove old shuffle blocks when Spark GC's a shuffle Id upstream.
+    // In order to do so, we need to find the IndexShuffleBlockResolver in use.
+    // We have two scenarios:
+    // 1) We could be running in some compatibility mode where IndexShuffleBlockResolver
+    //    (which comes from Spark) is the resolver we are using.
+    // 2) We are using our own GpuShuffleBlockResolver, which can keep data in its own
+    //    internal catalog, and it will also use the block manager to write map output
+    //    to disk.
+    val isbr = shuffleBlockResolver match {
+      case isbr: IndexShuffleBlockResolver => isbr
+      case gpur: GpuShuffleBlockResolver => gpur.resolver
       case _ =>
         throw new IllegalStateException(
           "unregisterShuffle called with unexpected resolver " +
             s"$shuffleBlockResolver and blocks left to be cleaned")
+    }
+    Option(taskIdMapsForShuffle.remove(shuffleId)).foreach { mapTaskIds =>
+      mapTaskIds.synchronized {
+        mapTaskIds.iterator.foreach { mapTaskId =>
+          isbr.removeDataByMap(shuffleId, mapTaskId)
+        }
+      }
     }
     wrapped.unregisterShuffle(shuffleId)
   }

--- a/sql-plugin/src/main/spark321/scala/org/apache/spark/rapids/shims/GpuShuffleBlockResolver.scala
+++ b/sql-plugin/src/main/spark321/scala/org/apache/spark/rapids/shims/GpuShuffleBlockResolver.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.rapids.GpuShuffleBlockResolverBase
 import org.apache.spark.storage.ShuffleMergedBlockId
 
 class GpuShuffleBlockResolver(
-    resolver: IndexShuffleBlockResolver,
+    val resolver: IndexShuffleBlockResolver,
     catalog: ShuffleBufferCatalog)
     extends GpuShuffleBlockResolverBase(resolver, catalog) {
 


### PR DESCRIPTION
This is a cherry pick of https://github.com/NVIDIA/spark-rapids/pull/14686. I will put it in draft while we merge the 26.04 jar, per @pxLi's recommendation.

Contributes https://github.com/NVIDIA/spark-rapids/issues/14683

### Description

With this change in 26.04 https://github.com/NVIDIA/spark-rapids/blob/main/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala#L1819 we started to use `GpuShuffleBlockResolver` as our shuffle resolver, instead of using the default `IndexShuffleBlockResolver`. 

The problem is then seen in `unregisterShuffle` where a special case https://github.com/NVIDIA/spark-rapids/blob/main/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala#L2102 prevents shuffles to be cleaned anymore, since now we use a different resolver.

The issue then is that we keep old shuffle files around even though they have been GC'ed. The fix, is to extract the `IndexShuffleBlockResolver` out of our `GpuShuffleBlockResolver` and ask it to remove shuffle files for map outputs we wrote, as we did prior to 26.04. This PR implements that path.

I verified this with nds-h, where without this patch, we would leave 50% more shuffle space used for the sf1k data scale. This could leave us open to "disk full" exceptions.

I could write tests for this as a follow on: something that verifies unregistered shuffle clears files. But I would like to do that as a follow on if that is OK.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
