### PR TITLE
Remove non-Kudo test from integration test

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2347,7 +2347,7 @@ def test_no_fallback_when_ansi_enabled(data_gen):
 @ignore_order(local=True)
 @approximate_float
 @incompat
-@pytest.mark.parametrize('data_gen', _init_list_with_decimals, ids=idfn)
+@pytest.mark.parametrize('data_gen', _init_list_with_decimals_and_floats, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 def test_std_variance(data_gen, conf):
     local_conf = copy_and_update(conf, {

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -212,8 +212,6 @@ _decimal_gen_36_5 = DecimalGen(precision=36, scale=5)
 _decimal_gen_36_neg5 = DecimalGen(precision=36, scale=-5)
 _decimal_gen_38_10 = DecimalGen(precision=38, scale=10)
 
-kudo_enabled_conf_key = "spark.rapids.shuffle.kudo.serializer.enabled"
-
 
 def get_params(init_list, marked_params=[]):
     """
@@ -316,9 +314,8 @@ _init_list_with_decimalbig = _init_list + [
 # or results in using too much memory on the GPU
 @nightly_gpu_mem_consuming_case
 @pytest.mark.parametrize('precision', [38, 37, 36, 35, 34, 33, 32, 31], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=["KUDO", "NOT_KUDO"])
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NOT_ANSI"])
-def test_hash_reduction_decimal_near_overflow_sum(precision, kudo_enabled, ansi):
+def test_hash_reduction_decimal_near_overflow_sum(precision, ansi):
     constant = '9' * precision
     count = pow(10, 38 - precision)
     assert_gpu_and_cpu_are_equal_collect(
@@ -330,7 +327,6 @@ def test_hash_reduction_decimal_near_overflow_sum(precision, kudo_enabled, ansi)
         # we really are just doing a really bad job at multiplying to get this result so
         # some optimizations are conspiring against us.
         conf = {'spark.rapids.sql.batchSizeBytes': '128m',
-                kudo_enabled_conf_key: kudo_enabled,
                 'spark.sql.ansi.enabled': ansi})
 
 #Any smaller precision takes way too long to process on the CPU
@@ -365,8 +361,7 @@ def test_hash_reduction_decimal_near_overflow_avg(precision, ansi):
 # or results in using too much memory on the GPU
 @nightly_gpu_mem_consuming_case
 @pytest.mark.parametrize('precision', [38, 37, 36, 35, 34, 33, 32, 31], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=["KUDO", "NOT_KUDO"])
-def test_hash_reduction_decimal_overflow_sum_no_ansi(precision, kudo_enabled):
+def test_hash_reduction_decimal_overflow_sum_no_ansi(precision):
     constant = '9' * precision
     count = pow(10, 38 - precision) + 1
     assert_gpu_and_cpu_are_equal_collect(
@@ -378,7 +373,6 @@ def test_hash_reduction_decimal_overflow_sum_no_ansi(precision, kudo_enabled):
         # we really are just doing a really bad job at multiplying to get this result so
         # some optimizations are conspiring against us.
         conf = {'spark.rapids.sql.batchSizeBytes': '128m',
-                kudo_enabled_conf_key: kudo_enabled,
                 'spark.sql.ansi.enabled': False})
 
 #Any smaller precision takes way too long to process on the CPU
@@ -411,8 +405,7 @@ def test_hash_reduction_decimal_overflow_avg_no_ansi(precision):
 # or results in using too much memory on the GPU
 @nightly_gpu_mem_consuming_case
 @pytest.mark.parametrize('precision', [38, 37, 36, 35, 34, 33, 32, 31], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=["KUDO", "NOT_KUDO"])
-def test_hash_reduction_decimal_overflow_sum_ansi(precision, kudo_enabled):
+def test_hash_reduction_decimal_overflow_sum_ansi(precision):
     constant = '9' * precision
     count = pow(10, 38 - precision) + 1
     assert_gpu_and_cpu_error(
@@ -424,7 +417,6 @@ def test_hash_reduction_decimal_overflow_sum_ansi(precision, kudo_enabled):
         # we really are just doing a really bad job at multiplying to get this result so
         # some optimizations are conspiring against us.
         conf = {'spark.rapids.sql.batchSizeBytes': '128m',
-                kudo_enabled_conf_key: kudo_enabled,
                 'spark.sql.ansi.enabled': True},
         error_message=re.compile(r'(overflow)|(NUMERIC_VALUE_OUT_OF_RANGE)|(ArithmeticException)', re.IGNORECASE))
 
@@ -497,13 +489,11 @@ def test_hash_reduction_decimal_avg_too_large(precision):
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
 @pytest.mark.parametrize('override_split_until_size', [None, 1], ids=idfn)
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_grpby_sum_count_action(data_gen, override_split_until_size,
-                                     override_batch_size_bytes, kudo_enabled):
+                                     override_batch_size_bytes):
     # disable ANSI mode to avoid overflow errors on longs_with_nulls
     conf = {
         'spark.rapids.sql.test.overrides.splitUntilSize': override_split_until_size,
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.ansi.enabled': False
     }
     if override_batch_size_bytes is not None:
@@ -517,31 +507,25 @@ def test_hash_grpby_sum_count_action(data_gen, override_split_until_size,
 @allow_non_gpu("SortAggregateExec", "SortExec", "ShuffleExchangeExec")
 @ignore_order
 @pytest.mark.parametrize('data_gen', _grpkey_nested_structs_with_array_basic_child + _grpkey_list_with_non_nested_children, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_grpby_list_min_max(data_gen, kudo_enabled):
+def test_hash_grpby_list_min_max(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100).coalesce(1).groupby('a').agg(f.min(
-            'b'), f.max('b')),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            'b'), f.max('b')))
 
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_reduction_sum_count_action(data_gen, kudo_enabled):
+def test_hash_reduction_sum_count_action(data_gen):
     # disable ANSI mode to avoid overflow errors on longs_with_nulls
     assert_gpu_and_cpu_row_counts_equal(
         lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b')),
-        conf = {kudo_enabled_conf_key: kudo_enabled,
-            'spark.sql.ansi.enabled': False}
+        conf = {'spark.sql.ansi.enabled': False}
     )
 
 # Make sure that we can do computation in the group by columns
 @ignore_order
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
-def test_computation_in_grpby_columns(kudo_enabled, ansi):
+def test_computation_in_grpby_columns(ansi):
     #We do not generate enough rows for the sum of a short to ever overflow
     conf = {'spark.rapids.sql.batchSizeBytes' : '250',
-            kudo_enabled_conf_key: kudo_enabled,
             'spark.sql.ansi.enabled': ansi}
     data_gen = [
             ('a', RepeatSeqGen(StringGen('a{1,20}'), length=50)),
@@ -556,11 +540,9 @@ def test_computation_in_grpby_columns(kudo_enabled, ansi):
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list_with_decimalbig, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_grpby_sum(data_gen, conf, kudo_enabled):
+def test_hash_grpby_sum(data_gen, conf):
     # disable ANSI mode to avoid possible overflow issues in some of the data gens
-    new_conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-        'spark.sql.ansi.enabled': False})
+    new_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': False})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b')),
         conf = new_conf)
@@ -571,11 +553,9 @@ def test_hash_grpby_sum(data_gen, conf, kudo_enabled):
 @incompat
 @pytest.mark.parametrize('data_gen', [_grpkey_short_sum_full_decimals, _grpkey_short_sum_full_neg_scale_decimals], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_grpby_sum_full_decimal(data_gen, conf, kudo_enabled):
+def test_hash_grpby_sum_full_decimal(data_gen, conf):
     # disable ANSI mode to avoid possible overflow issues in some of the data gens
-    new_conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-        'spark.sql.ansi.enabled': False})
+    new_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': False})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b')),
         conf = new_conf)
@@ -586,11 +566,9 @@ def test_hash_grpby_sum_full_decimal(data_gen, conf, kudo_enabled):
 @incompat
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_gens + [DecimalGen(precision=36, scale=5)], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_reduction_sum(data_gen, conf, kudo_enabled):
+def test_hash_reduction_sum(data_gen, conf):
     # disable ANSI mode to avoid possible overflow issues in some of the data gens
-    new_conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-        'spark.sql.ansi.enabled': False})
+    new_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': False})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen, length=100).selectExpr("SUM(a)"),
         conf = new_conf)
@@ -601,12 +579,10 @@ def test_hash_reduction_sum(data_gen, conf, kudo_enabled):
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_gens + [
     DecimalGen(precision=38, scale=0), DecimalGen(precision=38, scale=-10)], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
 @datagen_overrides(seed=0, permanent=True, reason='https://github.com/NVIDIA/spark-rapids/issues/9779')
-def test_hash_reduction_sum_full_decimal(data_gen, conf, kudo_enabled):
+def test_hash_reduction_sum_full_decimal(data_gen, conf):
     # disable ANSI mode to avoid possible overflow issues in some of the data gens
-    new_conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-        'spark.sql.ansi.enabled': False})
+    new_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': False})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen, length=100).selectExpr("SUM(a)"),
         conf = new_conf)
@@ -617,10 +593,8 @@ def test_hash_reduction_sum_full_decimal(data_gen, conf, kudo_enabled):
 @pytest.mark.parametrize('data_gen', _init_list + [_grpkey_short_mid_decimals,
     _grpkey_short_big_decimals, _grpkey_short_very_big_decimals, _grpkey_short_sum_full_decimals], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_hash_grpby_avg(data_gen, conf, kudo_enabled):
-    new_conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-        # Many of these tests can overflow
+def test_hash_grpby_avg(data_gen, conf):
+    new_conf = copy_and_update(conf, {# Many of these tests can overflow
         'spark.sql.ansi.enabled': False})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=200).groupby('a').agg(f.avg('b')),
@@ -638,10 +612,9 @@ def test_hash_grpby_avg(data_gen, conf, kudo_enabled):
 @pytest.mark.parametrize('data_gen', [
     StructGen(children=[('a', int_gen), ('b', int_gen)],nullable=False,
         special_cases=[((None, None), 400.0), ((None, -1542301795), 100.0)])], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/4963')
-def test_hash_avg_nulls_partial_only(data_gen, kudo_enabled):
-    conf = copy_and_update(_float_conf_partial, {kudo_enabled_conf_key: kudo_enabled})
+def test_hash_avg_nulls_partial_only(data_gen):
+    conf = copy_and_update(_float_conf_partial, {})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=2).agg(f.avg('b')),
         conf=conf)
@@ -650,25 +623,21 @@ def test_hash_avg_nulls_partial_only(data_gen, kudo_enabled):
 @ignore_order
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list_with_decimalbig, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_intersect_all(data_gen, kudo_enabled):
+def test_intersect_all(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : gen_df(spark, data_gen, length=100).intersectAll(gen_df(spark, data_gen,
-                                                                               length=100)),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+                                                                               length=100)))
 
 @approximate_float
 @ignore_order
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list_with_decimalbig, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_exceptAll(data_gen, kudo_enabled):
+def test_exceptAll(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : (gen_df(spark, data_gen, length=100)
                         .exceptAll(gen_df(spark, data_gen, length=100)
                         .filter('a != b'))),
-        conf = {kudo_enabled_conf_key: kudo_enabled,
-            # disable ansi because a != b can insert a cast that can fail in ANSI mode
+        conf = {# disable ansi because a != b can insert a cast that can fail in ANSI mode
             'spark.sql.ansi.enabled': False,
                 # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
                 'spark.sql.adaptive.enabled': False})
@@ -697,44 +666,40 @@ _pivot_gens_with_decimals = _init_list + [
 @incompat
 @pytest.mark.parametrize('data_gen', _pivot_gens_with_decimals, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_grpby_pivot(data_gen, conf, kudo_enabled):
+def test_hash_grpby_pivot(data_gen, conf):
     # disable ANSI mode to avoid overflow in some cases of SUM
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby('a')
             .pivot('b')
             .agg(f.sum('c')),
-        conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-            'spark.sql.ansi.enabled': False}))
+        conf = copy_and_update(conf, {'spark.sql.ansi.enabled': False}))
 
 @approximate_float
 @ignore_order(local=True)
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_multiple_grpby_pivot(data_gen, conf, kudo_enabled):
+def test_hash_multiple_grpby_pivot(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby('a','b')
             .pivot('b')
             .agg(f.min('c'), f.max('c')),
-        conf=copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled}))
+        conf=copy_and_update(conf, {}))
 
 @approximate_float
 @ignore_order(local=True)
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_reduction_pivot(data_gen, conf, kudo_enabled):
+def test_hash_reduction_pivot(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby()
             .pivot('b')
             .agg(f.max('c')),
-        conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled}))
+        conf = copy_and_update(conf, {}))
 
 @approximate_float
 @ignore_order(local=True)
@@ -742,8 +707,7 @@ def test_hash_reduction_pivot(data_gen, conf, kudo_enabled):
         'Literal', 'ShuffleExchangeExec', 'HashPartitioning', 'NormalizeNaNAndZero')
 @incompat
 @pytest.mark.parametrize('data_gen', [_grpkey_floats_with_nulls_and_nans], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_pivot_groupby_duplicates_fallback(data_gen, kudo_enabled):
+def test_hash_pivot_groupby_duplicates_fallback(data_gen):
     # PivotFirst will not work on the GPU when pivot_values has duplicates
     assert_gpu_fallback_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
@@ -753,8 +717,7 @@ def test_hash_pivot_groupby_duplicates_fallback(data_gen, kudo_enabled):
         "PivotFirst",
         conf=copy_and_update(
             _float_conf,
-            {kudo_enabled_conf_key: kudo_enabled,
-             # The CPU fails in ANSI mode for this test with an array index access
+            {# The CPU fails in ANSI mode for this test with an array index access
              'spark.sql.ansi.enabled': False,
              # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
              'spark.sql.adaptive.enabled': False}) )
@@ -827,56 +790,46 @@ _all_basic_gens_with_all_nans_cases = all_basic_gens + [SetValuesGen(t, [math.na
 # to future proof them
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_decimal128_count_reduction(data_gen, kudo_enabled, ansi):
+def test_decimal128_count_reduction(data_gen, ansi):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('count(a)'),
-        conf = {kudo_enabled_conf_key: kudo_enabled,
-            'spark.sql.ansi.enabled': ansi})
+        conf = {'spark.sql.ansi.enabled': ansi})
 
 @ignore_order(local=True)
 # COUNT does not care about ANSI more or not, but include a few tests
 # to future proof them
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_decimal128_count_group_by(data_gen, kudo_enabled, ansi):
+def test_decimal128_count_group_by(data_gen, ansi):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: two_col_df(spark, byte_gen, data_gen)
             .groupby('a')
             .agg(f.count('b')),
-        conf = {kudo_enabled_conf_key: kudo_enabled,
-            'spark.sql.ansi.enabled': ansi})
+        conf = {'spark.sql.ansi.enabled': ansi})
 
 # very simple test for just a min/max on decimals 128 values until we can support more with them
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_decimal128_min_max_reduction(data_gen, kudo_enabled):
+def test_decimal128_min_max_reduction(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, data_gen).selectExpr('min(a)', 'max(a)'),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        lambda spark: unary_op_df(spark, data_gen).selectExpr('min(a)', 'max(a)'))
 
 # very simple test for just a min/max on decimals 128 values until we can support more with them
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_decimal128_min_max_group_by(data_gen, kudo_enabled):
+def test_decimal128_min_max_group_by(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: two_col_df(spark, byte_gen, data_gen)
             .groupby('a')
-            .agg(f.min('b'), f.max('b')),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            .agg(f.min('b'), f.max('b')))
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _all_basic_gens_with_all_nans_cases, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_min_max_group_by(data_gen, kudo_enabled):
+def test_min_max_group_by(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: two_col_df(spark, byte_gen, data_gen)
             .groupby('a')
-            .agg(f.min('b'), f.max('b')),
-    conf = {kudo_enabled_conf_key: kudo_enabled})
+            .agg(f.min('b'), f.max('b')))
 
 # To avoid ordering issues with collect_list, sorting the arrays that are returned.
 # NOTE: sorting the arrays locally, because sort_array() does not yet
@@ -887,21 +840,18 @@ def test_min_max_group_by(data_gen, kudo_enabled):
 @ignore_order(local=True, arrays=["blist"])
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_list_op, ids=idfn)
 @pytest.mark.parametrize('use_obj_hash_agg', [True, False], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_collect_list(data_gen, use_obj_hash_agg, kudo_enabled):
+def test_hash_groupby_collect_list(data_gen, use_obj_hash_agg):
     def doit(spark):
         return gen_df(spark, data_gen, length=100)\
             .groupby('a')\
             .agg(f.collect_list('b').alias("blist"))
     assert_gpu_and_cpu_are_equal_collect(
         doit,
-        conf={'spark.sql.execution.useObjectHashAggregateExec': str(use_obj_hash_agg).lower(),
-              kudo_enabled_conf_key: kudo_enabled})
+        conf={'spark.sql.execution.useObjectHashAggregateExec': str(use_obj_hash_agg).lower()})
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('use_obj_hash_agg', [True, False], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_collect_list_of_maps(use_obj_hash_agg, kudo_enabled):
+def test_hash_groupby_collect_list_of_maps(use_obj_hash_agg):
     gens = [("a", RepeatSeqGen(LongGen(), length=20)), ("b", simple_string_to_string_map_gen)]
     def doit(spark):
         df = gen_df(spark, gens, length=100) \
@@ -913,31 +863,26 @@ def test_hash_groupby_collect_list_of_maps(use_obj_hash_agg, kudo_enabled):
         return spark.createDataFrame(df.rdd, schema=df.schema).select("a", f.explode("blist"))
     assert_gpu_and_cpu_are_equal_collect(
         doit,
-        conf={'spark.sql.execution.useObjectHashAggregateExec': str(use_obj_hash_agg).lower(),
-              kudo_enabled_conf_key: kudo_enabled})
+        conf={'spark.sql.execution.useObjectHashAggregateExec': str(use_obj_hash_agg).lower()})
 
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_groupby_collect_set(data_gen, kudo_enabled):
+def test_hash_groupby_collect_set(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby('a')
-            .agg(f.sort_array(f.collect_set('b')), f.count('b')),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            .agg(f.sort_array(f.collect_set('b')), f.count('b')))
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_set_op, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_groupby_collect_set_on_nested_type(data_gen, kudo_enabled):
+def test_hash_groupby_collect_set_on_nested_type(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .groupby('a')
-            .agg(f.sort_array(f.collect_set('b'))),
-        conf= {kudo_enabled_conf_key: kudo_enabled})
+            .agg(f.sort_array(f.collect_set('b'))))
 
 
 # NOTE: sorting the arrays locally, because sort_array() does not yet
@@ -947,11 +892,9 @@ def test_hash_groupby_collect_set_on_nested_type(data_gen, kudo_enabled):
 @ignore_order(local=True, arrays=["collect_set"])
 @allow_non_gpu("ProjectExec", *non_utc_allow)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_set_op_nested, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_collect_set_on_nested_array_type(data_gen, kudo_enabled):
+def test_hash_groupby_collect_set_on_nested_array_type(data_gen):
     conf = copy_and_update(_float_conf, {
         "spark.rapids.sql.castFloatToString.enabled": "true",
-        kudo_enabled_conf_key: kudo_enabled
     })
 
     def do_it(spark):
@@ -964,23 +907,19 @@ def test_hash_groupby_collect_set_on_nested_array_type(data_gen, kudo_enabled):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_reduction_collect_set(data_gen, kudo_enabled):
+def test_hash_reduction_collect_set(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
-            .agg(f.sort_array(f.collect_set('b')), f.count('b')),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            .agg(f.sort_array(f.collect_set('b')), f.count('b')))
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_set_op, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_reduction_collect_set_on_nested_type(data_gen, kudo_enabled):
+def test_hash_reduction_collect_set_on_nested_type(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
-            .agg(f.sort_array(f.collect_set('b'))),
-        conf= {kudo_enabled_conf_key: kudo_enabled})
+            .agg(f.sort_array(f.collect_set('b'))))
 
 
 # NOTE: sorting the arrays locally, because sort_array() does not yet
@@ -990,11 +929,9 @@ def test_hash_reduction_collect_set_on_nested_type(data_gen, kudo_enabled):
 @ignore_order(local=True, arrays=["collect_set"])
 @allow_non_gpu("ProjectExec", *non_utc_allow)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_set_op_nested, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_reduction_collect_set_on_nested_array_type(data_gen, kudo_enabled):
+def test_hash_reduction_collect_set_on_nested_array_type(data_gen):
     conf = copy_and_update(_float_conf, {
         "spark.rapids.sql.castFloatToString.enabled": "true",
-        kudo_enabled_conf_key: kudo_enabled
     })
 
     def do_it(spark):
@@ -1006,9 +943,8 @@ def test_hash_reduction_collect_set_on_nested_array_type(data_gen, kudo_enabled)
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_groupby_collect_with_single_distinct(data_gen, kudo_enabled):
+def test_hash_groupby_collect_with_single_distinct(data_gen):
     # test collect_ops with other distinct aggregations
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
@@ -1016,8 +952,7 @@ def test_hash_groupby_collect_with_single_distinct(data_gen, kudo_enabled):
             .agg(f.sort_array(f.collect_list('b')),
                  f.sort_array(f.collect_set('b')),
                  f.countDistinct('c'),
-                 f.count('c')),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+                 f.count('c')))
 
 
 def hash_groupby_single_distinct_collect_impl(data_gen, conf):
@@ -1044,45 +979,41 @@ def hash_groupby_single_distinct_collect_impl(data_gen, conf):
 # work if they do need ANSI
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_op, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_groupby_single_distinct_collect(data_gen, kudo_enabled):
+def test_hash_groupby_single_distinct_collect(data_gen):
     """
     Tests distinct collect, with ANSI disabled.
     The corresponding ANSI-enabled condition is tested in
     test_hash_groupby_single_distinct_collect_ansi_enabled
     """
-    ansi_disabled_conf = {'spark.sql.ansi.enabled': False,
-                          kudo_enabled_conf_key: kudo_enabled}
+    ansi_disabled_conf = {'spark.sql.ansi.enabled': False}
     hash_groupby_single_distinct_collect_impl(data_gen=data_gen, conf=ansi_disabled_conf)
 
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [_gen_data_for_collect_op[0]], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 @allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec')
-def test_hash_groupby_single_distinct_collect_ansi_enabled(data_gen, kudo_enabled):
+def test_hash_groupby_single_distinct_collect_ansi_enabled(data_gen):
     """
     Tests distinct collect, with ANSI enabled.
     Enabling ANSI mode causes the plan to include ObjectHashAggregateExec, which runs on CPU.
     """
     hash_groupby_single_distinct_collect_impl(data_gen=data_gen,
-                                              conf=copy_and_update(ansi_enabled_conf, {kudo_enabled_conf_key: kudo_enabled}))
+                                              conf=copy_and_update(ansi_enabled_conf, {}))
 
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _gen_data_for_collect_op, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_groupby_collect_with_multi_distinct(data_gen, kudo_enabled):
+def test_hash_groupby_collect_with_multi_distinct(data_gen):
     def spark_fn(spark_session):
         return gen_df(spark_session, data_gen, length=100).groupby('a').agg(
             f.sort_array(f.collect_list('b')),
             f.sort_array(f.collect_set('b')),
             f.countDistinct('b'),
             f.countDistinct('c'))
-    assert_gpu_and_cpu_are_equal_collect(spark_fn, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(spark_fn)
 
 _replace_modes_non_distinct = [
     # Spark: GPU(Final) -> CPU(Partial)
@@ -1101,16 +1032,13 @@ _replace_modes_non_distinct = [
 @pytest.mark.parametrize('replace_mode', _replace_modes_non_distinct, ids=idfn)
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize('use_obj_hash_agg', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_hash_groupby_collect_partial_replace_fallback(data_gen,
                                                        replace_mode,
                                                        aqe_enabled,
-                                                       use_obj_hash_agg,
-                                                       kudo_enabled):
+                                                       use_obj_hash_agg):
     conf = {'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
             'spark.sql.adaptive.enabled': aqe_enabled,
-            'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg,
-            kudo_enabled_conf_key: kudo_enabled}
+            'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg}
 
     cpu_clz, gpu_clz = ['CollectList', 'CollectSet'], ['GpuCollectList', 'GpuCollectSet']
     exist_clz, non_exist_clz = [], []
@@ -1218,17 +1146,14 @@ _replace_modes_single_distinct = [
 @pytest.mark.parametrize('replace_mode', _replace_modes_single_distinct, ids=idfn)
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize('use_obj_hash_agg', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/4963')
 def test_hash_groupby_collect_partial_replace_with_distinct_fallback(data_gen,
                                                                      replace_mode,
                                                                      aqe_enabled,
-                                                                     use_obj_hash_agg,
-                                                                     kudo_enabled):
+                                                                     use_obj_hash_agg):
     conf = {'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
             'spark.sql.adaptive.enabled': aqe_enabled,
-            'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg,
-            kudo_enabled_conf_key: kudo_enabled}
+            'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg}
     # test with single Distinct
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: gen_df(spark, data_gen, length=100)
@@ -1295,11 +1220,9 @@ def exact_percentile_reduction(df):
 
 @datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10233")
 @pytest.mark.parametrize('data_gen', exact_percentile_reduction_data_gen, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_exact_percentile_reduction(data_gen, kudo_enabled):
+def test_exact_percentile_reduction(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: exact_percentile_reduction(gen_df(spark, data_gen)),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        lambda spark: exact_percentile_reduction(gen_df(spark, data_gen)))
 
 exact_percentile_reduction_cpu_fallback_data_gen = [
     [('val', data_gen),
@@ -1313,10 +1236,9 @@ exact_percentile_reduction_cpu_fallback_data_gen = [
 @pytest.mark.parametrize('data_gen', exact_percentile_reduction_cpu_fallback_data_gen, ids=idfn)
 @pytest.mark.parametrize('replace_mode', ['partial', 'final|complete'], ids=idfn)
 @pytest.mark.parametrize('use_obj_hash_agg', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/9494')
 def test_exact_percentile_reduction_partial_fallback_to_cpu(data_gen,  replace_mode,
-                                                            use_obj_hash_agg, kudo_enabled):
+                                                            use_obj_hash_agg):
     cpu_clz, gpu_clz = ['Percentile'], ['GpuPercentileDefault']
     exist_clz, non_exist_clz = [], []
     # For aggregations without distinct, Databricks runtime removes the partial Aggregate stage (
@@ -1339,8 +1261,7 @@ def test_exact_percentile_reduction_partial_fallback_to_cpu(data_gen,  replace_m
         exist_classes=','.join(exist_clz),
         non_exist_classes=','.join(non_exist_clz),
         conf={'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
-              'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg,
-              kudo_enabled_conf_key: kudo_enabled}
+              'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg}
     )
 
 
@@ -1374,11 +1295,9 @@ def exact_percentile_groupby(df):
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', exact_percentile_groupby_data_gen, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_exact_percentile_groupby(data_gen, kudo_enabled):
+def test_exact_percentile_groupby(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: exact_percentile_groupby(gen_df(spark, data_gen)),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        lambda spark: exact_percentile_groupby(gen_df(spark, data_gen)))
 
 exact_percentile_groupby_cpu_fallback_data_gen = [
     [('key', RepeatSeqGen(IntegerGen(), length=100)),
@@ -1394,10 +1313,9 @@ exact_percentile_groupby_cpu_fallback_data_gen = [
 @pytest.mark.parametrize('data_gen', exact_percentile_groupby_cpu_fallback_data_gen, ids=idfn)
 @pytest.mark.parametrize('replace_mode', ['partial', 'final|complete'], ids=idfn)
 @pytest.mark.parametrize('use_obj_hash_agg', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/9494')
 def test_exact_percentile_groupby_partial_fallback_to_cpu(data_gen, replace_mode,
-                                                          use_obj_hash_agg, kudo_enabled):
+                                                          use_obj_hash_agg):
     cpu_clz, gpu_clz = ['Percentile'], ['GpuPercentileDefault']
     exist_clz, non_exist_clz = [], []
     # For aggregations without distinct, Databricks runtime removes the partial Aggregate stage (
@@ -1420,17 +1338,15 @@ def test_exact_percentile_groupby_partial_fallback_to_cpu(data_gen, replace_mode
         exist_classes=','.join(exist_clz),
         non_exist_classes=','.join(non_exist_clz),
         conf={'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
-              'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg,
-                kudo_enabled_conf_key: kudo_enabled})
+              'spark.sql.execution.useObjectHashAggregateExec': use_obj_hash_agg})
 
 
 @ignore_order(local=True)
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec',
                'HashAggregateExec', 'HashPartitioning',
                'ApproximatePercentile', 'Alias', 'Literal', 'AggregateExpression')
-def test_hash_groupby_typed_imperative_agg_without_gpu_implementation_fallback(kudo_enabled):
+def test_hash_groupby_typed_imperative_agg_without_gpu_implementation_fallback():
     assert_cpu_and_gpu_are_equal_sql_with_capture(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(LongGen(), length=20)),
                                      ('v', UniqueLongGen())], length=100),
@@ -1438,16 +1354,14 @@ def test_hash_groupby_typed_imperative_agg_without_gpu_implementation_fallback(k
         non_exist_classes='GpuApproximatePercentile,GpuObjectHashAggregateExec',
         table_name='table',
         sql="""select k,
-        approx_percentile(v, array(0.25, 0.5, 0.75)) from table group by k""",
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        approx_percentile(v, array(0.25, 0.5, 0.75)) from table group by k""")
 
 @approximate_float
 @ignore_order
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_multiple_mode_query(data_gen, conf, kudo_enabled):
+def test_hash_multiple_mode_query(data_gen, conf):
     print_params(data_gen)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
@@ -1461,8 +1375,7 @@ def test_hash_multiple_mode_query(data_gen, conf, kudo_enabled):
                  f.max('a'),
                  f.sumDistinct('b'),
                  f.countDistinct('c')
-                ), conf=copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-                    # The SUM can overflow in some cases in ANSI mode
+                ), conf=copy_and_update(conf, {# The SUM can overflow in some cases in ANSI mode
                     'spark.sql.ansi.enabled': False}))
 
 
