### PR TITLE
[AutoSparkUT] Fix GpuCast decimal-overflow error to match CPU's CheckOverflow message (#14143)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1487,11 +1487,32 @@ object GpuCast {
 
   def fixDecimalBounds(input: ColumnView,
       outOfBounds: ColumnView,
+      targetType: DecimalType,
       ansiMode: Boolean): ColumnVector = {
     if (ansiMode) {
       withResource(outOfBounds.any()) { isAny =>
         if (isAny.isValid && isAny.getBoolean) {
-          throw RapidsErrorUtils.arithmeticOverflowError(OVERFLOW_MESSAGE)
+          // Match Spark CPU's overflow message format
+          // ("Decimal(expanded, ${value}, ${p}, ${s}) cannot be represented as
+          // Decimal(${p'}, ${s'}). If necessary set ...") instead of a generic
+          // "overflow occurred" — this is what CheckOverflow on CPU produces
+          // and what the Spark UT for SPARK-28067 / SPARK-28224 / SPARK-35955
+          // asserts on. The decimal value's natural precision is preserved
+          // by using Decimal(BigDecimal) — the (value, p, s) constructor would
+          // cap precision at 38 and throw "Decimal precision N exceeds max
+          // precision 38" when the overflow value's BigDecimal precision
+          // exceeds the cuDF storage type's max.
+          // See https://github.com/NVIDIA/spark-rapids/issues/14143
+          val rowId = withResource(outOfBounds.copyToHost()) { hcv =>
+            (0L until outOfBounds.getRowCount)
+              .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
+              .get
+          }
+          val bigDecimalValue = withResource(input.copyToHost()) { hcv =>
+            hcv.getBigDecimal(rowId)
+          }
+          throw RapidsErrorUtils.cannotChangeDecimalPrecisionError(
+            Decimal(bigDecimalValue), targetType)
         }
       }
       input.copyToColumnVector()
@@ -1508,7 +1529,7 @@ object GpuCast {
       ansiMode: Boolean): ColumnVector = {
     assert(input.getType.isDecimalType)
     withResource(DecimalUtil.outOfBounds(input, to)) { outOfBounds =>
-      fixDecimalBounds(input, outOfBounds, ansiMode)
+      fixDecimalBounds(input, outOfBounds, to, ansiMode)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1492,27 +1492,8 @@ object GpuCast {
     if (ansiMode) {
       withResource(outOfBounds.any()) { isAny =>
         if (isAny.isValid && isAny.getBoolean) {
-          // Match Spark CPU's overflow message format
-          // ("Decimal(expanded, ${value}, ${p}, ${s}) cannot be represented as
-          // Decimal(${p'}, ${s'}). If necessary set ...") instead of a generic
-          // "overflow occurred" — this is what CheckOverflow on CPU produces
-          // and what the Spark UT for SPARK-28067 / SPARK-28224 / SPARK-35955
-          // asserts on. The decimal value's natural precision is preserved
-          // by using Decimal(BigDecimal) — the (value, p, s) constructor would
-          // cap precision at 38 and throw "Decimal precision N exceeds max
-          // precision 38" when the overflow value's BigDecimal precision
-          // exceeds the cuDF storage type's max.
-          // See https://github.com/NVIDIA/spark-rapids/issues/14143
-          val rowId = withResource(outOfBounds.copyToHost()) { hcv =>
-            (0L until outOfBounds.getRowCount)
-              .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
-              .get
-          }
-          val bigDecimalValue = withResource(input.copyToHost()) { hcv =>
-            hcv.getBigDecimal(rowId)
-          }
-          throw RapidsErrorUtils.cannotChangeDecimalPrecisionError(
-            Decimal(bigDecimalValue), targetType)
+          throw RoundingErrorUtil.cannotChangeDecimalPrecisionError(
+            input, outOfBounds, targetType)
         }
       }
       input.copyToColumnVector()
@@ -1535,7 +1516,6 @@ object GpuCast {
 
   private def checkNFixDecimalBounds(
       input: ColumnView,
-      fromType: DecimalType,
       toType: DecimalType,
       ansiMode: Boolean,
       originCol: ColumnView): ColumnVector = {
@@ -1545,7 +1525,7 @@ object GpuCast {
         withResource(outOfBounds.any()) { isAny =>
           if (isAny.isValid && isAny.getBoolean) {
             throw RoundingErrorUtil.cannotChangeDecimalPrecisionError(originCol, outOfBounds,
-              fromType, toType)
+              toType)
           }
         }
         input.copyToColumnVector()
@@ -1598,7 +1578,7 @@ object GpuCast {
           // We need to check for out of bound values.
           // The wholeNumberUpcast is obvious why we have to check, but we also have to check it
           // when we rounded, because rounding can add a digit to the effective precision.
-          checkNFixDecimalBounds(rounded, from, to, ansiMode, input)
+          checkNFixDecimalBounds(rounded, to, ansiMode, input)
         } else {
           rounded.incRefCount()
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -1603,7 +1603,7 @@ class SumBinaryFixer(toType: DataType, isAnsi: Boolean)
         }
       }
       withResource(outOfBounds) { _ =>
-        closeOnExcept(GpuCast.fixDecimalBounds(ret, outOfBounds, isAnsi)) { replaced =>
+        closeOnExcept(GpuCast.fixDecimalBounds(ret, outOfBounds, dt, isAnsi)) { replaced =>
           updateState(replaced, Some(outOfBounds))
           replaced
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -243,7 +243,7 @@ case class GpuCeil(child: Expression, outputType: DataType)
             withResource(outOfBounds.any()) { isAny =>
               if (isAny.isValid && isAny.getBoolean) {
                 throw RoundingErrorUtil.cannotChangeDecimalPrecisionError(
-                  input.getBase, outOfBounds, dt, outputType
+                  input.getBase, outOfBounds, outputType
                 )
               }
             }
@@ -319,7 +319,7 @@ case class GpuFloor(child: Expression, outputType: DataType)
             withResource(outOfBounds.any()) { isAny =>
               if (isAny.isValid && isAny.getBoolean) {
                 throw RoundingErrorUtil.cannotChangeDecimalPrecisionError(
-                  input.getBase, outOfBounds, dt, outputType
+                  input.getBase, outOfBounds, outputType
                 )
               }
             }
@@ -870,28 +870,30 @@ object RoundingErrorUtil {
   /**
    * Wrapper of the `cannotChangeDecimalPrecisionError` of RapidsErrorUtils.
    *
+   * Uses `Decimal(BigDecimal)` so the value's natural precision is preserved; the
+   * `(value, p, s)` constructor caps precision at 38 and would itself throw
+   * "Decimal precision N exceeds max precision 38" exactly when the overflow value
+   * already exceeds 38 digits, swallowing the intended overflow message.
+   *
    * @param values A decimal column which contains values that try to cast.
    * @param outOfBounds A boolean column that indicates which value cannot be casted.
    * Users must make sure that there is at least one `true` in this column.
-   * @param fromType The current decimal type.
    * @param toType The type to cast.
    * @param context The error context, default value is "".
    */
   def cannotChangeDecimalPrecisionError(
       values: ColumnView,
       outOfBounds: ColumnView,
-      fromType: DecimalType,
       toType: DecimalType,
       context: String = ""): ArithmeticException = {
-    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
-      (0.toLong until outOfBounds.getRowCount)
+    val rowId = withResource(outOfBounds.copyToHost()) { hcv =>
+      (0L until outOfBounds.getRowCount)
         .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
         .get
     }
-    val value = withResource(values.copyToHost()){hcv =>
-      hcv.getBigDecimal(row_id)
+    val value = withResource(values.getScalarElement(rowId.toInt)) { s =>
+      s.getBigDecimal
     }
-    RapidsErrorUtils.cannotChangeDecimalPrecisionError(
-      Decimal(value, fromType.precision, fromType.scale), toType)
+    RapidsErrorUtils.cannotChangeDecimalPrecisionError(Decimal(value), toType)
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -90,9 +90,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-28441: COUNT bug with attribute ref in subquery input and output with PythonUDF", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14258"))
   enableSuite[RapidsSQLViewSuite]
   enableSuite[RapidsDataFrameSuite]
-    .exclude("SPARK-28224: Aggregate sum big decimal overflow", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14143"))
-    .exclude("SPARK-28067: Aggregate sum should not return wrong results for decimal overflow", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14143"))
-    .exclude("SPARK-35955: Aggregate avg should not return wrong results for decimal overflow", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14143"))
     .exclude("reuse exchange", ADJUST_UT("Replaced by testRapids version that uses GPU class name"))
     .exclude("SPARK-22520: support code generation for large CaseWhen", WONT_FIX_ISSUE("It's a codegen related test, not applicable for GPU"))
     .exclude("Uuid expressions should produce same results at retries in the same DataFrame", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14149"))


### PR DESCRIPTION
Fixes #14143.

### Description

**Problem.** The Spark UTs `SPARK-28224`, `SPARK-28067`, and `SPARK-35955` in `DataFrameSuite` were excluded on GPU because `GpuCast.fixDecimalBounds` threw a generic `SparkArithmeticException("overflow occurred ...")` via `RapidsErrorUtils.arithmeticOverflowError`. CPU's `CheckOverflow` emits `SparkArithmeticException("Decimal(expanded, ${value}, ${p}, ${s}) cannot be represented as Decimal(${p'}, ${s'}). If necessary set ...")`. The tests assert on the message containing `"cannot be represented as Decimal"` or `"Overflow in sum of decimals"` — neither fragment was present in the GPU output.

The same file's `private checkNFixDecimalBounds` (line ~1515) already routed through `RoundingErrorUtil.cannotChangeDecimalPrecisionError`, so the fix also normalizes that shared utility instead of duplicating value extraction in `GpuCast.fixDecimalBounds`.

**Fix.**

1. `GpuCast.fixDecimalBounds` now takes a `targetType: DecimalType` parameter and routes ANSI overflow through `RoundingErrorUtil.cannotChangeDecimalPrecisionError(input, outOfBounds, targetType)` instead of throwing the generic `arithmeticOverflowError`.
2. `RoundingErrorUtil.cannotChangeDecimalPrecisionError` now centralizes the offending-row extraction and error construction. It drops the unused `fromType` parameter, uses `values.getScalarElement(rowId)` for the single failing value, and constructs `Decimal(value)` so values whose natural precision exceeds Spark's `MAX_PRECISION=38` do not trigger a secondary `"Decimal precision N exceeds max precision 38"` exception before the intended CPU-compatible overflow message is thrown.
3. Callers are updated to use the new utility shape: `GpuCast.fixDecimalBounds`, `GpuCast.checkNFixDecimalBounds`, `GpuCeil`, `GpuFloor`, and the window sum path through `GpuWindowExpression`.
4. `RapidsTestSettings.scala` drops the three `#14143` `KNOWN_ISSUE` exclusions — the inherited Spark UTs now run verbatim on GPU.

**Validation.**

`mvn package -pl tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsDataFrameSuite -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 -Drapids.test.gpu.minAllocFraction=0`

```
errors="0" failures="0" tests="202" time="146.638"
```

- `SPARK-28224: Aggregate sum big decimal overflow` — 1.353s, pass
- `SPARK-28067: Aggregate sum should not return wrong results for decimal overflow` — 15.127s, pass
- `SPARK-35955: Aggregate avg should not return wrong results for decimal overflow` — 13.165s, pass

**Cross-shim coverage.** Locally compile-validated with `-Dbuildver=330`, `-Dbuildver=340`, and `-Dbuildver=400`, covering the three error-context type regimes: Spark 3.3.x `String`, Spark 3.4+ `SQLQueryContext`, and Spark 4.0+ `QueryContext`.

**Performance.** Cold path. The new host/scalar extraction runs only on the ANSI overflow error path, immediately before throwing. The fast non-overflow path is unchanged (`outOfBounds.any()` check fires first). Zero impact on the successful aggregation path.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required