### PR TITLE
[AutoSparkUT] Recover ParquetEncodingSuite v2 tests via ADJUST_UT testRapids (#13745, #13746)

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetEncodingSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsParquetEncodingSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,92 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
+import java.math.BigDecimal
+import java.sql.{Date, Timestamp}
+import java.time.{Duration, Period}
+
+import org.apache.parquet.column.ParquetProperties
+import org.apache.parquet.hadoop.ParquetOutputFormat
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.parquet.ParquetEncodingSuite
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.utils.RapidsSQLTestsBaseTrait
 
 class RapidsParquetEncodingSuite
   extends ParquetEncodingSuite
-  with RapidsSQLTestsBaseTrait {}
+  with RapidsSQLTestsBaseTrait {
 
+  // Original: ParquetEncodingSuite.scala (Spark v3.3.0) lines 145-202 / 204-238.
+  // GPU's libcudf parquet writer chooses different but valid Parquet v2
+  // page encodings (PLAIN / RLE / PLAIN_DICTIONARY) than the CPU writer's
+  // (DELTA_BINARY_PACKED / DELTA_BYTE_ARRAY / RLE). Per #13745 / #13746,
+  // the encoding format is an internal optimization detail that does not
+  // affect data correctness; the round-trip data is identical. The
+  // testRapids versions drop the encoding-format assertions and keep the
+  // data-correctness round-trip — what the test actually guarantees about
+  // user-visible behavior.
+  // https://github.com/NVIDIA/spark-rapids/issues/13745
+  // https://github.com/NVIDIA/spark-rapids/issues/13746
+  testRapids("parquet v2 pages - delta encoding") {
+    val extraOptions = Map[String, String](
+      ParquetOutputFormat.WRITER_VERSION ->
+        ParquetProperties.WriterVersion.PARQUET_2_0.toString,
+      ParquetOutputFormat.ENABLE_DICTIONARY -> "false"
+    )
+    Seq("true", "false").foreach { offHeapMode =>
+      withSQLConf(
+        SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key -> offHeapMode,
+        SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true",
+        ParquetOutputFormat.JOB_SUMMARY_LEVEL -> "ALL") {
+        withTempPath { dir =>
+          val path = s"${dir.getCanonicalPath}/test.parquet"
+          val data = (1 to 8193).map { i =>
+            (i,
+              i.toLong, i.toShort, Array[Byte](i.toByte),
+              if (i % 2 == 1) s"test_$i" else null,
+              DateTimeUtils.fromJavaDate(Date.valueOf(s"2021-11-0" + ((i % 9) + 1))),
+              DateTimeUtils.fromJavaTimestamp(
+                Timestamp.valueOf(s"2020-11-01 12:00:0" + (i % 10))),
+              Period.of(1, (i % 11) + 1, 0),
+              Duration.ofMillis(((i % 9) + 1) * 100),
+              new BigDecimal(java.lang.Long.toUnsignedString(i * 100000))
+            )
+          }
+          spark.createDataFrame(data)
+            .write.options(extraOptions).mode("overwrite").parquet(path)
 
+          val actual = spark.read.parquet(path).collect()
+          assert(actual.sortBy(_.getInt(0)) === data.map(Row.fromTuple))
+        }
+      }
+    }
+  }
+
+  testRapids("parquet v2 pages - rle encoding for boolean value columns") {
+    val extraOptions = Map[String, String](
+      ParquetOutputFormat.WRITER_VERSION ->
+        ParquetProperties.WriterVersion.PARQUET_2_0.toString
+    )
+    withSQLConf(
+      SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true",
+      ParquetOutputFormat.JOB_SUMMARY_LEVEL -> "ALL") {
+      withTempPath { dir =>
+        val path = s"${dir.getCanonicalPath}/test.parquet"
+        val size = 10000
+        val data = (1 to size).map { i => (true, false, i % 2 == 1) }
+
+        spark.createDataFrame(data)
+          .write.options(extraOptions).mode("overwrite").parquet(path)
+
+        val actual = spark.read.parquet(path).collect()
+        assert(actual.length == size)
+        assert(actual.map(_.getBoolean(0)).forall(_ == true))
+        assert(actual.map(_.getBoolean(1)).forall(_ == false))
+        val expected = (1 to size).map { i => i % 2 == 1 }
+        assert(actual.map(_.getBoolean(2)).sameElements(expected))
+      }
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -156,8 +156,8 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsParquetDeltaLengthByteArrayEncodingSuite]
   enableSuite[RapidsParquetEncodingSuite]
     .exclude("Read row group containing both dictionary and plain encoded pages", ADJUST_UT("Test uses CPU VectorizedParquetRecordReader directly, not a GPU path. GPU-native mixed encoding test added in PR #13982. See https://github.com/NVIDIA/spark-rapids/issues/13739"))
-    .exclude("parquet v2 pages - delta encoding", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13745"))
-    .exclude("parquet v2 pages - rle encoding for boolean value columns", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13746"))
+    .exclude("parquet v2 pages - delta encoding", ADJUST_UT("Replaced by testRapids version that drops encoding-format assertion. GPU's libcudf parquet writer chooses different but valid Parquet v2 encodings (PLAIN/PLAIN_DICTIONARY) than CPU's DELTA_BINARY_PACKED/DELTA_BYTE_ARRAY; encoding choice is internal optimization that doesn't affect data correctness. See https://github.com/NVIDIA/spark-rapids/issues/13745"))
+    .exclude("parquet v2 pages - rle encoding for boolean value columns", ADJUST_UT("Replaced by testRapids version that drops encoding-format assertion. GPU's libcudf parquet writer uses PLAIN encoding for booleans rather than CPU's RLE; encoding choice is internal optimization that doesn't affect data correctness. See https://github.com/NVIDIA/spark-rapids/issues/13746"))
   enableSuite[RapidsParquetFileFormatSuite]
     .excludeByPrefix("Propagate Hadoop configs from", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11602"))
   enableSuite[RapidsParquetFieldIdIOSuite]


### PR DESCRIPTION
Fixes #13745.
Fixes #13746.

### Description

**Problem.** The Spark UTs `"parquet v2 pages - delta encoding"` and `"parquet v2 pages - rle encoding for boolean value columns"` (both in `ParquetEncodingSuite`) were excluded on GPU because they assert on specific Parquet v2 page encoding strings:

```scala
// delta encoding test
assert(columnChunkMetadataList(0).getEncodings.contains(Encoding.DELTA_BINARY_PACKED))
assert(columnChunkMetadataList(3).getEncodings.contains(Encoding.DELTA_BYTE_ARRAY))
...

// rle boolean test
assert(columnChunkMetadataList.head.getEncodings.contains(Encoding.RLE))
```

GPU's libcudf parquet writer chooses different but valid Parquet v2 encodings — `PLAIN` / `PLAIN_DICTIONARY` for the delta test, and `PLAIN` for booleans instead of `RLE`. Per the upstream issues #13745 / #13746, the encoding format is an internal optimization choice and does not affect data correctness. Both tests already include round-trip data assertions at the end, and that part works on GPU.

**Fix.**

- Add `testRapids` replacements in `RapidsParquetEncodingSuite.scala` that drop the encoding-format assertions and keep the round-trip data check (write the data with `WRITER_VERSION=PARQUET_2_0`, read it back, assert equality). The data is identical to the original; only the format-string assertions are gone.
- Reclassify the exclusions in `RapidsTestSettings.scala` from `KNOWN_ISSUE` → `ADJUST_UT`. The original `bug` framing was a misclassification: the GPU encoding choice is a valid implementation difference, not a defect, and the issue body itself notes "the encoding format is an internal optimization detail that does not affect data correctness."

No production code change.

**Validation.**

`mvn package -pl tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsParquetEncodingSuite -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 -Drapids.test.gpu.minAllocFraction=0`

```
errors="0" failures="0" tests="7" time="31.228"
```

- `Rapids - parquet v2 pages - delta encoding` — 3.441s, pass
- `Rapids - parquet v2 pages - rle encoding for boolean value columns` — 1.052s, pass
- Original CPU variants are correctly skipped per `ADJUST_UT` exclusion.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required