@@ -1473,12 +1386,11 @@ def test_hash_multiple_mode_query(data_gen, conf, kudo_enabled):
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs),
     ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_multiple_mode_query_avg_distincts(data_gen, conf, kudo_enabled):
+def test_hash_multiple_mode_query_avg_distincts(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .selectExpr('avg(distinct a)', 'avg(distinct b)','avg(distinct c)'),
-        conf=copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled}))
+        conf=copy_and_update(conf, {}))
 
 
 @approximate_float
@@ -1487,13 +1399,11 @@ def test_hash_multiple_mode_query_avg_distincts(data_gen, conf, kudo_enabled):
 @datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10388")
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_query_multiple_distincts_with_non_distinct(data_gen, conf, kudo_enabled):
+def test_hash_query_multiple_distincts_with_non_distinct(data_gen, conf):
     local_conf = copy_and_update(conf,
                                  {'spark.sql.legacy.allowParameterlessCount': 'true',
                                  # The SUM can overflow in some cases in ANSI mode
-                                 'spark.sql.ansi.enabled': False,
-                                 kudo_enabled_conf_key: kudo_enabled})
+                                 'spark.sql.ansi.enabled': False})
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=100),
         "hash_agg_table",
@@ -1515,10 +1425,8 @@ def test_hash_query_multiple_distincts_with_non_distinct(data_gen, conf, kudo_en
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_query_max_with_multiple_distincts(data_gen, conf, kudo_enabled):
+def test_hash_query_max_with_multiple_distincts(data_gen, conf):
     local_conf = copy_and_update(conf, {'spark.sql.legacy.allowParameterlessCount': 'true',
-                                        kudo_enabled_conf_key: kudo_enabled,
                                         'spark.sql.ansi.enabled': False})
     # Disable ANSI mode to avoid overflow on SUM. We test SUM elsewhere and none of the
     # others care about ANSI or not.
@@ -1535,13 +1443,11 @@ def test_hash_query_max_with_multiple_distincts(data_gen, conf, kudo_enabled):
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
 @pytest.mark.parametrize('data_gen', _init_list, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_hash_count_with_filter(data_gen, conf, kudo_enabled, ansi):
+def test_hash_count_with_filter(data_gen, conf, ansi):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
             .selectExpr('count(a) filter (where c > 50)'),
-        conf=copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-            'spark.sql.ansi.enabled': ansi}))
+        conf=copy_and_update(conf, {'spark.sql.ansi.enabled': ansi}))
 
 
 @approximate_float
