### PR TITLE
[AutoSparkUT] Fix binary host columnar copy for SPARK-33593

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
@@ -179,6 +179,28 @@ public class ColumnarCopyHelper {
     return bytesCopied;
   }
 
+  public static long binaryCopy(ColumnVector cv, RapidsHostColumnBuilder b, int rows) {
+    long bytesCopied = 0L;
+    if (!cv.hasNull()) {
+      for (int i = 0; i < rows; i++) {
+        byte[] value = cv.getBinary(i);
+        b.appendByteList(value);
+        bytesCopied += value.length;
+      }
+      return bytesCopied;
+    }
+    for (int i = 0; i < rows; i++) {
+      if (cv.isNullAt(i)) {
+        bytesCopied += b.appendNull();
+      } else {
+        byte[] value = cv.getBinary(i);
+        b.appendByteList(value);
+        bytesCopied += value.length;
+      }
+    }
+    return bytesCopied;
+  }
+
   public static long decimal32Copy(WritableColumnVector cv, RapidsHostColumnBuilder b, int rows) {
     return intCopy(cv, b, rows);
   }

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
@@ -185,7 +185,7 @@ public class ColumnarCopyHelper {
       for (int i = 0; i < rows; i++) {
         byte[] value = cv.getBinary(i);
         b.appendByteList(value);
-        bytesCopied += value.length;
+        bytesCopied += value.length + Integer.BYTES;
       }
       return bytesCopied;
     }
@@ -195,7 +195,7 @@ public class ColumnarCopyHelper {
       } else {
         byte[] value = cv.getBinary(i);
         b.appendByteList(value);
-        bytesCopied += value.length;
+        bytesCopied += value.length + Integer.BYTES;
       }
     }
     return bytesCopied;

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -144,6 +144,8 @@ object HostColumnarToGpu extends Logging {
         ColumnarCopyHelper.doubleCopy(cv, b, rows)
       case StringType =>
         ColumnarCopyHelper.stringCopy(cv, b, rows)
+      case BinaryType =>
+        ColumnarCopyHelper.binaryCopy(cv, b, rows)
       case dt: DecimalType =>
         cv match {
           case wcv: WritableColumnVector =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HostColumnarToGpuSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HostColumnarToGpuSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.Arm.withResource
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
+import org.apache.spark.sql.types.BinaryType
+
+class HostColumnarToGpuSuite extends AnyFunSuite {
+  test("binary columnar copy counts list offsets for row-limit estimates") {
+    val values = Seq(
+      Array[Byte](1, 2, 3),
+      Array.emptyByteArray,
+      Array[Byte](4, 5))
+
+    val bytesCopied = copyBinaryColumn(values, nullable = false) { actual =>
+      assertBinaryValues(values, actual)
+    }
+
+    assertResult(values.map(_.length + Integer.BYTES).sum)(bytesCopied)
+  }
+
+  test("binary columnar copy handles null and empty values") {
+    val values = Seq(
+      null,
+      Array.emptyByteArray,
+      Array[Byte](10, 11, 12),
+      null,
+      Array[Byte](13))
+
+    copyBinaryColumn(values, nullable = true) { actual =>
+      assertBinaryValues(values, actual)
+    }
+  }
+
+  private def copyBinaryColumn(
+      values: Seq[Array[Byte]],
+      nullable: Boolean)(verify: RapidsHostColumnVector => Unit): Long = {
+    withResource(new OnHeapColumnVector(values.length, BinaryType)) { cv =>
+      values.zipWithIndex.foreach {
+        case (null, index) => cv.putNull(index)
+        case (value, index) => cv.putByteArray(index, value)
+      }
+
+      withResource(new RapidsHostColumnBuilder(
+          GpuColumnVector.convertFrom(BinaryType, nullable), values.length)) { builder =>
+        val bytesCopied = HostColumnarToGpu.columnarCopy(cv, builder, BinaryType, values.length)
+        withResource(new RapidsHostColumnVector(BinaryType, builder.build())) { actual =>
+          verify(actual)
+        }
+        bytesCopied
+      }
+    }
+  }
+
+  private def assertBinaryValues(
+      expected: Seq[Array[Byte]],
+      actual: RapidsHostColumnVector): Unit = {
+    assertResult(expected.length)(actual.getBase.getRowCount)
+    expected.zipWithIndex.foreach {
+      case (null, index) =>
+        assert(actual.isNullAt(index))
+      case (value, index) =>
+        assert(!actual.isNullAt(index))
+        assert(actual.getBinary(index).sameElements(value))
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -226,7 +226,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("Common subexpression elimination", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14106"))
     .exclude("SPARK-27619: When spark.sql.legacy.allowHashOnMapType is true, hash can be used on Maptype", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14108"))
     .exclude("SPARK-31594: Do not display the seed of rand/randn with no argument in output schema", ADJUST_UT("Replaced by testRapids version with a correct regex expression to match the projectExplainOutput, randn isn't supported now. See https://github.com/NVIDIA/spark-rapids/issues/11613"))
-    .exclude("SPARK-33593: Vector reader got incorrect data with binary partition value", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14118"))
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL -- jar contains udf class", ADJUST_UT("Replaced by testRapids version that uses testFile() to access Spark test resources instead of getContextClassLoader"))
     .exclude("SPARK-33482: Fix FileScan canonicalization", ADJUST_UT("Replaced by testRapids version using V1 sources with AQE and broadcast disabled to assert ReusedExchangeExec directly"))
     .exclude("SPARK-36093: RemoveRedundantAliases should not change expression's name", ADJUST_UT("Replaced by testRapids version that checks the partition column name of the GpuInsertIntoHadoopFsRelationCommand"))


### PR DESCRIPTION
Closes #14118

Summary
- Add BinaryType support to HostColumnarToGpu's host columnar copy path.
- Copy binary values into the existing LIST<UINT8> host-column representation via RapidsHostColumnBuilder.appendByteList.
- Recover SQLQuerySuite's SPARK-33593 coverage by removing the known-issue exclusion.

Test traceability
- RAPIDS test: org.apache.spark.sql.rapids.suites.RapidsSQLQuerySuite / SPARK-33593: Vector reader got incorrect data with binary partition value
- Original Spark test: SQLQuerySuite / SPARK-33593: Vector reader got incorrect data with binary partition value
- Spark source: spark/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala:3836-3860

Validation
- Command: mvn package -pl tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsSQLQuerySuite -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 -Drapids.test.gpu.minAllocFraction=0 -s jenkins/settings.xml -P mirror-apache-to-urm
- Result: Tests: succeeded 222, failed 0, canceled 0, ignored 12, pending 0
- Maven: BUILD SUCCESS

Performance impact
- Existing non-binary copy paths are unchanged aside from the new BinaryType match branch.
- BinaryType previously threw during HostColumnarToGpu conversion; the new path copies each row's bytes into the existing LIST<UINT8> builder representation.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