@@ -1549,8 +1455,7 @@ def test_hash_count_with_filter(data_gen, conf, kudo_enabled, ansi):
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list + [_grpkey_short_mid_decimals, _grpkey_short_big_decimals], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_hash_multiple_filters(data_gen, conf, kudo_enabled):
+def test_hash_multiple_filters(data_gen, conf):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=100),
         "hash_agg_table",
@@ -1558,8 +1463,7 @@ def test_hash_multiple_filters(data_gen, conf, kudo_enabled):
         'count(b) filter (where c > 100),' +
         'avg(b) filter (where b > 20),' +
         'min(a), max(b) filter (where c > 250) from hash_agg_table group by a',
-        conf = copy_and_update(conf, {kudo_enabled_conf_key: kudo_enabled,
-            # ANSI on can result in a divide by 0 error
+        conf = copy_and_update(conf, {# ANSI on can result in a divide by 0 error
             'spark.sql.ansi.enabled': False}))
 
 @approximate_float
@@ -1588,10 +1492,8 @@ def test_hash_agg_with_nan_keys(data_gen, ansi):
 @ignore_order
 @pytest.mark.parametrize('data_gen',  [_grpkey_structs_with_non_nested_children,
                                        _grpkey_nested_structs], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_agg_with_struct_keys(data_gen, kudo_enabled):
+def test_hash_agg_with_struct_keys(data_gen):
     local_conf = copy_and_update(_float_conf, {'spark.sql.legacy.allowParameterlessCount': 'true',
-                                               kudo_enabled_conf_key: kudo_enabled,
                                                # SUM can overflow
                                                'spark.sql.ansi.enabled': False})
     assert_gpu_and_cpu_are_equal_sql(
@@ -1614,10 +1516,8 @@ def test_hash_agg_with_struct_keys(data_gen, kudo_enabled):
                'Cast', 'Literal', 'Alias', 'AggregateExpression',
                'ShuffleExchangeExec', 'HashPartitioning')
 @pytest.mark.parametrize('data_gen',  [_grpkey_nested_structs_with_array_child], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_agg_with_struct_of_array_fallback(data_gen, kudo_enabled):
-    local_conf = copy_and_update(_float_conf, {'spark.sql.legacy.allowParameterlessCount': 'true',
-                                               kudo_enabled_conf_key: kudo_enabled})
+def test_hash_agg_with_struct_of_array_fallback(data_gen):
+    local_conf = copy_and_update(_float_conf, {'spark.sql.legacy.allowParameterlessCount': 'true'})
     assert_cpu_and_gpu_are_equal_sql_with_capture(
         lambda spark : gen_df(spark, data_gen, length=100),
         'select a, '
@@ -1638,13 +1538,12 @@ def test_hash_agg_with_struct_of_array_fallback(data_gen, kudo_enabled):
 @approximate_float
 @ignore_order
 @pytest.mark.parametrize('data_gen', [ _grpkey_floats_with_nulls_and_nans ], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_count_distinct_with_nan_floats(data_gen, kudo_enabled):
+def test_count_distinct_with_nan_floats(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1024),
         "hash_agg_table",
         'select a, count(distinct b) as count_distinct_bees from hash_agg_table group by a',
-        copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}))
+        copy_and_update(_float_conf, {}))
 
 # TODO: Literal tests
 
@@ -1653,32 +1552,26 @@ def test_count_distinct_with_nan_floats(data_gen, kudo_enabled):
 _nested_gens = array_gens_sample + struct_gens_sample + map_gens_sample + [binary_gen]
 
 @pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_first_last_reductions_decimal_types(data_gen, kudo_enabled):
+def test_first_last_reductions_decimal_types(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         # Coalesce and sort are to make sure that first and last, which are non-deterministic
         # become deterministic
         lambda spark: unary_op_df(spark, data_gen).coalesce(1).selectExpr(
-            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'))
 
 @pytest.mark.parametrize('data_gen', _nested_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_first_last_reductions_nested_types(data_gen, kudo_enabled):
+def test_first_last_reductions_nested_types(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         # Coalesce and sort are to make sure that first and last, which are non-deterministic
         # become deterministic
         lambda spark: unary_op_df(spark, data_gen).coalesce(1).selectExpr(
-            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'))
 
 @pytest.mark.parametrize('data_gen', _all_basic_gens_with_all_nans_cases, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_generic_reductions(data_gen, kudo_enabled):
-    local_conf = copy_and_update(_float_conf, {'spark.sql.legacy.allowParameterlessCount': 'true',
-                                               kudo_enabled_conf_key: kudo_enabled})
+def test_generic_reductions(data_gen):
+    local_conf = copy_and_update(_float_conf, {'spark.sql.legacy.allowParameterlessCount': 'true'})
     assert_gpu_and_cpu_are_equal_collect(
         # Coalesce and sort are to make sure that first and last, which are non-deterministic
         # become deterministic
@@ -1696,50 +1589,41 @@ def test_generic_reductions(data_gen, kudo_enabled):
 # min_by and max_by are supported for pyspark since 3.3.0 so tested with sql
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_basic_gens + nested_gens_sample, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_min_max_by_unique(data_gen, kudo_enabled):
+def test_hash_groupby_min_max_by_unique(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: three_col_df(spark, byte_gen, data_gen, UniqueLongGen()),
         "tbl",
-        "SELECT a, min_by(b, c), max_by(b, c) FROM tbl GROUP BY a",
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        "SELECT a, min_by(b, c), max_by(b, c) FROM tbl GROUP BY a")
 
 # When the ordering column is not unique this gpu will always return the minimal/maximal value
 # while spark's result is non-deterministic. So we need to set the column b and c to be
 # the same to make the result comparable.
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_gen_no_floats + struct_gens_sample_with_decimal128 + array_gens_sample, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_min_max_by_same(data_gen, kudo_enabled):
+def test_hash_groupby_min_max_by_same(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: two_col_df(spark, byte_gen, data_gen),
         "tbl",
-        "SELECT a, min_by(b, b), max_by(b, b) FROM tbl GROUP BY a",
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        "SELECT a, min_by(b, b), max_by(b, b) FROM tbl GROUP BY a")
 
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_reduction_with_min_max_by_unique(kudo_enabled):
+def test_reduction_with_min_max_by_unique():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: two_col_df(spark, int_gen, UniqueLongGen()).selectExpr(
-            "min_by(a, b)", "max_by(a, b)"),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            "min_by(a, b)", "max_by(a, b)"))
 
 
 # When the ordering column is not unique this gpu will always return the minimal/maximal value
 # while spark's result is non-deterministic. So we need to set the column b and c to be
 # the same to make the result comparable.
 @pytest.mark.parametrize('data_gen', basic_gen_no_floats + struct_gens_sample_with_decimal128 + array_gens_sample, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_reduction_with_max_by_same(data_gen, kudo_enabled):
+def test_reduction_with_max_by_same(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr(
-            "min_by(a, a)", "max_by(a, a)"),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            "min_by(a, a)", "max_by(a, a)"))
 
 @pytest.mark.parametrize('data_gen', all_gen + _nested_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 @allow_non_gpu(*non_utc_allow)
-def test_count(data_gen, kudo_enabled):
+def test_count(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen) \
             .selectExpr(
@@ -1747,48 +1631,40 @@ def test_count(data_gen, kudo_enabled):
             'count()',
             'count()',
             'count(1)'),
-        conf = {'spark.sql.legacy.allowParameterlessCount': 'true',
-                kudo_enabled_conf_key: kudo_enabled})
+        conf = {'spark.sql.legacy.allowParameterlessCount': 'true'})
 
 @pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 @allow_non_gpu(*non_utc_allow)
-def test_distinct_count_reductions(data_gen, kudo_enabled):
+def test_distinct_count_reductions(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).selectExpr(
-                'count(DISTINCT a)'),
-        conf= {kudo_enabled_conf_key: kudo_enabled})
+                'count(DISTINCT a)'))
 
 @pytest.mark.parametrize('data_gen', [float_gen, double_gen], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_distinct_float_count_reductions(data_gen, kudo_enabled):
+def test_distinct_float_count_reductions(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).selectExpr(
-                'count(DISTINCT a)'),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+                'count(DISTINCT a)'))
 
 @approximate_float
 @pytest.mark.parametrize('data_gen', numeric_gens + [decimal_gen_64bit, decimal_gen_128bit], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_arithmetic_reductions(data_gen, kudo_enabled):
+def test_arithmetic_reductions(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr(
                 'sum(a)',
                 'avg(a)'),
-            conf = copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled,
-                #SUM cna overflow
+            conf = copy_and_update(_float_conf, {#SUM cna overflow
                 'spark.sql.ansi.enabled': False}))
 
 @pytest.mark.parametrize('data_gen',
                          all_basic_gens + decimal_gens + _nested_gens,
                          ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_collect_list_reductions(data_gen, kudo_enabled):
+def test_collect_list_reductions(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         # coalescing because collect_list is not deterministic
         lambda spark: unary_op_df(spark, data_gen).coalesce(1).selectExpr('collect_list(a)'),
-        conf= copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}) )
+        conf= copy_and_update(_float_conf, {}) )
 
 _no_neg_zero_all_basic_gens = [byte_gen, short_gen, int_gen, long_gen,
         # -0.0 cannot work because of -0.0 == 0.0 in cudf for distinct and
@@ -1802,12 +1678,11 @@ _struct_only_nested_gens = [all_basic_struct_gen,
 @pytest.mark.parametrize('data_gen',
                          _no_neg_zero_all_basic_gens + decimal_gens + _struct_only_nested_gens,
                          ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_collect_set_reductions(data_gen, kudo_enabled):
+def test_collect_set_reductions(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('sort_array(collect_set(a))'),
-        conf=copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}))
+        conf=copy_and_update(_float_conf, {}))
 
 def test_collect_empty():
     assert_gpu_and_cpu_are_equal_collect(
@@ -1817,9 +1692,8 @@ def test_collect_empty():
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen + _nested_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_groupby_first_last(data_gen, kudo_enabled):
+def test_groupby_first_last(data_gen):
     gen_fn = [('a', RepeatSeqGen(LongGen(), length=20)), ('b', data_gen)]
     agg_fn = lambda df: df.groupBy('a').agg(
         f.first('b'), f.last('b'), f.first('b', True), f.last('b', True))
@@ -1828,14 +1702,12 @@ def test_groupby_first_last(data_gen, kudo_enabled):
         # We set parallelism 1 to prevent nondeterministic results because of distributed setup.
         lambda spark: agg_fn(gen_df(spark, gen_fn, num_slices=1)),
         # Disable RADIX sort as the CPU sort is not stable if it is
-        conf={'spark.sql.sort.enableRadixSort': False,
-              kudo_enabled_conf_key: kudo_enabled})
+        conf={'spark.sql.sort.enableRadixSort': False})
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen + _struct_only_nested_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_sorted_groupby_first_last(data_gen, kudo_enabled):
+def test_sorted_groupby_first_last(data_gen):
     gen_fn = [('a', RepeatSeqGen(LongGen(), length=20)), ('b', data_gen)]
     # sort by more than the group by columns to be sure that first/last don't remove the ordering
     agg_fn = lambda df: df.orderBy('a', 'b').groupBy('a').agg(
@@ -1847,7 +1719,6 @@ def test_sorted_groupby_first_last(data_gen, kudo_enabled):
         # of distributed setups.
         lambda spark: agg_fn(gen_df(spark, gen_fn, num_slices=1)),
         conf = {'spark.sql.shuffle.partitions': '1',
-                kudo_enabled_conf_key: kudo_enabled,
                 'spark.sql.adaptive.enabled': 'false'})
 
 # Spark has a sorting bug with decimals, see https://issues.apache.org/jira/browse/SPARK-40129.
@@ -1855,13 +1726,11 @@ def test_sorted_groupby_first_last(data_gen, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('count_func', [f.count, f.countDistinct], ids=["COUNT", "COUNT_DISTINCT"])
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
 @allow_non_gpu(*non_utc_allow)
-def test_agg_count(data_gen, count_func, kudo_enabled):
+def test_agg_count(data_gen, count_func):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : gen_df(spark, [('a', data_gen), ('b', data_gen)],
-                              length=1024).groupBy('a').agg(count_func("b")),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+                              length=1024).groupBy('a').agg(count_func("b")))
 
 # Spark has a sorting bug with decimals, see https://issues.apache.org/jira/browse/SPARK-40129.
 # Have pytest do the sorting rather than Spark as a workaround.
@@ -1872,14 +1741,12 @@ def test_agg_count(data_gen, count_func, kudo_enabled):
                          [ArrayGen(StructGen([['child0', byte_gen], ['child1', string_gen], ['child2', float_gen]]))],
                          ids=idfn)
 @pytest.mark.parametrize('count_func', [f.count, f.countDistinct])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_groupby_list_types_fallback(data_gen, count_func, kudo_enabled):
+def test_groupby_list_types_fallback(data_gen, count_func):
     assert_gpu_fallback_collect(
         lambda spark : gen_df(spark, [('a', data_gen), ('b', data_gen)],
                               length=1024).groupBy('a').agg(count_func("b")),
         "HashAggregateExec",
-    conf = {kudo_enabled_conf_key: kudo_enabled,
-            # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
+    conf = {# Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
             'spark.sql.adaptive.enabled': 'false'})
 
 def subquery_create_temp_views(spark, expr):
@@ -1903,12 +1770,10 @@ def subquery_create_temp_views(spark, expr):
   "select sum(distinct(if(c > (select sum(distinct(a)) from t1), d, 0))) as csum " +
     "from t2 group by c"
 ])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_subquery_in_agg(adaptive, expr, kudo_enabled):
+def test_subquery_in_agg(adaptive, expr):
     assert_gpu_and_cpu_are_equal_collect(
       lambda spark: subquery_create_temp_views(spark, expr),
-        conf = {"spark.sql.adaptive.enabled" : adaptive,
-                kudo_enabled_conf_key: kudo_enabled})
+        conf = {"spark.sql.adaptive.enabled" : adaptive})
 
 
 # TODO support multi-level structs https://github.com/NVIDIA/spark-rapids/issues/2438
@@ -1938,13 +1803,12 @@ def workaround_dedupe_by_value(df, num_cols):
     ], nullable=False),
 ], ids=idfn)
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_struct_groupby_count(key_data_gen, kudo_enabled):
+def test_struct_groupby_count(key_data_gen):
     def group_by_count(spark):
         df = two_col_df(spark, key_data_gen, IntegerGen())
         assert_single_level_struct(df)
         return workaround_dedupe_by_value(df.groupBy(df.a).count(), 3)
-    assert_gpu_and_cpu_are_equal_collect(group_by_count, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(group_by_count)
 
 
 @pytest.mark.parametrize('cast_struct_tostring', ['LEGACY', 'SPARK311+'])
@@ -1958,15 +1822,13 @@ def test_struct_groupby_count(key_data_gen, kudo_enabled):
     ], nullable=False)
 ], ids=idfn)
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO","NO_KUDO"])
-def test_struct_cast_groupby_count(cast_struct_tostring, key_data_gen, kudo_enabled):
+def test_struct_cast_groupby_count(cast_struct_tostring, key_data_gen):
     def _group_by_struct_or_cast(spark):
         df = two_col_df(spark, key_data_gen, IntegerGen())
         assert_single_level_struct(df)
         return df.groupBy(df.a.cast(StringType())).count()
     assert_gpu_and_cpu_are_equal_collect(_group_by_struct_or_cast, {
         'spark.sql.legacy.castComplexTypesToString.enabled': cast_struct_tostring == 'LEGACY',
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 
@@ -1983,13 +1845,12 @@ def test_struct_cast_groupby_count(cast_struct_tostring, key_data_gen, kudo_enab
         ]))], nullable=False),
 ], ids=idfn)
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_struct_count_distinct(key_data_gen, kudo_enabled):
+def test_struct_count_distinct(key_data_gen):
     def _count_distinct_by_struct(spark):
         df = gen_df(spark, key_data_gen)
         assert_single_level_struct(df)
         return df.agg(f.countDistinct(df.a))
-    assert_gpu_and_cpu_are_equal_collect(_count_distinct_by_struct, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(_count_distinct_by_struct)
 
 
 @pytest.mark.parametrize('cast_struct_tostring', ['LEGACY', 'SPARK311+'])
@@ -2005,85 +1866,72 @@ def test_struct_count_distinct(key_data_gen, kudo_enabled):
         ]))], nullable=False),
 ], ids=idfn)
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_struct_count_distinct_cast(cast_struct_tostring, key_data_gen, kudo_enabled):
+def test_struct_count_distinct_cast(cast_struct_tostring, key_data_gen):
     def _count_distinct_by_struct(spark):
         df = gen_df(spark, key_data_gen)
         assert_single_level_struct(df)
         return df.agg(f.countDistinct(df.a.cast(StringType())))
     assert_gpu_and_cpu_are_equal_collect(_count_distinct_by_struct, {
         'spark.sql.legacy.castComplexTypesToString.enabled': cast_struct_tostring == 'LEGACY',
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
-def test_reduction_nested_struct(kudo_enabled, ansi):
+def test_reduction_nested_struct(ansi):
     # we do not generate enough rows for the values 0 to 4 to overflow in a sum
     def do_it(spark):
         df = unary_op_df(spark, StructGen([('aa', StructGen([('aaa', IntegerGen(min_val=0, max_val=4))]))]))
         return df.agg(f.sum(df.a.aa.aaa))
     assert_gpu_and_cpu_are_equal_collect(do_it,
-            conf = {kudo_enabled_conf_key: kudo_enabled,
-                'spark.sql.ansi.enabled': ansi})
+            conf = {'spark.sql.ansi.enabled': ansi})
 
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
-def test_reduction_nested_array(kudo_enabled, ansi):
+def test_reduction_nested_array(ansi):
     # we do not generate enough rows for the values 0 to 4 to overflow in a sum
     def do_it(spark):
         # Set the min array length to 2 to avoid array index out of bounds errors in ANSI mode
         df = unary_op_df(spark, ArrayGen(StructGen([('aa', IntegerGen(min_val=0, max_val=4))]), min_length=2))
         return df.agg(f.sum(df.a[1].aa))
     assert_gpu_and_cpu_are_equal_collect(do_it,
-            conf = {kudo_enabled_conf_key: kudo_enabled,
-                'spark.sql.ansi.enabled': ansi})
+            conf = {'spark.sql.ansi.enabled': ansi})
 
 # The map here is a child not a top level, because we only support GetMapValue on String to String maps.
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_reduction_nested_map(kudo_enabled):
+def test_reduction_nested_map():
     def do_it(spark):
         df = unary_op_df(spark, ArrayGen(MapGen(StringGen('a{1,5}', nullable=False), StringGen('[ab]{1,5}'))))
         return df.agg(f.min(df.a[1]["a"]))
-    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled,
-        # Disable ANSI to avoid array index out of bounds errors
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {# Disable ANSI to avoid array index out of bounds errors
         'spark.sql.ansi.enabled': False})
 
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
-def test_agg_nested_struct(kudo_enabled, ansi):
+def test_agg_nested_struct(ansi):
     # we do not generate enough rows for the values 0 to 4 to overflow in a sum
     def do_it(spark):
         df = two_col_df(spark, StringGen('k{1,5}'), StructGen([('aa', StructGen([('aaa', IntegerGen(min_val=0, max_val=4))]))]))
         return df.groupBy('a').agg(f.sum(df.b.aa.aaa))
     assert_gpu_and_cpu_are_equal_collect(do_it, 
-            conf = {kudo_enabled_conf_key: kudo_enabled,
-                'spark.sql.ansi.enabled': ansi})
+            conf = {'spark.sql.ansi.enabled': ansi})
 
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_agg_nested_array(kudo_enabled):
+def test_agg_nested_array():
     # Ths SUM in ANSI mode is okay because we cannot overflow with values 0 to 4 with a small number of rows
     def do_it(spark):
         # have a min length of 2 to avoid ANSI issues when getting a value from an array
         df = two_col_df(spark, StringGen('k{1,5}'), ArrayGen(StructGen([('aa', IntegerGen(min_val=0, max_val=4))]), min_length=2))
         return df.groupBy('a').agg(f.sum(df.b[1].aa))
-    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_it)
 
 # The map here is a child not a top level, because we only support GetMapValue on String to String maps.
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_agg_nested_map(kudo_enabled):
+def test_agg_nested_map():
     def do_it(spark):
         df = two_col_df(spark, StringGen('k{1,5}'), ArrayGen(MapGen(StringGen('a{1,5}', nullable=False), StringGen('[ab]{1,5}'))))
         return df.groupBy('a').agg(f.min(df.b[1]["a"]))
-    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {kudo_enabled_conf_key: kudo_enabled,
-        # Disable ANSI mode to avoid issues with array indexes and map keys not being present
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {# Disable ANSI mode to avoid issues with array indexes and map keys not being present
         'spark.sql.ansi.enabled': False})
 
 @pytest.mark.skipif(is_before_spark_330(), reason="try_sum is not supported before Spark 3.3.0")
@@ -2130,10 +1978,8 @@ def test_try_avg_fallback_to_cpu(data_gen):
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_reduction(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_reduction(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('v', DoubleGen())], length=100),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf, reduction = True)
@@ -2141,10 +1987,8 @@ def test_hash_groupby_approx_percentile_reduction(aqe_enabled, kudo_enabled):
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_reduction_single_row(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_reduction_single_row(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('v', DoubleGen())], length=1),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf, reduction = True)
@@ -2152,10 +1996,8 @@ def test_hash_groupby_approx_percentile_reduction_single_row(aqe_enabled, kudo_e
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_reduction_no_rows(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_reduction_no_rows(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('v', DoubleGen())], length=0),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf, reduction = True)
@@ -2163,10 +2005,8 @@ def test_hash_groupby_approx_percentile_reduction_no_rows(aqe_enabled, kudo_enab
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_byte(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_byte(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
                                      ('v', ByteGen())], length=100),
@@ -2176,10 +2016,8 @@ def test_hash_groupby_approx_percentile_byte(aqe_enabled, kudo_enabled):
 @disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/11198
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_byte_scalar(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_byte_scalar(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
                                      ('v', ByteGen())], length=100),
@@ -2188,10 +2026,8 @@ def test_hash_groupby_approx_percentile_byte_scalar(aqe_enabled, kudo_enabled):
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(LongGen(), length=20)),
                                      ('v', UniqueLongGen())], length=100),
@@ -2200,10 +2036,8 @@ def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled, kudo_ena
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_long(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_long(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
                                      ('v', UniqueLongGen())], length=100),
@@ -2213,10 +2047,8 @@ def test_hash_groupby_approx_percentile_long(aqe_enabled, kudo_enabled):
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @disable_ansi_mode  # ANSI mode is tested in test_hash_groupby_approx_percentile_long_single_ansi
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_long_single(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_long_single(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
                                      ('v', UniqueLongGen())], length=100),
@@ -2227,15 +2059,13 @@ def test_hash_groupby_approx_percentile_long_single(aqe_enabled, kudo_enabled):
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec')
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_long_single_ansi(aqe_enabled, kudo_enabled):
+def test_hash_groupby_approx_percentile_long_single_ansi(aqe_enabled):
     """
     Tests approx_percentile with ANSI mode enabled.
     Note: In ANSI mode, the test query exercises ObjectHashAggregateExec and ShuffleExchangeExec,
           which fall back to CPU.
     """
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     conf.update(ansi_enabled_conf)
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
@@ -2246,10 +2076,8 @@ def test_hash_groupby_approx_percentile_long_single_ansi(aqe_enabled, kudo_enabl
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_double(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_double(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
                                      ('v', DoubleGen())], length=100),
@@ -2258,10 +2086,8 @@ def test_hash_groupby_approx_percentile_double(aqe_enabled, kudo_enabled):
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_double_single(aqe_enabled, kudo_enabled):
-    conf = {'spark.sql.adaptive.enabled': aqe_enabled,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_hash_groupby_approx_percentile_double_single(aqe_enabled):
+    conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
                                      ('v', DoubleGen())], length=100),
@@ -2270,15 +2096,13 @@ def test_hash_groupby_approx_percentile_double_single(aqe_enabled, kudo_enabled)
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @ignore_order(local=True)
 @allow_non_gpu('TakeOrderedAndProjectExec', 'Alias', 'Cast', 'ObjectHashAggregateExec', 'AggregateExpression',
     'ApproximatePercentile', 'Literal', 'ShuffleExchangeExec', 'HashPartitioning', 'CollectLimitExec')
-def test_hash_groupby_approx_percentile_partial_fallback_to_cpu(aqe_enabled, kudo_enabled):
+def test_hash_groupby_approx_percentile_partial_fallback_to_cpu(aqe_enabled):
     conf = {
         'spark.rapids.sql.hashAgg.replaceMode': 'partial',
         'spark.sql.adaptive.enabled': aqe_enabled,
-        kudo_enabled_conf_key: kudo_enabled
     }
 
     def approx_percentile_query(spark):
@@ -2292,86 +2116,73 @@ def test_hash_groupby_approx_percentile_partial_fallback_to_cpu(aqe_enabled, kud
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_decimal32(kudo_enabled):
+def test_hash_groupby_approx_percentile_decimal32():
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(ByteGen(nullable=False), length=2)),
                                      ('v', DecimalGen(6, 2))]),
-        [0.05, 0.25, 0.5, 0.75, 0.95],
-    conf = {kudo_enabled_conf_key: kudo_enabled})
+        [0.05, 0.25, 0.5, 0.75, 0.95])
 
 
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
 @disable_ansi_mode  # ANSI mode is tested with test_hash_groupby_approx_percentile_decimal_single_ansi.
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_decimal32_single(kudo_enabled):
+def test_hash_groupby_approx_percentile_decimal32_single():
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(ByteGen(nullable=False), length=2)),
                                      ('v', DecimalGen(6, 2))]),
-        0.05,
-    conf = {kudo_enabled_conf_key: kudo_enabled})
+        0.05)
 
 
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
 @allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec')
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_decimal_single_ansi(kudo_enabled):
+def test_hash_groupby_approx_percentile_decimal_single_ansi():
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(ByteGen(nullable=False), length=2)),
                                      ('v', DecimalGen(6, 2))]),
         0.05,
-        conf=copy_and_update(ansi_enabled_conf, {kudo_enabled_conf_key: kudo_enabled}))
+        conf=copy_and_update(ansi_enabled_conf, {}))
 
 
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_decimal64(kudo_enabled):
+def test_hash_groupby_approx_percentile_decimal64():
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(ByteGen(nullable=False), length=2)),
                                      ('v', DecimalGen(10, 9))]),
-        [0.05, 0.25, 0.5, 0.75, 0.95],
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        [0.05, 0.25, 0.5, 0.75, 0.95])
 
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @disable_ansi_mode  # ANSI mode is tested with test_hash_groupby_approx_percentile_decimal_single_ansi.
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_decimal64_single(kudo_enabled):
+def test_hash_groupby_approx_percentile_decimal64_single():
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(ByteGen(nullable=False), length=2)),
                                      ('v', DecimalGen(10, 9))]),
-        0.05,
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        0.05)
 
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_decimal128(kudo_enabled):
+def test_hash_groupby_approx_percentile_decimal128():
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(ByteGen(nullable=False), length=2)),
                                      ('v', DecimalGen(19, 18))]),
-        [0.05, 0.25, 0.5, 0.75, 0.95],
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        [0.05, 0.25, 0.5, 0.75, 0.95])
 
 @incompat
 @pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/13049")
 @disable_ansi_mode  # ANSI mode is tested with test_hash_groupby_approx_percentile_decimal_single_ansi.
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_groupby_approx_percentile_decimal128_single(kudo_enabled):
+def test_hash_groupby_approx_percentile_decimal128_single():
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(ByteGen(nullable=False), length=2)),
                                      ('v', DecimalGen(19, 18))]),
-        0.05,
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        0.05)
 
 # The percentile approx tests differ from other tests because we do not expect the CPU and GPU to produce the same
 # results due to the different algorithms being used. Instead we compute an exact percentile on the CPU and then
@@ -2465,21 +2276,17 @@ def create_percentile_sql(func_name, percentiles, reduction):
 @ignore_order
 @pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_grpby_avg_nulls(data_gen, conf, kudo_enabled):
+def test_hash_grpby_avg_nulls(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a')
           .agg(f.avg('c')),
-        conf=copy_and_update(conf, {'spark.sql.ansi.enabled': 'false',
-            kudo_enabled_conf_key: kudo_enabled}))
+        conf=copy_and_update(conf, {'spark.sql.ansi.enabled': 'false'}))
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_grpby_avg_nulls_ansi(data_gen, conf, kudo_enabled):
-    local_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': 'true',
-                                        kudo_enabled_conf_key: kudo_enabled})
+def test_hash_grpby_avg_nulls_ansi(data_gen, conf):
+    local_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a')
           .agg(f.avg('c')),
@@ -2488,21 +2295,17 @@ def test_hash_grpby_avg_nulls_ansi(data_gen, conf, kudo_enabled):
 @ignore_order
 @pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_reduction_avg_nulls(data_gen, conf, kudo_enabled):
+def test_hash_reduction_avg_nulls(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
           .agg(f.avg('c')),
-        conf=copy_and_update(conf, {'spark.sql.ansi.enabled': 'false',
-            kudo_enabled_conf_key: kudo_enabled}))
+        conf=copy_and_update(conf, {'spark.sql.ansi.enabled': 'false'}))
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_reduction_avg_nulls_ansi(data_gen, conf, kudo_enabled):
-    local_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': 'true',
-                                        kudo_enabled_conf_key: kudo_enabled})
+def test_hash_reduction_avg_nulls_ansi(data_gen, conf):
+    local_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
           .agg(f.avg('c')),
@@ -2510,30 +2313,27 @@ def test_hash_reduction_avg_nulls_ansi(data_gen, conf, kudo_enabled):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sum_ansi_enabled(data_gen, kudo_enabled):
+def test_sum_ansi_enabled(data_gen):
     def do_it(spark):
         df = gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100)
         return df.groupBy('a').agg(f.sum("b"))
 
     assert_gpu_and_cpu_are_equal_collect(do_it,
-        conf={'spark.sql.ansi.enabled': 'true', kudo_enabled_conf_key: kudo_enabled})
+        conf={'spark.sql.ansi.enabled': 'true'})
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_count_when_ansi_enabled(data_gen, kudo_enabled):
+def test_count_when_ansi_enabled(data_gen):
     def do_it(spark):
         df = gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100)
         return df.groupBy('a').agg(f.count("b"), f.count("*"))
 
     assert_gpu_and_cpu_are_equal_collect(do_it,
-        conf={'spark.sql.ansi.enabled': 'true', kudo_enabled_conf_key: kudo_enabled})
+        conf={'spark.sql.ansi.enabled': 'true'})
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_no_fallback_when_ansi_enabled(data_gen, kudo_enabled):
+def test_no_fallback_when_ansi_enabled(data_gen):
     def do_it(spark):
         df = gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100)
         # coalescing because first/last are not deterministic
@@ -2541,19 +2341,17 @@ def test_no_fallback_when_ansi_enabled(data_gen, kudo_enabled):
         return df.groupBy('a').agg(f.first("b"), f.last("b"), f.min("b"), f.max("b"))
 
     assert_gpu_and_cpu_are_equal_collect(do_it,
-        conf={'spark.sql.ansi.enabled': 'true', kudo_enabled_conf_key: kudo_enabled})
+        conf={'spark.sql.ansi.enabled': 'true'})
 
 # Tests for standard deviation and variance aggregations.
 @ignore_order(local=True)
 @approximate_float
 @incompat
-@pytest.mark.parametrize('data_gen', _init_list_with_decimals_and_floats, ids=idfn)
+@pytest.mark.parametrize('data_gen', _init_list_with_decimals, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_std_variance(data_gen, conf, kudo_enabled):
+def test_std_variance(data_gen, conf):
     local_conf = copy_and_update(conf, {
-        'spark.rapids.sql.castDecimalToFloat.enabled': 'true',
-        kudo_enabled_conf_key: kudo_enabled})
+        'spark.rapids.sql.castDecimalToFloat.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1000),
         "data_table",
@@ -2582,10 +2380,8 @@ def test_std_variance(data_gen, conf, kudo_enabled):
 @pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_std_variance_nulls(data_gen, conf, ansi_enabled, kudo_enabled):
-    local_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': ansi_enabled,
-                                        kudo_enabled_conf_key: kudo_enabled})
+def test_std_variance_nulls(data_gen, conf, ansi_enabled):
+    local_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': ansi_enabled})
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1000),
         "data_table",
@@ -2621,16 +2417,13 @@ def test_std_variance_nulls(data_gen, conf, ansi_enabled, kudo_enabled):
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize('replace_mode', _replace_modes_non_distinct, ids=idfn)
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/4963')
 def test_std_variance_partial_replace_fallback(data_gen,
                                                conf,
                                                replace_mode,
-                                               aqe_enabled,
-                                               kudo_enabled):
+                                               aqe_enabled):
     local_conf = copy_and_update(conf, {'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
-                                        'spark.sql.adaptive.enabled': aqe_enabled,
-                                        kudo_enabled_conf_key: kudo_enabled})
+                                        'spark.sql.adaptive.enabled': aqe_enabled})
 
     exist_clz = ['StddevPop', 'StddevSamp', 'VariancePop', 'VarianceSamp',
                  'GpuStddevPop', 'GpuStddevSamp', 'GpuVariancePop', 'GpuVarianceSamp']
@@ -2675,9 +2468,8 @@ gens_for_max_min = [byte_gen, short_gen, int_gen, long_gen,
     null_gen] + array_gens_sample + struct_gens_sample
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen',  gens_for_max_min, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_min_max_in_groupby_and_reduction(data_gen, kudo_enabled):
+def test_min_max_in_groupby_and_reduction(data_gen):
     df_gen = [('a', data_gen), ('b', RepeatSeqGen(IntegerGen(), length=20))]
 
     # test max
@@ -2685,42 +2477,39 @@ def test_min_max_in_groupby_and_reduction(data_gen, kudo_enabled):
         lambda spark : gen_df(spark, df_gen),
         "hash_agg_table",
         'select b, max(a) from hash_agg_table group by b',
-        copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}))
+        copy_and_update(_float_conf, {}))
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, df_gen),
         "hash_agg_table",
         'select max(a) from hash_agg_table',
-        copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}))
+        copy_and_update(_float_conf, {}))
 
     # test min
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, df_gen, length=1024),
         "hash_agg_table",
         'select b, min(a) from hash_agg_table group by b',
-        copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}))
+        copy_and_update(_float_conf, {}))
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, df_gen, length=1024),
         "hash_agg_table",
         'select min(a) from hash_agg_table',
-        copy_and_update(_float_conf, {kudo_enabled_conf_key: kudo_enabled}))
+        copy_and_update(_float_conf, {}))
 
 # Some Spark implementations will optimize this aggregation as a
 # complete aggregation (i.e.: only one aggregation node in the plan)
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_aggregate_complete_with_grouping_expressions(kudo_enabled):
+def test_hash_aggregate_complete_with_grouping_expressions():
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : spark.range(10).withColumn("id2", f.col("id")),
         "hash_agg_complete_table",
-        "select id, avg(id) from hash_agg_complete_table group by id, id2 + 1",
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        "select id, avg(id) from hash_agg_complete_table group by id, id2 + 1")
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('cast_key_to', ["byte", "short", "int",
     "long", "string", "DECIMAL(38,5)"], ids=idfn)
 @pytest.mark.parametrize("ansi", [True, False], ids=["ANSI", "NO_ANSI"])
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_agg_force_pre_sort(cast_key_to, kudo_enabled, ansi):
+def test_hash_agg_force_pre_sort(cast_key_to, ansi):
     def do_it(spark):
         # limit long value to avoid overflow in ANSI mode
         # limit key value range to avoid ANSI cast overflow to BYTE
@@ -2730,7 +2519,6 @@ def test_hash_agg_force_pre_sort(cast_key_to, kudo_enabled, ansi):
     assert_gpu_and_cpu_are_equal_collect(do_it,
         conf={'spark.rapids.sql.agg.forceSinglePassPartialSort': True,
             'spark.rapids.sql.agg.singlePassPartialSortEnabled': True,
-            kudo_enabled_conf_key: kudo_enabled,
             'spark.sql.ansi.enabled': ansi})
 
 @ignore_order(local=True)
@@ -2920,8 +2708,7 @@ def test_avg_divide_by_zero(data_type, ansi):
             conf=conf)
 
 @ignore_order
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO", "NO_KUDO"])
-def test_hash_agg_with_aliased_grouping_key_in_result_expr(kudo_enabled):
+def test_hash_agg_with_aliased_grouping_key_in_result_expr():
     """
     Test that GpuHashAggregateExec correctly handles GpuAlias in resultExpressions.
     """
@@ -2969,7 +2756,6 @@ def test_hash_agg_with_aliased_grouping_key_in_result_expr(kudo_enabled):
     assert_gpu_and_cpu_are_equal_collect(
         do_it,
         conf={
-            kudo_enabled_conf_key: kudo_enabled,
             "spark.sql.adaptive.enabled": "true"
         }
     )

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -101,8 +101,6 @@ _hash_join_conf = {'spark.sql.autoBroadcastJoinThreshold': '160',
                    'spark.sql.shuffle.partitions': '2',
                   }
 
-kudo_enabled_conf_key = "spark.rapids.shuffle.kudo.serializer.enabled"
-
 def create_df(spark, data_gen, left_length, right_length, num_slices=None):
     left = binary_op_df(spark, data_gen, length=left_length, num_slices=num_slices)
     right = binary_op_df(spark, data_gen, length=right_length, num_slices=num_slices).withColumnRenamed("a", "r_a")\
@@ -132,88 +130,76 @@ def join_batch_size_test_params(*args):
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/11100
 @allow_non_gpu('EmptyRelationExec')
-def test_right_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled, kudo_enabled):
+def test_right_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(broadcast(right), how=join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         "spark.sql.adaptive.enabled": aqe_enabled,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/11100
 @allow_non_gpu('EmptyRelationExec')
-def test_left_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled, kudo_enabled):
+def test_left_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 0, 50)
         return left.join(broadcast(right), how=join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         "spark.sql.adaptive.enabled": aqe_enabled,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/11100
 @allow_non_gpu('EmptyRelationExec')
-def test_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled, kudo_enabled):
+def test_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 0, 0)
         return left.join(broadcast(right), how=join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         "spark.sql.adaptive.enabled": aqe_enabled,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/11100
 @allow_non_gpu('EmptyRelationExec')
-def test_right_broadcast_nested_loop_join_without_condition_empty_small_batch(join_type, kudo_enabled):
+def test_right_broadcast_nested_loop_join_without_condition_empty_small_batch(join_type):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(broadcast(right), how=join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.sql.adaptive.enabled': 'true',
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/11100
 @allow_non_gpu('EmptyRelationExec')
-def test_empty_broadcast_hash_join(join_type, kudo_enabled):
+def test_empty_broadcast_hash_join(join_type):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(right.hint("broadcast"), left.a == right.r_a, join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.sql.adaptive.enabled': 'true',
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/11100
 @allow_non_gpu('EmptyRelationExec')
-def test_broadcast_hash_join_constant_keys(join_type, kudo_enabled):
+def test_broadcast_hash_join_constant_keys(join_type):
     def do_join(spark):
         left = spark.range(10).withColumn("s", lit(1))
         right = spark.range(10000).withColumn("r_s", lit(1))
         return left.join(right.hint("broadcast"), left.s == right.r_s, join_type)
     assert_gpu_and_cpu_row_counts_equal(do_join, conf={
         'spark.sql.adaptive.enabled': 'true',
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 
@@ -224,14 +210,12 @@ def test_broadcast_hash_join_constant_keys(join_type, kudo_enabled):
     (all_gen, '1g'),
     (join_small_batch_gens, '1000')), ids=idfn)
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sortmerge_join(data_gen, join_type, batch_size, kudo_enabled):
+def test_sortmerge_join(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 500)
         return left.join(right, left.a == right.r_a, join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
@@ -239,13 +223,11 @@ def test_sortmerge_join(data_gen, join_type, batch_size, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sortmerge_join_ridealong(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_ridealong(data_gen, join_type):
     def do_join(spark):
         left, right = create_ridealong_df(spark, short_gen, data_gen, 500, 500)
         return left.join(right, left.key == right.r_key, join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
@@ -258,13 +240,11 @@ def test_sortmerge_join_ridealong(data_gen, join_type, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', single_level_array_gens + [binary_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sortmerge_join_wrong_key_fallback(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_wrong_key_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 500)
         return left.join(right, left.a == right.r_a, join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_fallback_collect(do_join, 'SortMergeJoinExec', conf=conf)
@@ -289,12 +269,10 @@ def hash_join_ridealong(data_gen, join_type, confs):
 @pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
 @pytest.mark.parametrize('join_type', all_non_sized_join_types, ids=idfn)
 @pytest.mark.parametrize('sub_part_enabled', ['false', 'true'], ids=['SubPartition_OFF', 'SubPartition_ON'])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_join_ridealong_non_sized(data_gen, join_type, sub_part_enabled, kudo_enabled):
+def test_hash_join_ridealong_non_sized(data_gen, join_type, sub_part_enabled):
     confs = {
         "spark.rapids.sql.test.subPartitioning.enabled": sub_part_enabled,
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # Disable AQE as it can change the query plan
     }
     hash_join_ridealong(data_gen, join_type, confs)
@@ -303,12 +281,10 @@ def test_hash_join_ridealong_non_sized(data_gen, join_type, sub_part_enabled, ku
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
 @pytest.mark.parametrize('join_type', all_symmetric_sized_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_join_ridealong_symmetric(data_gen, join_type, kudo_enabled):
+def test_hash_join_ridealong_symmetric(data_gen, join_type):
     confs = {
         "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # Disable AQE as it can change the query plan
     }
     hash_join_ridealong(data_gen, join_type, confs)
@@ -317,12 +293,10 @@ def test_hash_join_ridealong_symmetric(data_gen, join_type, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
 @pytest.mark.parametrize('join_type', all_asymmetric_sized_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_join_ridealong_asymmetric(data_gen, join_type, kudo_enabled):
+def test_hash_join_ridealong_asymmetric(data_gen, join_type):
     confs = {
         "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # Disable AQE as it can change the query plan
     }
     hash_join_ridealong(data_gen, join_type, confs)
@@ -350,13 +324,11 @@ def hash_join_side_is_build_side(data_gen, join_type, confs):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_nested_gens + [decimal_gen_128bit], ids=idfn)
 @pytest.mark.parametrize('join_type', all_asymmetric_sized_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_join_side_is_build_side_asymmetric(data_gen, join_type, kudo_enabled):
+def test_hash_join_side_is_build_side_asymmetric(data_gen, join_type):
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
     confs = {
         "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false'
     }
     hash_join_side_is_build_side(data_gen, join_type, confs)
@@ -399,14 +371,13 @@ def test_hash_join_side_is_build_side_basic(join_type):
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_right_table(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_right_table(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right), left.a == right.r_a, join_type)
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
-    conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'}
+    conf = {'spark.sql.adaptive.enabled': 'false'}
     assert_gpu_and_cpu_are_equal_collect(do_join, conf = conf)
 
 @ignore_order(local=True)
@@ -465,15 +436,13 @@ def test_broadcast_nested_loop_join_degen_left_outer_stream_no_columns(a_val):
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_right_table_ridealong(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_right_table_ridealong(data_gen, join_type):
     def do_join(spark):
         left, right = create_ridealong_df(spark, short_gen, data_gen, 500, 500)
         return left.join(broadcast(right), left.key == right.r_key, join_type)
 
-    conf = {kudo_enabled_conf_key: kudo_enabled}
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -482,16 +451,14 @@ def test_broadcast_join_right_table_ridealong(data_gen, join_type, kudo_enabled)
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_right_table_with_job_group(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_right_table_with_job_group(data_gen, join_type):
     with_cpu_session(lambda spark : spark.sparkContext.setJobGroup("testjob1", "test", False))
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right), left.a == right.r_a, join_type)
 
-    conf = {kudo_enabled_conf_key: kudo_enabled,
-            'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
+    conf = {'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
             }
     assert_gpu_and_cpu_are_equal_collect(do_join, conf = conf)
 
@@ -536,15 +503,13 @@ def test_empty_right_outer_side_with_limit(std_input_path):
 @pytest.mark.parametrize('data_gen,batch_size', join_batch_size_test_params(
     (all_gen + basic_nested_gens, '1g'),
     (join_small_batch_gens + [basic_struct_gen, ArrayGen(string_gen)], '100')), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_cartesian_join(data_gen, batch_size, kudo_enabled):
+def test_cartesian_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(right)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -554,14 +519,12 @@ def test_cartesian_join(data_gen, batch_size, kudo_enabled):
 @pytest.mark.xfail(condition=is_databricks_runtime(),
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_cartesian_join_special_case_count(batch_size, kudo_enabled):
+def test_cartesian_join_special_case_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(right).selectExpr('COUNT(*)')
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -571,14 +534,12 @@ def test_cartesian_join_special_case_count(batch_size, kudo_enabled):
 @pytest.mark.xfail(condition=is_databricks_runtime(),
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_cartesian_join_special_case_group_by_count(batch_size, kudo_enabled):
+def test_cartesian_join_special_case_group_by_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(right).groupBy('a').count()
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -588,9 +549,8 @@ def test_cartesian_join_special_case_group_by_count(batch_size, kudo_enabled):
 @pytest.mark.parametrize('data_gen,batch_size', join_batch_size_test_params(
     (all_gen, '1g'),
     (join_small_batch_gens, '100')), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_cartesian_join_with_condition(data_gen, batch_size, kudo_enabled):
+def test_cartesian_join_with_condition(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294
@@ -600,7 +560,6 @@ def test_cartesian_join_with_condition(data_gen, batch_size, kudo_enabled):
         return left.join(right, left.b >= right.r_b, "cross")
     conf = copy_and_update(_sortmerge_join_conf, {
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
@@ -610,29 +569,25 @@ def test_cartesian_join_with_condition(data_gen, batch_size, kudo_enabled):
 @pytest.mark.parametrize('data_gen,batch_size', join_batch_size_test_params(
     (all_gen + basic_nested_gens, '1g'),
     (join_small_batch_gens, '100')), ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_nested_loop_join(data_gen, batch_size, kudo_enabled):
+def test_broadcast_nested_loop_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right))
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_nested_loop_join_special_case_count(batch_size, kudo_enabled):
+def test_broadcast_nested_loop_join_special_case_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(broadcast(right)).selectExpr('COUNT(*)')
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -641,14 +596,12 @@ def test_broadcast_nested_loop_join_special_case_count(batch_size, kudo_enabled)
 @pytest.mark.xfail(condition=is_databricks_runtime(),
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_nested_loop_join_special_case_group_by_count(batch_size, kudo_enabled):
+def test_broadcast_nested_loop_join_special_case_group_by_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(broadcast(right)).groupBy('a').count()
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -658,9 +611,8 @@ def test_broadcast_nested_loop_join_special_case_group_by_count(batch_size, kudo
     (join_ast_gen, '1g'),
     ([int_gen], 100)), ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti', 'Cross'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_right_broadcast_nested_loop_join_with_ast_condition(data_gen, join_type, batch_size, kudo_enabled):
+def test_right_broadcast_nested_loop_join_with_ast_condition(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294
@@ -670,16 +622,14 @@ def test_right_broadcast_nested_loop_join_with_ast_condition(data_gen, join_type
         return left.join(broadcast(right), (left.b >= right.r_b), join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.rapids.sql.batchSizeBytes': batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', join_ast_gen, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_left_broadcast_nested_loop_join_with_ast_condition(data_gen, kudo_enabled):
+def test_left_broadcast_nested_loop_join_with_ast_condition(data_gen):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294
@@ -687,15 +637,14 @@ def test_left_broadcast_nested_loop_join_with_ast_condition(data_gen, kudo_enabl
         # but these take a long time to verify so we run with smaller numbers by default
         # that do not expose the error
         return broadcast(left).join(right, (left.b >= right.r_b), 'Right')
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [IntegerGen(), LongGen(), pytest.param(FloatGen(), marks=[incompat]), pytest.param(DoubleGen(), marks=[incompat])], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Cross'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_nested_loop_join_with_condition_post_filter(data_gen, join_type, kudo_enabled):
+def test_broadcast_nested_loop_join_with_condition_post_filter(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294
@@ -704,15 +653,14 @@ def test_broadcast_nested_loop_join_with_condition_post_filter(data_gen, join_ty
         # that do not expose the error
         # AST does not support cast or logarithm yet, so this must be implemented as a post-filter
         return left.join(broadcast(right), left.a > f.log(right.r_a), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [IntegerGen(), LongGen(), pytest.param(FloatGen(), marks=[incompat]), pytest.param(DoubleGen(), marks=[incompat])], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Cross', 'Left', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 # https://github.com/NVIDIA/spark-rapids/issues/12700
 @disable_ansi_mode
-def test_broadcast_nested_loop_join_with_condition(data_gen, join_type, kudo_enabled):
+def test_broadcast_nested_loop_join_with_condition(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # AST does not support cast or logarithm yet which is supposed to be extracted into child
@@ -725,22 +673,19 @@ def test_broadcast_nested_loop_join_with_condition(data_gen, join_type, kudo_ena
         return left.join(broadcast(right), f.round(left.a).cast('integer') > f.round(f.log(right.r_a).cast('integer')), join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         "spark.rapids.sql.castFloatToIntegralTypes.enabled": True,
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 @allow_non_gpu('BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'Cast', 'GreaterThan', 'Log')
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [IntegerGen(), LongGen(), pytest.param(FloatGen(), marks=[incompat]), pytest.param(DoubleGen(), marks=[incompat])], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_nested_loop_join_with_condition_fallback(data_gen, join_type, kudo_enabled):
+def test_broadcast_nested_loop_join_with_condition_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # AST does not support double type which is not split-able into child nodes.
         return broadcast(left).join(right, left.a > f.log(right.r_a), join_type)
     assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec',
-                                conf = {kudo_enabled_conf_key: kudo_enabled,
-                                        # disable AQE as it can change the join type
+                                conf = {# disable AQE as it can change the join type
                                         "spark.sql.adaptive.enabled": "false"})
 
 @ignore_order(local=True)
@@ -748,23 +693,21 @@ def test_broadcast_nested_loop_join_with_condition_fallback(data_gen, join_type,
                                       float_gen, double_gen,
                                       string_gen, boolean_gen, date_gen, timestamp_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_nested_loop_join_with_array_contains(data_gen, join_type, kudo_enabled):
+def test_broadcast_nested_loop_join_with_array_contains(data_gen, join_type):
     arr_gen = ArrayGen(data_gen)
     literal = with_cpu_session(lambda spark: gen_scalar(data_gen))
     def do_join(spark):
         left, right = create_df(spark, arr_gen, 50, 25)
         # Array_contains will be pushed down into project child nodes
         return broadcast(left).join(right, array_contains(left.a, literal.cast(data_gen.data_type)) < array_contains(right.r_a, literal.cast(data_gen.data_type)))
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_right_broadcast_nested_loop_join_condition_missing(data_gen, join_type, kudo_enabled):
+def test_right_broadcast_nested_loop_join_condition_missing(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294
@@ -776,16 +719,14 @@ def test_right_broadcast_nested_loop_join_condition_missing(data_gen, join_type,
         return left.join(broadcast(right), how=join_type).distinct()
     assert_gpu_and_cpu_are_equal_collect(
         do_join,
-        conf = {kudo_enabled_conf_key: kudo_enabled,
-                'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
+        conf = {'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
                 })
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Right'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_left_broadcast_nested_loop_join_condition_missing(data_gen, join_type, kudo_enabled):
+def test_left_broadcast_nested_loop_join_condition_missing(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294
@@ -795,57 +736,49 @@ def test_left_broadcast_nested_loop_join_condition_missing(data_gen, join_type, 
         # Compute the distinct of the join result to verify the join produces a proper dataframe
         # for downstream processing.
         return broadcast(left).join(right, how=join_type).distinct()
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens + [binary_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_right_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type, kudo_enabled):
+def test_right_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.join(broadcast(right), how=join_type).selectExpr('COUNT(*)')
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled,
-                                                          'spark.sql.adaptive.enabled': 'false'
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {'spark.sql.adaptive.enabled': 'false'
                                                           })
 
 @pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens + [binary_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Right'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_left_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type, kudo_enabled):
+def test_left_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return broadcast(left).join(right, how=join_type).selectExpr('COUNT(*)')
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @allow_non_gpu('BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'GreaterThanOrEqual', *non_utc_allow)
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['LeftOuter', 'LeftSemi', 'LeftAnti', 'FullOuter'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_nested_loop_join_with_conditionals_build_left_fallback(data_gen, join_type,
-                                                                          kudo_enabled):
+def test_broadcast_nested_loop_join_with_conditionals_build_left_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return broadcast(left).join(right, (left.b >= right.r_b), join_type)
     assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec',
-                                conf = {kudo_enabled_conf_key: kudo_enabled,
-                                        'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
+                                conf = {'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
                                         })
 
 @allow_non_gpu('BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'GreaterThanOrEqual', *non_utc_allow)
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['RightOuter', 'FullOuter'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_nested_loop_with_conditionals_build_right_fallback(data_gen, join_type, kudo_enabled):
+def test_broadcast_nested_loop_with_conditionals_build_right_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.join(broadcast(right), (left.b >= right.r_b), join_type)
-    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec',
-                                conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec')
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -857,14 +790,13 @@ def test_broadcast_nested_loop_with_conditionals_build_right_fallback(data_gen, 
 # Specify 200 shuffle partitions to test cases where streaming side is empty
 # as in https://github.com/NVIDIA/spark-rapids/issues/7516
 @pytest.mark.parametrize('shuffle_conf', [{}, {'spark.sql.shuffle.partitions': 200}], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_left_table(data_gen, join_type, shuffle_conf, kudo_enabled):
+def test_broadcast_join_left_table(data_gen, join_type, shuffle_conf):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 250, 500)
         return broadcast(left).join(right, left.a == right.r_a, join_type)
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
-    conf = copy_and_update(shuffle_conf, {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+    conf = copy_and_update(shuffle_conf, {'spark.sql.adaptive.enabled': 'false'})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -872,15 +804,14 @@ def test_broadcast_join_left_table(data_gen, join_type, shuffle_conf, kudo_enabl
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', join_ast_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO_ON", "KUDO_OFF"])
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_with_conditionals(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_with_conditionals(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right),
                    (left.a == right.r_a) & (left.b >= right.r_b), join_type)
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {'spark.sql.adaptive.enabled': 'false'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -888,8 +819,7 @@ def test_broadcast_join_with_conditionals(data_gen, join_type, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [long_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_join_with_condition_ast_op_fallback(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_with_condition_ast_op_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # AST does not support cast or logarithm yet
@@ -897,7 +827,7 @@ def test_broadcast_join_with_condition_ast_op_fallback(data_gen, join_type, kudo
                          (left.a == right.r_a) & (left.b > f.log(right.r_b)), join_type)
     exec = 'SortMergeJoinExec' if join_type in ['Right', 'FullOuter'] else 'BroadcastHashJoinExec'
     # Disable AQE as it changes the query plan
-    assert_gpu_fallback_collect(do_join, exec, conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+    assert_gpu_fallback_collect(do_join, exec, conf = {'spark.sql.adaptive.enabled': 'false'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -905,8 +835,7 @@ def test_broadcast_join_with_condition_ast_op_fallback(data_gen, join_type, kudo
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', join_no_ast_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_join_with_condition_ast_type_fallback(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_with_condition_ast_type_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # AST does not support cast or logarithm yet
@@ -914,23 +843,21 @@ def test_broadcast_join_with_condition_ast_type_fallback(data_gen, join_type, ku
                          (left.a == right.r_a) & (left.b > right.r_b), join_type)
     exec = 'SortMergeJoinExec' if join_type in ['Right', 'FullOuter'] else 'BroadcastHashJoinExec'
     # Disable AQE as it changes the query plan
-    assert_gpu_fallback_collect(do_join, exec, conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+    assert_gpu_fallback_collect(do_join, exec, conf = {'spark.sql.adaptive.enabled': 'false'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', join_no_ast_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Cross'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_join_with_condition_post_filter(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_with_condition_post_filter(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right),
                          (left.a == right.r_a) & (left.b > right.r_b), join_type)
     assert_gpu_and_cpu_are_equal_collect(
         do_join,
-        conf = {kudo_enabled_conf_key: kudo_enabled,
-                'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
+        conf = {'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
                 })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -938,14 +865,12 @@ def test_broadcast_join_with_condition_post_filter(data_gen, join_type, kudo_ena
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', join_ast_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO_ON", "KUDO_OFF"])
 @allow_non_gpu(*non_utc_allow)
-def test_sortmerge_join_with_condition_ast(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_with_condition_ast(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(right, (left.a == right.r_a) & (left.b >= right.r_b), join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
@@ -956,14 +881,12 @@ def test_sortmerge_join_with_condition_ast(data_gen, join_type, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [long_gen], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sortmerge_join_with_condition_ast_op_fallback(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_with_condition_ast_op_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         # AST does not support cast or logarithm yet
         return left.join(right, (left.a == right.r_a) & (left.b > f.log(right.r_b)), join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_fallback_collect(do_join, 'SortMergeJoinExec', conf=conf)
@@ -974,13 +897,11 @@ def test_sortmerge_join_with_condition_ast_op_fallback(data_gen, join_type, kudo
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', join_no_ast_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'FullOuter', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sortmerge_join_with_condition_ast_type_fallback(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_with_condition_ast_type_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(right, (left.a == right.r_a) & (left.b > right.r_b), join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_fallback_collect(do_join, 'SortMergeJoinExec', conf=conf)
@@ -994,23 +915,21 @@ _mixed_df2_with_nulls = [('a', RepeatSeqGen(LongGen(nullable=(True, 20.0)), leng
 
 @ignore_order
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'FullOuter', 'Cross'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_join_mixed(join_type, kudo_enabled):
+def test_broadcast_join_mixed(join_type):
     def do_join(spark):
         left = gen_df(spark, _mixed_df1_with_nulls, length=500)
         right = gen_df(spark, _mixed_df2_with_nulls, length=500).withColumnRenamed("a", "r_a")\
                 .withColumnRenamed("b", "r_b").withColumnRenamed("c", "r_c")
         return left.join(broadcast(right), left.a.eqNullSafe(right.r_a), join_type)
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf={kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.sql.adaptive.enabled': 'false'})
 
 @ignore_order
 @allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.xfail(condition=is_emr_runtime(),
     reason='https://github.com/NVIDIA/spark-rapids/issues/821')
 @pytest.mark.parametrize('repartition', ["true", "false"], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_join_bucketed_table(repartition, spark_tmp_table_factory, kudo_enabled):
+def test_join_bucketed_table(repartition, spark_tmp_table_factory):
     def do_join(spark):
         table_name = spark_tmp_table_factory.get()
         data = [("http://fooblog.com/blog-entry-116.html", "https://fooblog.com/blog-entry-116.html"),
@@ -1027,7 +946,6 @@ def test_join_bucketed_table(repartition, spark_tmp_table_factory, kudo_enabled)
                 return testurls.join(resolved, "Url", "inner")
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={
         'spark.sql.autoBroadcastJoinThreshold': '-1',
-        kudo_enabled_conf_key: kudo_enabled
     })
 
 
@@ -1077,9 +995,8 @@ def test_bucket_join_io_precache(spark_tmp_table_factory, join_type, aqe_enabled
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize('cache_side', ['cache_left', 'cache_right'], ids=idfn)
 @pytest.mark.parametrize('cpu_side', ['cache', 'not_cache'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @disable_ansi_mode
-def test_half_cache_join(join_type, cache_side, cpu_side, kudo_enabled):
+def test_half_cache_join(join_type, cache_side, cpu_side):
     left_gen = [('a', SetValuesGen(LongType(), range(500))), ('b', IntegerGen())]
     right_gen = [('r_a', SetValuesGen(LongType(), range(500))), ('c', LongGen())]
     def do_join(spark):
@@ -1113,7 +1030,6 @@ def test_half_cache_join(join_type, cache_side, cpu_side, kudo_enabled):
     # we tell it to, this is just to be safe
     assert_gpu_and_cpu_are_equal_collect(do_join, {
         'spark.sql.autoBroadcastJoinThreshold': '1',
-        'spark.rapids.shuffle.kudo.serializer.enabled': kudo_enabled
     })
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -1121,14 +1037,12 @@ def test_half_cache_join(join_type, cache_side, cpu_side, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', struct_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Left', 'Right', 'Cross', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_sortmerge_join_struct_as_key(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_struct_as_key(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(right, left.a == right.r_a, join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
@@ -1138,15 +1052,13 @@ def test_sortmerge_join_struct_as_key(data_gen, join_type, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', struct_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Left', 'Right', 'Cross', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_sortmerge_join_struct_mixed_key(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_struct_mixed_key(data_gen, join_type):
     def do_join(spark):
         left = two_col_df(spark, data_gen, int_gen, length=500)
         right = two_col_df(spark, data_gen, int_gen, length=500)
         return left.join(right, (left.a == right.a) & (left.b == right.b), join_type)
     conf = copy_and_update(_sortmerge_join_conf, {
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
@@ -1156,9 +1068,8 @@ def test_sortmerge_join_struct_mixed_key(data_gen, join_type, kudo_enabled):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', struct_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Left', 'Right', 'Cross', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_sortmerge_join_struct_mixed_key_with_null_filter(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_struct_mixed_key_with_null_filter(data_gen, join_type):
     def do_join(spark):
         left = two_col_df(spark, data_gen, int_gen, length=500)
         right = two_col_df(spark, data_gen, int_gen, length=500)
@@ -1166,7 +1077,6 @@ def test_sortmerge_join_struct_mixed_key_with_null_filter(data_gen, join_type, k
     # Disable constraintPropagation to test null filter on built table with nullable structures.
     # Disable AQE as it can change the join type
     conf = {'spark.sql.constraintPropagation.enabled': 'false',
-            'spark.rapids.shuffle.kudo.serializer.enabled': kudo_enabled,
             'spark.sql.adaptive.enabled': 'false',
             **_sortmerge_join_conf}
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
@@ -1176,29 +1086,27 @@ def test_sortmerge_join_struct_mixed_key_with_null_filter(data_gen, join_type, k
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', struct_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Left', 'Right', 'Cross', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_right_struct_as_key(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_right_struct_as_key(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right), left.a == right.r_a, join_type)
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {'spark.sql.adaptive.enabled': 'false'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', struct_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Left', 'Right', 'Cross', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_broadcast_join_right_struct_mixed_key(data_gen, join_type, kudo_enabled):
+def test_broadcast_join_right_struct_mixed_key(data_gen, join_type):
     def do_join(spark):
         left = two_col_df(spark, data_gen, int_gen, length=500)
         right = two_col_df(spark, data_gen, int_gen, length=250)
         return left.join(broadcast(right), (left.a == right.a) & (left.b == right.b), join_type)
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {'spark.sql.adaptive.enabled': 'false'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -1206,13 +1114,12 @@ def test_broadcast_join_right_struct_mixed_key(data_gen, join_type, kudo_enabled
 @pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/2140')
 @pytest.mark.parametrize('data_gen', [basic_struct_gen_with_floats], ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Left', 'Right', 'Cross', 'LeftSemi', 'LeftAnti'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sortmerge_join_struct_with_floats_key(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_struct_with_floats_key(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(right, left.a == right.r_a, join_type)
     conf = copy_and_update(_sortmerge_join_conf,
-                           {kudo_enabled_conf_key: kudo_enabled})
+                           {})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 @allow_non_gpu('SortMergeJoinExec', 'SortExec', 'NormalizeNaNAndZero', 'CreateNamedStruct',
@@ -1221,21 +1128,18 @@ def test_sortmerge_join_struct_with_floats_key(data_gen, join_type, kudo_enabled
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', struct_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', ['FullOuter'], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_sortmerge_join_struct_as_key_fallback(data_gen, join_type, kudo_enabled):
+def test_sortmerge_join_struct_as_key_fallback(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 500)
         return left.join(right, left.a == right.r_a, join_type)
     conf = copy_and_update(_sortmerge_join_conf,
-                           {kudo_enabled_conf_key: kudo_enabled,
-                            # disable AQE as it can change the join type
+                           {# disable AQE as it can change the join type
                             'spark.sql.adaptive.enabled': 'false'})
     assert_gpu_fallback_collect(do_join, 'SortMergeJoinExec', conf=conf)
 
 # Regression test for https://github.com/NVIDIA/spark-rapids/issues/3775
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_struct_self_join(spark_tmp_table_factory, kudo_enabled):
+def test_struct_self_join(spark_tmp_table_factory):
     def do_join(spark):
         data = [
             (("Adam ", "", "Green"), "1", "M", 1000),
@@ -1262,7 +1166,7 @@ def test_struct_self_join(spark_tmp_table_factory, kudo_enabled):
         resultdf.createOrReplaceTempView(resultdf_name)
         return spark.sql("select a.* from {} a, {} b where a.name=b.name".format(
             resultdf_name, resultdf_name))
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = {kudo_enabled_conf_key: kudo_enabled})
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # ExistenceJoin occurs in the context of existential subqueries (which is rewritten to SemiJoin) if
 # there is an additional condition that may qualify left records even though they don't have
@@ -1282,9 +1186,8 @@ def test_struct_self_join(spark_tmp_table_factory, kudo_enabled):
 ])
 @pytest.mark.parametrize('conditionalJoin', [False, True], ids=['ast:off', 'ast:on'])
 @pytest.mark.parametrize('forceBroadcastHashJoin', [False, True], ids=['broadcastHJ:off', 'broadcastHJ:on'])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_existence_join(numComplementsToExists, aqeEnabled, conditionalJoin,
-                        forceBroadcastHashJoin, spark_tmp_table_factory, kudo_enabled):
+                        forceBroadcastHashJoin, spark_tmp_table_factory):
     leftTable = spark_tmp_table_factory.get()
     rightTable = spark_tmp_table_factory.get()
     def do_join(spark):
@@ -1335,13 +1238,11 @@ def test_existence_join(numComplementsToExists, aqeEnabled, conditionalJoin,
         conf={
             "spark.sql.adaptive.enabled": aqeEnabled,
             "spark.sql.autoBroadcastJoinThreshold": bhjThreshold,
-            kudo_enabled_conf_key: kudo_enabled
         })
 
 @ignore_order
 @pytest.mark.parametrize('aqeEnabled', [True, False], ids=['aqe:on', 'aqe:off'])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_existence_join_in_broadcast_nested_loop_join(spark_tmp_table_factory, aqeEnabled, kudo_enabled):
+def test_existence_join_in_broadcast_nested_loop_join(spark_tmp_table_factory, aqeEnabled):
     left_table_name = spark_tmp_table_factory.get()
     right_table_name = spark_tmp_table_factory.get()
 
@@ -1361,13 +1262,11 @@ def test_existence_join_in_broadcast_nested_loop_join(spark_tmp_table_factory, a
 
     capture_regexp = r"GpuBroadcastNestedLoopJoin ExistenceJoin\(exists#[0-9]+\),"
     assert_cpu_and_gpu_are_equal_collect_with_capture(do_join, capture_regexp,
-                                                      conf={"spark.sql.adaptive.enabled": aqeEnabled,
-                                                            kudo_enabled_conf_key: kudo_enabled})
+                                                      conf={"spark.sql.adaptive.enabled": aqeEnabled})
 
 @ignore_order
 @pytest.mark.parametrize('aqeEnabled', [True, False], ids=['aqe:on', 'aqe:off'])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_degenerate_broadcast_nested_loop_existence_join(spark_tmp_table_factory, aqeEnabled, kudo_enabled):
+def test_degenerate_broadcast_nested_loop_existence_join(spark_tmp_table_factory, aqeEnabled):
     left_table_name = spark_tmp_table_factory.get()
     right_table_name = spark_tmp_table_factory.get()
 
@@ -1387,15 +1286,13 @@ def test_degenerate_broadcast_nested_loop_existence_join(spark_tmp_table_factory
 
     capture_regexp = r"GpuBroadcastNestedLoopJoin ExistenceJoin\(exists#[0-9]+\),"
     assert_cpu_and_gpu_are_equal_collect_with_capture(do_join, capture_regexp,
-                                                      conf={"spark.sql.adaptive.enabled": aqeEnabled,
-                                                            kudo_enabled_conf_key: kudo_enabled})
+                                                      conf={"spark.sql.adaptive.enabled": aqeEnabled})
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [StringGen(), IntegerGen()], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", [True, False], ids=idfn)
 @pytest.mark.parametrize("join_reorder_enabled", [True, False], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_multi_table_hash_join(data_gen, aqe_enabled, join_reorder_enabled, kudo_enabled):
+def test_multi_table_hash_join(data_gen, aqe_enabled, join_reorder_enabled):
     def do_join(spark):
         t1 = binary_op_df(spark, data_gen, length=1000)
         t2 = binary_op_df(spark, data_gen, length=800)
@@ -1407,14 +1304,13 @@ def test_multi_table_hash_join(data_gen, aqe_enabled, join_reorder_enabled, kudo
     conf = copy_and_update(_hash_join_conf, {
         'spark.sql.adaptive.enabled': aqe_enabled,
         'spark.rapids.sql.optimizer.joinReorder.enabled': join_reorder_enabled,
-        kudo_enabled_conf_key: kudo_enabled
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 
 limited_integral_gens = [byte_gen, ShortGen(max_val=BYTE_MAX), IntegerGen(max_val=BYTE_MAX), LongGen(max_val=BYTE_MAX)]
 
-def hash_join_different_key_integral_types(left_gen, right_gen, join_type, kudo_enabled):
+def hash_join_different_key_integral_types(left_gen, right_gen, join_type):
     def do_join(spark):
         left = unary_op_df(spark, left_gen, length=50)
         right = unary_op_df(spark, right_gen, length=500)
@@ -1423,7 +1319,6 @@ def hash_join_different_key_integral_types(left_gen, right_gen, join_type, kudo_
         "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
         "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
         "spark.rapids.sql.test.subPartitioning.enabled": True,
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false' # disable AQE as it can change the join type
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=_all_conf)
@@ -1433,27 +1328,24 @@ def hash_join_different_key_integral_types(left_gen, right_gen, join_type, kudo_
 @pytest.mark.parametrize('left_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('right_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', all_non_sized_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_join_different_key_integral_types_non_sized(left_gen, right_gen, join_type, kudo_enabled):
-    hash_join_different_key_integral_types(left_gen, right_gen, join_type, kudo_enabled)
+def test_hash_join_different_key_integral_types_non_sized(left_gen, right_gen, join_type):
+    hash_join_different_key_integral_types(left_gen, right_gen, join_type)
 
 @validate_execs_in_gpu_plan('GpuShuffledSymmetricHashJoinExec')
 @ignore_order(local=True)
 @pytest.mark.parametrize('left_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('right_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', all_symmetric_sized_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_join_different_key_integral_types_symmetric(left_gen, right_gen, join_type, kudo_enabled):
-    hash_join_different_key_integral_types(left_gen, right_gen, join_type, kudo_enabled)
+def test_hash_join_different_key_integral_types_symmetric(left_gen, right_gen, join_type):
+    hash_join_different_key_integral_types(left_gen, right_gen, join_type)
 
 @validate_execs_in_gpu_plan('GpuShuffledAsymmetricHashJoinExec')
 @ignore_order(local=True)
 @pytest.mark.parametrize('left_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('right_gen', limited_integral_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', all_asymmetric_sized_join_types, ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_join_different_key_integral_types_asymmetric(left_gen, right_gen, join_type, kudo_enabled):
-    hash_join_different_key_integral_types(left_gen, right_gen, join_type, kudo_enabled)
+def test_hash_join_different_key_integral_types_asymmetric(left_gen, right_gen, join_type):
+    hash_join_different_key_integral_types(left_gen, right_gen, join_type)
 
 
 bloom_filter_confs = {
@@ -1481,10 +1373,8 @@ def check_bloom_filter_join(confs, expected_classes, is_multi_column):
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_bloom_filter_join(batch_size, is_multi_column, kudo_enabled):
-    conf = {"spark.rapids.sql.batchSizeBytes": batch_size,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_bloom_filter_join(batch_size, is_multi_column):
+    conf = {"spark.rapids.sql.batchSizeBytes": batch_size}
     check_bloom_filter_join(confs=conf,
                             expected_classes="GpuBloomFilterMightContain,GpuBloomFilterAggregate",
                             is_multi_column=is_multi_column)
@@ -1494,10 +1384,8 @@ def test_bloom_filter_join(batch_size, is_multi_column, kudo_enabled):
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_bloom_filter_join_cpu_probe(is_multi_column, kudo_enabled):
-    conf = {"spark.rapids.sql.expression.BloomFilterMightContain": "false",
-            kudo_enabled_conf_key: kudo_enabled}
+def test_bloom_filter_join_cpu_probe(is_multi_column):
+    conf = {"spark.rapids.sql.expression.BloomFilterMightContain": "false"}
     check_bloom_filter_join(confs=conf,
                             expected_classes="BloomFilterMightContain,GpuBloomFilterAggregate",
                             is_multi_column=is_multi_column)
@@ -1507,10 +1395,8 @@ def test_bloom_filter_join_cpu_probe(is_multi_column, kudo_enabled):
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_bloom_filter_join_cpu_build(is_multi_column, kudo_enabled):
-    conf = {"spark.rapids.sql.expression.BloomFilterAggregate": "false",
-            kudo_enabled_conf_key: kudo_enabled}
+def test_bloom_filter_join_cpu_build(is_multi_column):
+    conf = {"spark.rapids.sql.expression.BloomFilterAggregate": "false"}
     check_bloom_filter_join(confs=conf,
                             expected_classes="GpuBloomFilterMightContain,BloomFilterAggregate",
                             is_multi_column=is_multi_column)
@@ -1521,10 +1407,8 @@ def test_bloom_filter_join_cpu_build(is_multi_column, kudo_enabled):
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_bloom_filter_join_split_cpu_build(agg_replace_mode, is_multi_column, kudo_enabled):
-    conf = {"spark.rapids.sql.hashAgg.replaceMode": agg_replace_mode,
-            kudo_enabled_conf_key: kudo_enabled}
+def test_bloom_filter_join_split_cpu_build(agg_replace_mode, is_multi_column):
+    conf = {"spark.rapids.sql.hashAgg.replaceMode": agg_replace_mode}
     check_bloom_filter_join(confs=conf,
                             expected_classes="GpuBloomFilterMightContain,BloomFilterAggregate,GpuBloomFilterAggregate",
                             is_multi_column=is_multi_column)
@@ -1532,16 +1416,14 @@ def test_bloom_filter_join_split_cpu_build(agg_replace_mode, is_multi_column, ku
 @ignore_order(local=True)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_bloom_filter_join_with_merge_some_null_filters(spark_tmp_path, kudo_enabled):
+def test_bloom_filter_join_with_merge_some_null_filters(spark_tmp_path):
     data_path1 = spark_tmp_path + "/BLOOM_JOIN_DATA1"
     data_path2 = spark_tmp_path + "/BLOOM_JOIN_DATA2"
     with_cpu_session(lambda spark: spark.range(100000).coalesce(1).write.parquet(data_path1))
     with_cpu_session(lambda spark: spark.range(100000).withColumn("id2", col("id").cast("string"))\
                      .coalesce(1).write.parquet(data_path2))
     confs = copy_and_update(bloom_filter_confs,
-                            {"spark.sql.files.maxPartitionBytes": "1000",
-                             kudo_enabled_conf_key: kudo_enabled})
+                            {"spark.sql.files.maxPartitionBytes": "1000"})
     def do_join(spark):
         left = spark.read.parquet(data_path1)
         right = spark.read.parquet(data_path2)
@@ -1551,8 +1433,7 @@ def test_bloom_filter_join_with_merge_some_null_filters(spark_tmp_path, kudo_ena
 @ignore_order(local=True)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_bloom_filter_join_with_merge_all_null_filters(spark_tmp_path, kudo_enabled):
+def test_bloom_filter_join_with_merge_all_null_filters(spark_tmp_path):
     data_path1 = spark_tmp_path + "/BLOOM_JOIN_DATA1"
     data_path2 = spark_tmp_path + "/BLOOM_JOIN_DATA2"
     with_cpu_session(lambda spark: spark.range(100000).write.parquet(data_path1))
@@ -1564,8 +1445,7 @@ def test_bloom_filter_join_with_merge_all_null_filters(spark_tmp_path, kudo_enab
         return right.filter("cast(id2 as bigint) % 3 = 4").join(left, left.id == right.id, "inner")
     conf = copy_and_update(
         bloom_filter_confs,
-        {kudo_enabled_conf_key: kudo_enabled,
-         'spark.sql.adaptive.enabled': 'false'} # disable AQE as it can change the join type
+        {'spark.sql.adaptive.enabled': 'false'} # disable AQE as it can change the join type
     )
     assert_gpu_and_cpu_are_equal_collect(do_join, conf)
 
@@ -1573,8 +1453,7 @@ def test_bloom_filter_join_with_merge_all_null_filters(spark_tmp_path, kudo_enab
 @ignore_order(local=True)
 @allow_non_gpu("ProjectExec", "FilterExec", "BroadcastHashJoinExec", "ColumnarToRowExec", "BroadcastExchangeExec", "BatchScanExec")
 @pytest.mark.parametrize("disable_build", [True, False])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_hash_join_fix_fallback_by_inputfile(spark_tmp_path, disable_build, kudo_enabled):
+def test_broadcast_hash_join_fix_fallback_by_inputfile(spark_tmp_path, disable_build):
     data_path_parquet = spark_tmp_path + "/parquet"
     data_path_orc = spark_tmp_path + "/orc"
     # The smaller one (orc) will be the build side (a broadcast)
@@ -1605,7 +1484,6 @@ def test_broadcast_hash_join_fix_fallback_by_inputfile(spark_tmp_path, disable_b
         conf={"spark.sql.autoBroadcastJoinThreshold": "10M",
               "spark.sql.sources.useV1SourceList": "",
               "spark.rapids.sql.input." + scan_name: False,
-              kudo_enabled_conf_key: kudo_enabled,
               'spark.sql.adaptive.enabled': 'false'} # disable AQE as it can change the join type
     )
 
@@ -1613,8 +1491,7 @@ def test_broadcast_hash_join_fix_fallback_by_inputfile(spark_tmp_path, disable_b
 @ignore_order(local=True)
 @allow_non_gpu("ProjectExec", "BroadcastNestedLoopJoinExec", "ColumnarToRowExec", "BroadcastExchangeExec", "BatchScanExec")
 @pytest.mark.parametrize("disable_build", [True, False])
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_broadcast_nested_join_fix_fallback_by_inputfile(spark_tmp_path, disable_build, kudo_enabled):
+def test_broadcast_nested_join_fix_fallback_by_inputfile(spark_tmp_path, disable_build):
     data_path_parquet = spark_tmp_path + "/parquet"
     data_path_orc = spark_tmp_path + "/orc"
     # The smaller one (orc) will be the build side (a broadcast)
@@ -1644,18 +1521,15 @@ def test_broadcast_nested_join_fix_fallback_by_inputfile(spark_tmp_path, disable
         conf={"spark.sql.autoBroadcastJoinThreshold": "-1",
               "spark.sql.sources.useV1SourceList": "",
               "spark.rapids.sql.input." + scan_name: False,
-              kudo_enabled_conf_key: kudo_enabled,
               'spark.sql.adaptive.enabled': 'false'} # disable AQE as it can change the join type
     )
 
 @ignore_order(local=True)
 @pytest.mark.parametrize("join_type", ["Inner", "LeftOuter", "RightOuter"], ids=idfn)
 @pytest.mark.parametrize("batch_size", ["500", "1g"], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_distinct_join(join_type, batch_size, kudo_enabled):
+def test_distinct_join(join_type, batch_size):
     join_conf = {
         "spark.rapids.sql.batchSizeBytes": batch_size,
-        kudo_enabled_conf_key: kudo_enabled
     }
     def do_join(spark):
         left_df = spark.range(1024).withColumn("x", f.col("id") + 1)
@@ -1669,16 +1543,14 @@ def test_distinct_join(join_type, batch_size, kudo_enabled):
 @pytest.mark.parametrize("is_right_host_shuffle", [False, True], ids=idfn)
 @pytest.mark.parametrize("is_left_smaller", [False, True], ids=idfn)
 @pytest.mark.parametrize("batch_size", ["1024", "1g"], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_sized_join(join_type, is_left_host_shuffle, is_right_host_shuffle,
-                    is_left_smaller, batch_size, kudo_enabled):
+                    is_left_smaller, batch_size):
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
     join_conf = {
         "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
         "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
         "spark.sql.autoBroadcastJoinThreshold": "1",
         "spark.rapids.sql.batchSizeBytes": batch_size,
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false'
     }
     left_size, right_size = (2048, 1024) if is_left_smaller else (1024, 2048)
@@ -1709,8 +1581,7 @@ def test_sized_join(join_type, is_left_host_shuffle, is_right_host_shuffle,
 @pytest.mark.parametrize("is_left_smaller", [False, True], ids=["LEFT_SMALLER", "RIGHT_SMALLER"])
 @pytest.mark.parametrize("is_ast_supported", [False, True], ids=["AST_OFF", "AST_ON"])
 @pytest.mark.parametrize("batch_size", ["1024", "1g"], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO_ON", "KUDO_OFF"])
-def test_sized_join_conditional(join_type, is_ast_supported, is_left_smaller, batch_size, kudo_enabled):
+def test_sized_join_conditional(join_type, is_ast_supported, is_left_smaller, batch_size):
     if join_type != "Inner" and not is_ast_supported:
         pytest.skip("Only inner joins support a non-AST condition")
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
@@ -1719,7 +1590,6 @@ def test_sized_join_conditional(join_type, is_ast_supported, is_left_smaller, ba
         "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
         "spark.sql.autoBroadcastJoinThreshold": "1",
         "spark.rapids.sql.batchSizeBytes": batch_size,
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false'
     }
     left_size, right_size = (2048, 1024) if is_left_smaller else (1024, 2048)
@@ -1746,16 +1616,14 @@ def test_sized_join_conditional(join_type, is_ast_supported, is_left_smaller, ba
 @pytest.mark.parametrize("is_left_replicated", [False, True], ids=["LEFT_REPLICATED_OFF", "LEFT_REPLICATED_ON"])
 @pytest.mark.parametrize("is_conditional", [False, True], ids=["CONDITIONAL_OFF", "CONDITIONAL_ON"])
 @pytest.mark.parametrize("is_outer_side_small", [False, True], ids=["OUTER_LARGER_SIDE", "OUTER_SMALLER_SIDE"])
-@pytest.mark.parametrize("kudo_enabled", [True, False], ids=["KUDO_ON", "KUDO_OFF"])
 def test_sized_join_high_key_replication(join_type, is_left_replicated, is_conditional,
-                                         is_outer_side_small, kudo_enabled):
+                                         is_outer_side_small):
     # Disable AQE temporarily until https://github.com/NVIDIA/spark-rapids/issues/14319 is resolved.
     join_conf = {
         "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
         "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
         "spark.rapids.sql.join.use"
         "spark.sql.autoBroadcastJoinThreshold": "1",
-        kudo_enabled_conf_key: kudo_enabled,
         'spark.sql.adaptive.enabled': 'false'
     }
     left_size, right_size = (30000, 40000)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -1622,7 +1622,6 @@ def test_sized_join_high_key_replication(join_type, is_left_replicated, is_condi
     join_conf = {
         "spark.rapids.sql.join.useShuffledSymmetricHashJoin": "true",
         "spark.rapids.sql.join.useShuffledAsymmetricHashJoin": "true",
-        "spark.rapids.sql.join.use"
         "spark.sql.autoBroadcastJoinThreshold": "1",
         'spark.sql.adaptive.enabled': 'false'
     }

--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -57,8 +57,6 @@ map_gens = [simple_string_to_string_map_gen,
 struct_of_maps = StructGen([['child0', BooleanGen()]] + [
     ['child%d' % (i + 1), gen] for i, gen in enumerate(map_gens)])
 
-kudo_enabled_conf_key = "spark.rapids.shuffle.kudo.serializer.enabled"
-
 @pytest.mark.parametrize('data_gen', [pytest.param((StructGen([['child0', DecimalGen(7, 2)]]),
                                                     StructGen([['child1', IntegerGen()]]))),
                                       # left_struct(child0 = 4 level nested struct, child1 = Int)
@@ -80,13 +78,11 @@ kudo_enabled_conf_key = "spark.rapids.shuffle.kudo.serializer.enabled"
                                        StructGen([['child1', MapGen(BooleanGen(nullable=False), boolean_gen)]], nullable=False))], ids=idfn)
 # This tests the union of DF of structs with different types of cols as long as the struct itself
 # isn't null. This is a limitation in cudf because we don't support nested types as literals
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_union_struct_missing_children(data_gen, kudo_enabled):
+def test_union_struct_missing_children(data_gen):
     left_gen, right_gen = data_gen
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : binary_op_df(spark, left_gen).unionByName(binary_op_df(
-            spark, right_gen), True),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            spark, right_gen), True))
 
 @pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
@@ -94,11 +90,9 @@ def test_union_struct_missing_children(data_gen, kudo_enabled):
                                       nested_struct,
                                       struct_of_maps], ids=idfn)
 # This tests union of two DFs of two cols each. The types of the left col and right col is the same
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_union(data_gen, kudo_enabled):
+def test_union(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).union(binary_op_df(spark, data_gen)),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            lambda spark : binary_op_df(spark, data_gen).union(binary_op_df(spark, data_gen)))
 
 @pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
@@ -106,11 +100,9 @@ def test_union(data_gen, kudo_enabled):
                                       nested_struct,
                                       struct_of_maps], ids=idfn)
 # This tests union of two DFs of two cols each. The types of the left col and right col is the same
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_unionAll(data_gen, kudo_enabled):
+def test_unionAll(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).unionAll(binary_op_df(spark, data_gen)),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            lambda spark : binary_op_df(spark, data_gen).unionAll(binary_op_df(spark, data_gen)))
 
 @pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
@@ -122,13 +114,11 @@ def test_unionAll(data_gen, kudo_enabled):
                                       struct_of_maps], ids=idfn)
 # This tests the union of two DFs of structs with missing child column names. The missing child
 # column will be replaced by nulls in the output DF. This is a feature added in 3.1+
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_union_by_missing_col_name(data_gen, kudo_enabled):
+def test_union_by_missing_col_name(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : binary_op_df(spark, data_gen).withColumnRenamed("a", "x")
                                 .unionByName(binary_op_df(spark, data_gen).withColumnRenamed("a",
-                                                                                             "y"), True),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+                                                                                             "y"), True))
 
 
 # the first number ('1' and '2') is the nest level
@@ -144,8 +134,7 @@ nest_2_two = (StructGen([('b', ArrayGen(base_two[0], 1, 1))]), StructGen([('b', 
                                       nest_1_one, nest_1_two,
                                       nest_2_one, nest_2_two])
 @pytest.mark.skipif(is_before_spark_330(), reason="This is supported only in Spark 3.3.0+")
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_union_by_missing_field_name_in_arrays_structs(gen_pair, kudo_enabled):
+def test_union_by_missing_field_name_in_arrays_structs(gen_pair):
     """
     This tests the union of two DFs of arrays of structs with missing field names.
     The missing field will be replaced be nulls in the output DF. This is a feature added in 3.3+
@@ -154,8 +143,7 @@ def test_union_by_missing_field_name_in_arrays_structs(gen_pair, kudo_enabled):
     """
     def assert_union_equal(gen1, gen2):
         assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, gen1).unionByName(unary_op_df(spark, gen2), True),
-            conf = {kudo_enabled_conf_key: kudo_enabled})
+            lambda spark: unary_op_df(spark, gen1).unionByName(unary_op_df(spark, gen2), True))
     
     assert_union_equal(gen_pair[0], gen_pair[1])
     assert_union_equal(gen_pair[1], gen_pair[0])
@@ -167,12 +155,10 @@ def test_union_by_missing_field_name_in_arrays_structs(gen_pair, kudo_enabled):
                                       StructGen([['child0', DecimalGen(7, 2)]]),
                                       nested_struct,
                                       struct_of_maps], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_union_by_name(data_gen, kudo_enabled):
+def test_union_by_name(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).unionByName(binary_op_df(spark,
-                                                                                  data_gen)),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+                                                                                  data_gen)))
 
 
 @pytest.mark.parametrize('data_gen', [
@@ -181,23 +167,19 @@ def test_union_by_name(data_gen, kudo_enabled):
     pytest.param([('array' + str(i), gen) for i, gen in enumerate(array_gens_sample + [ArrayGen(BinaryGen(max_length=5), max_length=5)])]),
     pytest.param([('map' + str(i), gen) for i, gen in enumerate(map_gens_sample)]),
 ], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_coalesce_types(data_gen, kudo_enabled):
+def test_coalesce_types(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: gen_df(spark, data_gen).coalesce(2),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+        lambda spark: gen_df(spark, data_gen).coalesce(2))
 
 @pytest.mark.parametrize('num_parts', [1, 10, 100, 1000, 2000], ids=idfn)
 @pytest.mark.parametrize('length', [0, 2048, 4096], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_coalesce_df(num_parts, length, kudo_enabled):
+def test_coalesce_df(num_parts, length):
     #This should change eventually to be more than just the basic gens
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + [binary_gen])]
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : gen_df(spark, gen_list, length=length).coalesce(num_parts),
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            lambda spark : gen_df(spark, gen_list, length=length).coalesce(num_parts))
 
 @pytest.mark.parametrize('data_gen', [
     pytest.param([('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + [binary_gen])]),
@@ -207,17 +189,15 @@ def test_coalesce_df(num_parts, length, kudo_enabled):
 ], ids=idfn)
 @pytest.mark.parametrize('num_parts', [1, 10, 2345], ids=idfn)
 @pytest.mark.parametrize('length', [0, 2048, 4096], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
 @allow_non_gpu(*non_utc_allow)
-def test_repartition_df(data_gen, num_parts, length, kudo_enabled):
+def test_repartition_df(data_gen, num_parts, length):
     from pyspark.sql.functions import lit
     assert_gpu_and_cpu_are_equal_collect(
             # Add a computed column to avoid shuffle being optimized back to a CPU shuffle
             lambda spark : gen_df(spark, data_gen, length=length).withColumn('x', lit(1)).repartition(num_parts),
             # disable sort before shuffle so round robin works for maps
-            conf = {'spark.sql.execution.sortBeforeRepartition': 'false',
-                    kudo_enabled_conf_key: kudo_enabled})
+            conf = {'spark.sql.execution.sortBeforeRepartition': 'false'})
 
 @pytest.mark.parametrize('data_gen', [
     pytest.param([('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens)]),
@@ -226,37 +206,33 @@ def test_repartition_df(data_gen, num_parts, length, kudo_enabled):
 ], ids=idfn)
 @pytest.mark.parametrize('num_parts', [1, 10, 2345], ids=idfn)
 @pytest.mark.parametrize('length', [0, 2048, 4096], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
 @allow_non_gpu(*non_utc_allow)
-def test_repartition_df_for_round_robin(data_gen, num_parts, length, kudo_enabled):
+def test_repartition_df_for_round_robin(data_gen, num_parts, length):
     from pyspark.sql.functions import lit
     assert_gpu_and_cpu_are_equal_collect(
         # Add a computed column to avoid shuffle being optimized back to a CPU shuffle
         lambda spark : gen_df(spark, data_gen, length=length).withColumn('x', lit(1)).repartition(num_parts),
         # Enable sort for round robin partition
-        conf = {'spark.sql.execution.sortBeforeRepartition': 'true',
-                kudo_enabled_conf_key: kudo_enabled}) # default is true
+        conf = {'spark.sql.execution.sortBeforeRepartition': 'true'}) # default is true
 
 @allow_non_gpu('ShuffleExchangeExec', 'RoundRobinPartitioning')
 @pytest.mark.parametrize('data_gen', [[('a', simple_string_to_string_map_gen)]], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
-def test_round_robin_sort_fallback(data_gen, kudo_enabled):
+def test_round_robin_sort_fallback(data_gen):
     from pyspark.sql.functions import lit
     # Disable AQE as it can change the shuffle type
     assert_gpu_fallback_collect(
             # Add a computed column to avoid shuffle being optimized back to a CPU shuffle like in test_repartition_df
             lambda spark : gen_df(spark, data_gen).withColumn('extra', lit(1)).repartition(13),
             'ShuffleExchangeExec',
-        conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+        conf = {'spark.sql.adaptive.enabled': 'false'})
 
 @allow_non_gpu("ProjectExec", "ShuffleExchangeExec")
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
 @pytest.mark.parametrize('num_parts', [2, 10, 17, 19, 32], ids=idfn)
 @pytest.mark.parametrize('gen', [([('ag', ArrayGen(StructGen([('b1', long_gen)])))], ['ag'])], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_repartition_exact_fallback(gen, num_parts, kudo_enabled):
+def test_hash_repartition_exact_fallback(gen, num_parts):
     data_gen = gen[0]
     part_on = gen[1]
     # Disable AQE as it can change the shuffle type
@@ -267,17 +243,14 @@ def test_hash_repartition_exact_fallback(gen, num_parts, kudo_enabled):
             .selectExpr('*'), "ShuffleExchangeExec",
         # Force to use murmur3
         conf = {'spark.rapids.sql.partitioning.hashFunction.enabled': False,
-                kudo_enabled_conf_key: kudo_enabled,
                 'spark.sql.adaptive.enabled': 'false'})
 
 @allow_non_gpu("ProjectExec")
 @pytest.mark.parametrize('data_gen', [ArrayGen(StructGen([('b1', long_gen)]))], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_hash_fallback(data_gen, kudo_enabled):
+def test_hash_fallback(data_gen):
     assert_gpu_fallback_collect(
         lambda spark : unary_op_df(spark, data_gen, length=1024) \
-            .selectExpr('*', 'hash(a) as h'), "ProjectExec",
-        conf = {kudo_enabled_conf_key: kudo_enabled})
+            .selectExpr('*', 'hash(a) as h'), "ProjectExec")
 
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
 @pytest.mark.parametrize('num_parts', [1, 2, 10, 17, 19, 32], ids=idfn)
@@ -313,9 +286,8 @@ def test_hash_fallback(data_gen, kudo_enabled):
     ([('a', decimal_gen_64bit), ('b', decimal_gen_64bit), ('c', decimal_gen_64bit)], ['a', 'b', 'c']),
     ([('a', decimal_gen_128bit), ('b', decimal_gen_128bit), ('c', decimal_gen_128bit)], ['a', 'b', 'c']),
     ], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_repartition_exact(gen, num_parts, kudo_enabled):
+def test_hash_repartition_exact(gen, num_parts):
     data_gen = gen[0]
     part_on = gen[1]
     # Disable AQE as it can change the shuffle type
@@ -325,7 +297,7 @@ def test_hash_repartition_exact(gen, num_parts, kudo_enabled):
                     .withColumn('id', f.spark_partition_id())\
                     .withColumn('hashed', f.hash(*part_on))\
                     .selectExpr('*', 'pmod(hashed, {})'.format(num_parts)),
-        conf = {kudo_enabled_conf_key: kudo_enabled, 'spark.sql.adaptive.enabled': 'false'})
+        conf = {'spark.sql.adaptive.enabled': 'false'})
 
 
 @ignore_order(local=True)  # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
@@ -349,10 +321,9 @@ def test_hash_repartition_exact_longs_no_overflow(num_parts, is_ansi_mode):
 
 @ignore_order(local=True)  # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
 @pytest.mark.parametrize('num_parts', [17], ids=idfn)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
-def test_hash_repartition_long_overflow_ansi_exception(num_parts, kudo_enabled):
-    conf = copy_and_update(ansi_enabled_conf, {kudo_enabled_conf_key: kudo_enabled})
+def test_hash_repartition_long_overflow_ansi_exception(num_parts):
+    conf = copy_and_update(ansi_enabled_conf, {})
 
     def test_function(spark):
         df = gen_df(spark, [('a', long_gen)], length=1024)
@@ -371,13 +342,11 @@ def test_hash_repartition_long_overflow_ansi_exception(num_parts, kudo_enabled):
 
 # Test a query that should cause Spark to leverage getShuffleRDD
 @ignore_order(local=True)
-@pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
-def test_union_with_filter(kudo_enabled):
+def test_union_with_filter():
     def doit(spark):
         dfa = spark.range(1, 100).withColumn("id2", f.col("id"))
         dfb = dfa.groupBy("id").agg(f.size(f.collect_set("id2")).alias("idc"))
         dfc = dfb.filter(f.col("idc") == 1).select("id")
         return dfc.union(dfc)
-    conf = { "spark.sql.adaptive.enabled": "true",
-             kudo_enabled_conf_key: kudo_enabled}
+    conf = { "spark.sql.adaptive.enabled": "true"}
     assert_gpu_and_cpu_are_equal_collect(doit, conf)


### PR DESCRIPTION
Fixes #13564.

### Description
Kudo is enabled by default
No value to test non-Kudo cases
Drop non-Kudo test to reduce the test time by removing the kudo_enabled parametrize and the kudo_enabled parameter in each case.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required