### PR TITLE
Replace cuDF regex chain in GpuToTimestamp with fused JNI parser

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -591,42 +591,40 @@ object ExceptionTimeParserPolicy extends TimeParserPolicy
 object CorrectedTimeParserPolicy extends TimeParserPolicy
 
 object GpuToTimestamp {
-  import CastStrings.SimpleTimestampFormat._
-
   // We are compatible with Spark for these formats when the timeParserPolicy is CORRECTED
   // or EXCEPTION. It is possible that other formats may be supported but these are the only
   // ones that we have tests for.
   val CORRECTED_COMPATIBLE_FORMATS = Map(
     "yyyy-MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{2}-\d{2}\Z", CORRECTED_YYYY_DASH_MM_DASH_DD),
+      raw"\A\d{4}-\d{2}-\d{2}\Z"),
     "yyyy/MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}\Z", CORRECTED_YYYY_SLASH_MM_SLASH_DD),
+      raw"\A\d{4}/\d{1,2}/\d{1,2}\Z"),
     "yyyy-MM" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{2}\Z", CORRECTED_YYYY_DASH_MM),
+      raw"\A\d{4}-\d{2}\Z"),
     "yyyy/MM" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{2}\Z", CORRECTED_YYYY_SLASH_MM),
+      raw"\A\d{4}/\d{2}\Z"),
     "dd/MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}/\d{4}\Z", CORRECTED_DD_SLASH_MM_SLASH_YYYY),
+      raw"\A\d{2}/\d{2}/\d{4}\Z"),
     "yyyy-MM-dd HH:mm:ss" -> ParseFormatMeta(Option('-'), isTimestamp = true,
-      raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\Z", CORRECTED_YYYY_DASH_MM_DASH_DD_HH_MM_SS),
+      raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\Z"),
     "MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}\Z", CORRECTED_MM_DASH_DD),
+      raw"\A\d{2}-\d{2}\Z"),
     "MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}\Z", CORRECTED_MM_SLASH_DD),
+      raw"\A\d{2}/\d{2}\Z"),
     "dd-MM" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}\Z", CORRECTED_DD_DASH_MM),
+      raw"\A\d{2}-\d{2}\Z"),
     "dd/MM" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}\Z", CORRECTED_DD_SLASH_MM),
+      raw"\A\d{2}/\d{2}\Z"),
     "MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{4}\Z", CORRECTED_MM_SLASH_YYYY),
+      raw"\A\d{2}/\d{4}\Z"),
     "MM-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{4}\Z", CORRECTED_MM_DASH_YYYY),
+      raw"\A\d{2}-\d{4}\Z"),
     "MM/dd/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}/\d{4}\Z", CORRECTED_MM_SLASH_DD_SLASH_YYYY),
+      raw"\A\d{2}/\d{2}/\d{4}\Z"),
     "MM-dd-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}-\d{4}\Z", CORRECTED_MM_DASH_DD_DASH_YYYY),
+      raw"\A\d{2}-\d{2}-\d{4}\Z"),
     "MMyyyy" -> ParseFormatMeta(Option.empty, isTimestamp = false,
-      raw"\A\d{6}\Z", CORRECTED_MMYYYY)
+      raw"\A\d{6}\Z")
   )
 
   // We are compatible with Spark for these formats when the timeParserPolicy is LEGACY. It
@@ -634,27 +632,25 @@ object GpuToTimestamp {
   // tests for.
   val LEGACY_COMPATIBLE_FORMATS = Map(
     "yyyy-MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)", LEGACY_YYYY_DASH_MM_DASH_DD),
+      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
     "yyyy-mm-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)", LEGACY_YYYY_DASH_MM_DASH_DD_LOWER),
+      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
     "yyyy/MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}(\D|\s|\Z)", LEGACY_YYYY_SLASH_MM_SLASH_DD),
+      raw"\A\d{4}/\d{1,2}/\d{1,2}(\D|\s|\Z)"),
     "dd-MM-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{1,2}-\d{1,2}-\d{4}(\D|\s|\Z)", LEGACY_DD_DASH_MM_DASH_YYYY),
+      raw"\A\d{1,2}-\d{1,2}-\d{4}(\D|\s|\Z)"),
     "dd/MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{1,2}/\d{1,2}/\d{4}(\D|\s|\Z)", LEGACY_DD_SLASH_MM_SLASH_YYYY),
+      raw"\A\d{1,2}/\d{1,2}/\d{4}(\D|\s|\Z)"),
     "yyyy-MM-dd HH:mm:ss" -> ParseFormatMeta(Option('-'), isTimestamp = true,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)",
-      LEGACY_YYYY_DASH_MM_DASH_DD_HH_MM_SS),
+      raw"\A\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
     "yyyy/MM/dd HH:mm:ss" -> ParseFormatMeta(Option('/'), isTimestamp = true,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)",
-      LEGACY_YYYY_SLASH_MM_SLASH_DD_HH_MM_SS),
+      raw"\A\d{4}/\d{1,2}/\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
     "yyyyMMdd HH:mm:ss" -> ParseFormatMeta(None, isTimestamp = true,
-      raw"\A\d{4}\d{1,2}\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)", LEGACY_YYYYMMDD_HH_MM_SS),
+      raw"\A\d{4}\d{1,2}\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
     "yyyyMMdd" -> ParseFormatMeta(None, isTimestamp = false,
-      raw"\A\d{8}(\D|\s|\Z)", LEGACY_YYYYMMDD),
+      raw"\A\d{8}(\D|\s|\Z)"),
     "yyyymmdd" -> ParseFormatMeta(None, isTimestamp = false,
-      raw"\A\d{8}(\D|\s|\Z)", LEGACY_YYYYMMDD_LOWER)
+      raw"\A\d{8}(\D|\s|\Z)")
   )
 
   def daysEqual(col: ColumnVector, name: String): ColumnVector = {
@@ -682,11 +678,11 @@ object GpuToTimestamp {
     }
   }
 
-  private def simpleTimestampFormatId(
-      sparkFormat: String,
-      isLegacy: Boolean): Option[CastStrings.SimpleTimestampFormat] = {
+  // True iff the fused JNI parser handles this (sparkFormat, policy) combination.
+  // Today the JNI accepts every entry in CORRECTED_COMPATIBLE_FORMATS / LEGACY_COMPATIBLE_FORMATS.
+  private def isSimpleSparkFormat(sparkFormat: String, isLegacy: Boolean): Boolean = {
     val map = if (isLegacy) LEGACY_COMPATIBLE_FORMATS else CORRECTED_COMPATIBLE_FORMATS
-    map.get(sparkFormat).map(_.simpleFmt)
+    map.contains(sparkFormat)
   }
 
   def isTimestamp(col: ColumnVector, sparkFormat: String, strfFormat: String) : ColumnVector = {
@@ -754,32 +750,31 @@ object GpuToTimestamp {
       failOnError: Boolean): ColumnVector = {
 
     // `tsVector` will be closed in replaceSpecialDates
-    val tsVector = simpleTimestampFormatId(sparkFormat, isLegacy = false) match {
-      case Some(fmtId) =>
-        // Fused kernel skips the regex+length+cuDF-asTimestamp chain.
-        val parsed = CastStrings.parseTimestampWithFormat(lhs.getBase, fmtId)
-        closeOnExcept(parsed) { _ =>
-          if (failOnError && parsed.getNullCount > lhs.getBase.getNullCount) {
-            // ANSI mode + a row that was non-null in input but failed to parse.
-            // CPU may throw DateTimeParseException, DateTimeException or ParseException
-            throw new IllegalArgumentException(
-              "Exception occurred when parsing timestamp in ANSI mode")
+    val tsVector = if (isSimpleSparkFormat(sparkFormat, isLegacy = false)) {
+      // Fused kernel skips the regex+length+cuDF-asTimestamp chain.
+      val parsed = CastStrings.parseTimestampWithFormat(lhs.getBase, sparkFormat, false)
+      closeOnExcept(parsed) { _ =>
+        if (failOnError && parsed.getNullCount > lhs.getBase.getNullCount) {
+          // ANSI mode + a row that was non-null in input but failed to parse.
+          // CPU may throw DateTimeParseException, DateTimeException or ParseException
+          throw new IllegalArgumentException(
+            "Exception occurred when parsing timestamp in ANSI mode")
+        }
+      }
+      parsed
+    } else {
+      // Fallback for incompatibleDateFormats: keep the legacy regex+cuDF chain.
+      withResource(isTimestamp(lhs.getBase, sparkFormat, strfFormat)) { isTs =>
+        if(failOnError && !BoolUtils.isAllValidTrue(isTs)) {
+          throw new IllegalArgumentException(
+            "Exception occurred when parsing timestamp in ANSI mode")
+        }
+        withResource(Scalar.fromNull(dtype)) { nullValue =>
+          withResource(lhs.getBase.asTimestamp(dtype, strfFormat)) { tsVec =>
+            isTs.ifElse(tsVec, nullValue)
           }
         }
-        parsed
-      case None =>
-        // Fallback for incompatibleDateFormats: keep the legacy regex+cuDF chain.
-        withResource(isTimestamp(lhs.getBase, sparkFormat, strfFormat)) { isTs =>
-          if(failOnError && !BoolUtils.isAllValidTrue(isTs)) {
-            throw new IllegalArgumentException(
-              "Exception occurred when parsing timestamp in ANSI mode")
-          }
-          withResource(Scalar.fromNull(dtype)) { nullValue =>
-            withResource(lhs.getBase.asTimestamp(dtype, strfFormat)) { tsVec =>
-              isTs.ifElse(tsVec, nullValue)
-            }
-          }
-        }
+      }
     }
 
     // in addition to date/timestamp strings, we also need to check for special dates and null
@@ -806,18 +801,15 @@ object GpuToTimestamp {
       strfFormat: String,
       dtype: DType,
       asTimestamp: (ColumnVector, String) => ColumnVector): ColumnVector = {
-    val fmtId = simpleTimestampFormatId(sparkFormat, isLegacy = true).getOrElse(
-      throw new IllegalStateException(s"Unsupported format $sparkFormat"))
-    CastStrings.parseTimestampWithFormat(lhs.getBase, fmtId)
+    if (!isSimpleSparkFormat(sparkFormat, isLegacy = true)) {
+      throw new IllegalStateException(s"Unsupported format $sparkFormat")
+    }
+    CastStrings.parseTimestampWithFormat(lhs.getBase, sparkFormat, true)
   }
 
 }
 
-case class ParseFormatMeta(
-    separator: Option[Char],
-    isTimestamp: Boolean,
-    validRegex: String,
-    simpleFmt: CastStrings.SimpleTimestampFormat)
+case class ParseFormatMeta(separator: Option[Char], isTimestamp: Boolean, validRegex: String)
 
 /**
  * A direct conversion of Spark's ToTimestamp class which converts time to UNIX timestamp by

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -27,7 +27,7 @@ import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.ExprMeta
 import com.nvidia.spark.rapids.GpuOverrides.{extractStringLit, getTimeParserPolicy}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.jni.{Arithmetic, DateTimeUtils, GpuTimeZoneDB}
+import com.nvidia.spark.rapids.jni.{Arithmetic, CastStrings, DateTimeUtils, GpuTimeZoneDB}
 import com.nvidia.spark.rapids.shims.{NullIntolerantShim, ShimBinaryExpression, ShimExpression}
 
 import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, ExpectsInputTypes, Expression, FromUnixTime, FromUTCTimestamp, ImplicitCastInputTypes, MonthsBetween, TimeZoneAwareExpression, ToUTCTimestamp, TruncDate, TruncTimestamp}
@@ -591,40 +591,42 @@ object ExceptionTimeParserPolicy extends TimeParserPolicy
 object CorrectedTimeParserPolicy extends TimeParserPolicy
 
 object GpuToTimestamp {
+  import CastStrings.SimpleTimestampFormat._
+
   // We are compatible with Spark for these formats when the timeParserPolicy is CORRECTED
   // or EXCEPTION. It is possible that other formats may be supported but these are the only
   // ones that we have tests for.
   val CORRECTED_COMPATIBLE_FORMATS = Map(
     "yyyy-MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{2}-\d{2}\Z"),
+      raw"\A\d{4}-\d{2}-\d{2}\Z", CORRECTED_YYYY_DASH_MM_DASH_DD),
     "yyyy/MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}\Z"),
+      raw"\A\d{4}/\d{1,2}/\d{1,2}\Z", CORRECTED_YYYY_SLASH_MM_SLASH_DD),
     "yyyy-MM" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{2}\Z"),
+      raw"\A\d{4}-\d{2}\Z", CORRECTED_YYYY_DASH_MM),
     "yyyy/MM" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{2}\Z"),
+      raw"\A\d{4}/\d{2}\Z", CORRECTED_YYYY_SLASH_MM),
     "dd/MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}/\d{4}\Z"),
+      raw"\A\d{2}/\d{2}/\d{4}\Z", CORRECTED_DD_SLASH_MM_SLASH_YYYY),
     "yyyy-MM-dd HH:mm:ss" -> ParseFormatMeta(Option('-'), isTimestamp = true,
-      raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\Z"),
+      raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\Z", CORRECTED_YYYY_DASH_MM_DASH_DD_HH_MM_SS),
     "MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}\Z"),
+      raw"\A\d{2}-\d{2}\Z", CORRECTED_MM_DASH_DD),
     "MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}\Z"),
+      raw"\A\d{2}/\d{2}\Z", CORRECTED_MM_SLASH_DD),
     "dd-MM" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}\Z"),
+      raw"\A\d{2}-\d{2}\Z", CORRECTED_DD_DASH_MM),
     "dd/MM" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}\Z"),
+      raw"\A\d{2}/\d{2}\Z", CORRECTED_DD_SLASH_MM),
     "MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{4}\Z"),
+      raw"\A\d{2}/\d{4}\Z", CORRECTED_MM_SLASH_YYYY),
     "MM-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{4}\Z"),
+      raw"\A\d{2}-\d{4}\Z", CORRECTED_MM_DASH_YYYY),
     "MM/dd/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}/\d{4}\Z"),
+      raw"\A\d{2}/\d{2}/\d{4}\Z", CORRECTED_MM_SLASH_DD_SLASH_YYYY),
     "MM-dd-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}-\d{4}\Z"),
+      raw"\A\d{2}-\d{2}-\d{4}\Z", CORRECTED_MM_DASH_DD_DASH_YYYY),
     "MMyyyy" -> ParseFormatMeta(Option.empty, isTimestamp = false,
-      raw"\A\d{6}\Z")
+      raw"\A\d{6}\Z", CORRECTED_MMYYYY)
   )
 
   // We are compatible with Spark for these formats when the timeParserPolicy is LEGACY. It
@@ -632,30 +634,28 @@ object GpuToTimestamp {
   // tests for.
   val LEGACY_COMPATIBLE_FORMATS = Map(
     "yyyy-MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
+      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)", LEGACY_YYYY_DASH_MM_DASH_DD),
     "yyyy-mm-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
+      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)", LEGACY_YYYY_DASH_MM_DASH_DD_LOWER),
     "yyyy/MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}(\D|\s|\Z)"),
+      raw"\A\d{4}/\d{1,2}/\d{1,2}(\D|\s|\Z)", LEGACY_YYYY_SLASH_MM_SLASH_DD),
     "dd-MM-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{1,2}-\d{1,2}-\d{4}(\D|\s|\Z)"),
+      raw"\A\d{1,2}-\d{1,2}-\d{4}(\D|\s|\Z)", LEGACY_DD_DASH_MM_DASH_YYYY),
     "dd/MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{1,2}/\d{1,2}/\d{4}(\D|\s|\Z)"),
+      raw"\A\d{1,2}/\d{1,2}/\d{4}(\D|\s|\Z)", LEGACY_DD_SLASH_MM_SLASH_YYYY),
     "yyyy-MM-dd HH:mm:ss" -> ParseFormatMeta(Option('-'), isTimestamp = true,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
+      raw"\A\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)",
+      LEGACY_YYYY_DASH_MM_DASH_DD_HH_MM_SS),
     "yyyy/MM/dd HH:mm:ss" -> ParseFormatMeta(Option('/'), isTimestamp = true,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
+      raw"\A\d{4}/\d{1,2}/\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)",
+      LEGACY_YYYY_SLASH_MM_SLASH_DD_HH_MM_SS),
     "yyyyMMdd HH:mm:ss" -> ParseFormatMeta(None, isTimestamp = true,
-      raw"\A\d{4}\d{1,2}\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
+      raw"\A\d{4}\d{1,2}\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)", LEGACY_YYYYMMDD_HH_MM_SS),
     "yyyyMMdd" -> ParseFormatMeta(None, isTimestamp = false,
-      raw"\A\d{8}(\D|\s|\Z)"),
+      raw"\A\d{8}(\D|\s|\Z)", LEGACY_YYYYMMDD),
     "yyyymmdd" -> ParseFormatMeta(None, isTimestamp = false,
-      raw"\A\d{8}(\D|\s|\Z)")
+      raw"\A\d{8}(\D|\s|\Z)", LEGACY_YYYYMMDD_LOWER)
   )
-
-  /** remove whitespace before month and day */
-  val REMOVE_WHITESPACE_FROM_MONTH_DAY: RegexReplace =
-    RegexReplace(raw"(\A\d+)-([ \t]*)(\d+)-([ \t]*)(\d+)", raw"\1-\3-\5")
 
   def daysEqual(col: ColumnVector, name: String): ColumnVector = {
     withResource(Scalar.fromString(name)) { scalarName =>
@@ -680,6 +680,13 @@ object GpuToTimestamp {
         }
       }
     }
+  }
+
+  private def simpleTimestampFormatId(
+      sparkFormat: String,
+      isLegacy: Boolean): Option[CastStrings.SimpleTimestampFormat] = {
+    val map = if (isLegacy) LEGACY_COMPATIBLE_FORMATS else CORRECTED_COMPATIBLE_FORMATS
+    map.get(sparkFormat).map(_.simpleFmt)
   }
 
   def isTimestamp(col: ColumnVector, sparkFormat: String, strfFormat: String) : ColumnVector = {
@@ -747,18 +754,32 @@ object GpuToTimestamp {
       failOnError: Boolean): ColumnVector = {
 
     // `tsVector` will be closed in replaceSpecialDates
-    val tsVector = withResource(isTimestamp(lhs.getBase, sparkFormat, strfFormat)) { isTs =>
-      if(failOnError && !BoolUtils.isAllValidTrue(isTs)) {
-        // ANSI mode and has invalid value.
-        // CPU may throw `DateTimeParseException`, `DateTimeException` or `ParseException`
-        throw new IllegalArgumentException("Exception occurred when parsing timestamp in ANSI mode")
-      }
-
-      withResource(Scalar.fromNull(dtype)) { nullValue =>
-        withResource(lhs.getBase.asTimestamp(dtype, strfFormat)) { tsVec =>
-          isTs.ifElse(tsVec, nullValue)
+    val tsVector = simpleTimestampFormatId(sparkFormat, isLegacy = false) match {
+      case Some(fmtId) =>
+        // Fused kernel skips the regex+length+cuDF-asTimestamp chain.
+        val parsed = CastStrings.parseTimestampWithFormat(lhs.getBase, fmtId)
+        closeOnExcept(parsed) { _ =>
+          if (failOnError && parsed.getNullCount > lhs.getBase.getNullCount) {
+            // ANSI mode + a row that was non-null in input but failed to parse.
+            // CPU may throw DateTimeParseException, DateTimeException or ParseException
+            throw new IllegalArgumentException(
+              "Exception occurred when parsing timestamp in ANSI mode")
+          }
         }
-      }
+        parsed
+      case None =>
+        // Fallback for incompatibleDateFormats: keep the legacy regex+cuDF chain.
+        withResource(isTimestamp(lhs.getBase, sparkFormat, strfFormat)) { isTs =>
+          if(failOnError && !BoolUtils.isAllValidTrue(isTs)) {
+            throw new IllegalArgumentException(
+              "Exception occurred when parsing timestamp in ANSI mode")
+          }
+          withResource(Scalar.fromNull(dtype)) { nullValue =>
+            withResource(lhs.getBase.asTimestamp(dtype, strfFormat)) { tsVec =>
+              isTs.ifElse(tsVec, nullValue)
+            }
+          }
+        }
     }
 
     // in addition to date/timestamp strings, we also need to check for special dates and null
@@ -785,96 +806,18 @@ object GpuToTimestamp {
       strfFormat: String,
       dtype: DType,
       asTimestamp: (ColumnVector, String) => ColumnVector): ColumnVector = {
-
-    val format = LEGACY_COMPATIBLE_FORMATS.getOrElse(sparkFormat,
+    val fmtId = simpleTimestampFormatId(sparkFormat, isLegacy = true).getOrElse(
       throw new IllegalStateException(s"Unsupported format $sparkFormat"))
-
-    val regexReplaceRules = Seq(REMOVE_WHITESPACE_FROM_MONTH_DAY)
-
-    // we support date formats using either `-` or `/` to separate year, month, and day and the
-    // regex rules are written with '-' so we need to replace '-' with '/' here as necessary
-    val rulesWithSeparator = format.separator match {
-      case Some('/') =>
-        regexReplaceRules.map {
-          case RegexReplace(pattern, backref) =>
-            RegexReplace(pattern.replace('-', '/'), backref.replace('-', '/'))
-        }
-      case Some('-') | Some(_) =>
-        regexReplaceRules
-      case None =>
-        // For formats like `yyyyMMdd` that do not contains separator,
-        // do not need to do regexp replacement rules
-        // Note: here introduced the following inconsistent behavior compared to Spark
-        // Spark's behavior:
-        //   to_date('20240101', 'yyyyMMdd')  = 2024-01-01
-        //   to_date('202401 01', 'yyyyMMdd') = 2024-01-01
-        //   to_date('2024 0101', 'yyyyMMdd') = null
-        // GPU behavior:
-        //   to_date('20240101', 'yyyyMMdd')  = 2024-01-01
-        //   to_date('202401 01', 'yyyyMMdd') = null
-        //   to_date('2024 0101', 'yyyyMMdd') = null
-        Seq()
-    }
-
-    // apply each rule in turn to the data
-    val fixedUp = rulesWithSeparator
-      .foldLeft(rejectLeadingNewlineThenStrip(lhs))((cv, regexRule) => {
-        withResource(cv) {
-          _.stringReplaceWithBackrefs(new RegexProgram(regexRule.search), regexRule.replace)
-        }
-      })
-
-    // check the final value against a regex to determine if it is valid or not, so we produce
-    // null values for any invalid inputs
-    withResource(Scalar.fromNull(dtype)) { nullValue =>
-      val prog = new RegexProgram(format.validRegex, CaptureGroups.NON_CAPTURE)
-      withResource(fixedUp.matchesRe(prog)) { isValidDate =>
-        withResource(asTimestampOrNull(fixedUp, dtype, strfFormat, asTimestamp)) { timestamp =>
-          isValidDate.ifElse(timestamp, nullValue)
-        }
-      }
-    }
-  }
-
-  /**
-   * Filter out strings that have a newline before the first non-whitespace character
-   * and then strip all leading and trailing whitespace.
-   */
-  private def rejectLeadingNewlineThenStrip(lhs: GpuColumnVector) = {
-    val prog = new RegexProgram("\\A[ \\t]*[\\n]+", CaptureGroups.NON_CAPTURE)
-    withResource(lhs.getBase.matchesRe(prog)) { hasLeadingNewline =>
-      withResource(Scalar.fromNull(DType.STRING)) { nullValue =>
-        withResource(lhs.getBase.strip()) { stripped =>
-          hasLeadingNewline.ifElse(nullValue, stripped)
-        }
-      }
-    }
-  }
-
-  /**
-   * Parse a string column to timestamp.
-   */
-  def asTimestampOrNull(
-      cv: ColumnVector,
-      dtype: DType,
-      strfFormat: String,
-      asTimestamp: (ColumnVector, String) => ColumnVector): ColumnVector = {
-    withResource(cv) { _ =>
-      withResource(Scalar.fromNull(dtype)) { nullValue =>
-        withResource(cv.isTimestamp(strfFormat)) { isTimestamp =>
-          withResource(asTimestamp(cv, strfFormat)) { timestamp =>
-            isTimestamp.ifElse(timestamp, nullValue)
-          }
-        }
-      }
-    }
+    CastStrings.parseTimestampWithFormat(lhs.getBase, fmtId)
   }
 
 }
 
-case class ParseFormatMeta(separator: Option[Char], isTimestamp: Boolean, validRegex: String)
-
-case class RegexReplace(search: String, replace: String)
+case class ParseFormatMeta(
+    separator: Option[Char],
+    isTimestamp: Boolean,
+    validRegex: String,
+    simpleFmt: CastStrings.SimpleTimestampFormat)
 
 /**
  * A direct conversion of Spark's ToTimestamp class which converts time to UNIX timestamp by

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -595,62 +595,37 @@ object GpuToTimestamp {
   // or EXCEPTION. It is possible that other formats may be supported but these are the only
   // ones that we have tests for.
   val CORRECTED_COMPATIBLE_FORMATS = Map(
-    "yyyy-MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{2}-\d{2}\Z"),
-    "yyyy/MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}\Z"),
-    "yyyy-MM" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{2}\Z"),
-    "yyyy/MM" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{2}\Z"),
-    "dd/MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}/\d{4}\Z"),
-    "yyyy-MM-dd HH:mm:ss" -> ParseFormatMeta(Option('-'), isTimestamp = true,
-      raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\Z"),
-    "MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}\Z"),
-    "MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}\Z"),
-    "dd-MM" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}\Z"),
-    "dd/MM" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}\Z"),
-    "MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{4}\Z"),
-    "MM-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{4}\Z"),
-    "MM/dd/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{2}/\d{2}/\d{4}\Z"),
-    "MM-dd-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{2}-\d{2}-\d{4}\Z"),
-    "MMyyyy" -> ParseFormatMeta(Option.empty, isTimestamp = false,
-      raw"\A\d{6}\Z")
+    "yyyy-MM-dd" -> raw"\A\d{4}-\d{2}-\d{2}\Z",
+    "yyyy/MM/dd" -> raw"\A\d{4}/\d{1,2}/\d{1,2}\Z",
+    "yyyy-MM" -> raw"\A\d{4}-\d{2}\Z",
+    "yyyy/MM" -> raw"\A\d{4}/\d{2}\Z",
+    "dd/MM/yyyy" -> raw"\A\d{2}/\d{2}/\d{4}\Z",
+    "yyyy-MM-dd HH:mm:ss" -> raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\Z",
+    "MM-dd" -> raw"\A\d{2}-\d{2}\Z",
+    "MM/dd" -> raw"\A\d{2}/\d{2}\Z",
+    "dd-MM" -> raw"\A\d{2}-\d{2}\Z",
+    "dd/MM" -> raw"\A\d{2}/\d{2}\Z",
+    "MM/yyyy" -> raw"\A\d{2}/\d{4}\Z",
+    "MM-yyyy" -> raw"\A\d{2}-\d{4}\Z",
+    "MM/dd/yyyy" -> raw"\A\d{2}/\d{2}/\d{4}\Z",
+    "MM-dd-yyyy" -> raw"\A\d{2}-\d{2}-\d{4}\Z",
+    "MMyyyy" -> raw"\A\d{6}\Z"
   )
 
   // We are compatible with Spark for these formats when the timeParserPolicy is LEGACY. It
   // is possible that other formats may be supported but these are the only ones that we have
   // tests for.
-  val LEGACY_COMPATIBLE_FORMATS = Map(
-    "yyyy-MM-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
-    "yyyy-mm-dd" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}(\D|\s|\Z)"),
-    "yyyy/MM/dd" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}(\D|\s|\Z)"),
-    "dd-MM-yyyy" -> ParseFormatMeta(Option('-'), isTimestamp = false,
-      raw"\A\d{1,2}-\d{1,2}-\d{4}(\D|\s|\Z)"),
-    "dd/MM/yyyy" -> ParseFormatMeta(Option('/'), isTimestamp = false,
-      raw"\A\d{1,2}/\d{1,2}/\d{4}(\D|\s|\Z)"),
-    "yyyy-MM-dd HH:mm:ss" -> ParseFormatMeta(Option('-'), isTimestamp = true,
-      raw"\A\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
-    "yyyy/MM/dd HH:mm:ss" -> ParseFormatMeta(Option('/'), isTimestamp = true,
-      raw"\A\d{4}/\d{1,2}/\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
-    "yyyyMMdd HH:mm:ss" -> ParseFormatMeta(None, isTimestamp = true,
-      raw"\A\d{4}\d{1,2}\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}(\D|\s|\Z)"),
-    "yyyyMMdd" -> ParseFormatMeta(None, isTimestamp = false,
-      raw"\A\d{8}(\D|\s|\Z)"),
-    "yyyymmdd" -> ParseFormatMeta(None, isTimestamp = false,
-      raw"\A\d{8}(\D|\s|\Z)")
+  val LEGACY_COMPATIBLE_FORMATS = Set(
+    "yyyy-MM-dd",
+    "yyyy-mm-dd",
+    "yyyy/MM/dd",
+    "dd-MM-yyyy",
+    "dd/MM/yyyy",
+    "yyyy-MM-dd HH:mm:ss",
+    "yyyy/MM/dd HH:mm:ss",
+    "yyyyMMdd HH:mm:ss",
+    "yyyyMMdd",
+    "yyyymmdd"
   )
 
   def daysEqual(col: ColumnVector, name: String): ColumnVector = {
@@ -681,19 +656,22 @@ object GpuToTimestamp {
   // True iff the fused JNI parser handles this (sparkFormat, policy) combination.
   // Today the JNI accepts every entry in CORRECTED_COMPATIBLE_FORMATS / LEGACY_COMPATIBLE_FORMATS.
   private def isSimpleSparkFormat(sparkFormat: String, isLegacy: Boolean): Boolean = {
-    val map = if (isLegacy) LEGACY_COMPATIBLE_FORMATS else CORRECTED_COMPATIBLE_FORMATS
-    map.contains(sparkFormat)
+    if (isLegacy) {
+      LEGACY_COMPATIBLE_FORMATS.contains(sparkFormat)
+    } else {
+      CORRECTED_COMPATIBLE_FORMATS.contains(sparkFormat)
+    }
   }
 
   def isTimestamp(col: ColumnVector, sparkFormat: String, strfFormat: String) : ColumnVector = {
     CORRECTED_COMPATIBLE_FORMATS.get(sparkFormat) match {
-      case Some(fmt) =>
+      case Some(validRegex) =>
         // the cuDF `is_timestamp` function is less restrictive than Spark's behavior for UnixTime
         // and ToUnixTime and will support parsing a subset of a string so we check the length of
         // the string as well which works well for fixed-length formats but if/when we want to
         // support variable-length formats (such as timestamps with milliseconds) then we will need
         // to use regex instead.
-        val prog = new RegexProgram(fmt.validRegex, CaptureGroups.NON_CAPTURE)
+        val prog = new RegexProgram(validRegex, CaptureGroups.NON_CAPTURE)
         val isTimestamp = withResource(col.matchesRe(prog)) { matches =>
           withResource(col.isTimestamp(strfFormat)) { isTimestamp =>
             isTimestamp.and(matches)
@@ -797,10 +775,7 @@ object GpuToTimestamp {
    */
   def parseStringAsTimestampWithLegacyParserPolicy(
       lhs: GpuColumnVector,
-      sparkFormat: String,
-      strfFormat: String,
-      dtype: DType,
-      asTimestamp: (ColumnVector, String) => ColumnVector): ColumnVector = {
+      sparkFormat: String): ColumnVector = {
     if (!isSimpleSparkFormat(sparkFormat, isLegacy = true)) {
       throw new IllegalStateException(s"Unsupported format $sparkFormat")
     }
@@ -808,8 +783,6 @@ object GpuToTimestamp {
   }
 
 }
-
-case class ParseFormatMeta(separator: Option[Char], isTimestamp: Boolean, validRegex: String)
 
 /**
  * A direct conversion of Spark's ToTimestamp class which converts time to UNIX timestamp by
@@ -842,12 +815,7 @@ abstract class GpuToTimestamp
       case StringType =>
         // rhs is ignored we already parsed the format
         val res = if (getTimeParserPolicy == LegacyTimeParserPolicy) {
-          parseStringAsTimestampWithLegacyParserPolicy(
-            lhs,
-            sparkFormat,
-            strfFormat,
-            DType.TIMESTAMP_MICROSECONDS,
-            (col, strfFormat) => col.asTimestampMicroseconds(strfFormat))
+          parseStringAsTimestampWithLegacyParserPolicy(lhs, sparkFormat)
         } else {
           parseStringAsTimestamp(
             lhs,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -594,22 +594,22 @@ object GpuToTimestamp {
   // We are compatible with Spark for these formats when the timeParserPolicy is CORRECTED
   // or EXCEPTION. It is possible that other formats may be supported but these are the only
   // ones that we have tests for.
-  val CORRECTED_COMPATIBLE_FORMATS = Map(
-    "yyyy-MM-dd" -> raw"\A\d{4}-\d{2}-\d{2}\Z",
-    "yyyy/MM/dd" -> raw"\A\d{4}/\d{1,2}/\d{1,2}\Z",
-    "yyyy-MM" -> raw"\A\d{4}-\d{2}\Z",
-    "yyyy/MM" -> raw"\A\d{4}/\d{2}\Z",
-    "dd/MM/yyyy" -> raw"\A\d{2}/\d{2}/\d{4}\Z",
-    "yyyy-MM-dd HH:mm:ss" -> raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\Z",
-    "MM-dd" -> raw"\A\d{2}-\d{2}\Z",
-    "MM/dd" -> raw"\A\d{2}/\d{2}\Z",
-    "dd-MM" -> raw"\A\d{2}-\d{2}\Z",
-    "dd/MM" -> raw"\A\d{2}/\d{2}\Z",
-    "MM/yyyy" -> raw"\A\d{2}/\d{4}\Z",
-    "MM-yyyy" -> raw"\A\d{2}-\d{4}\Z",
-    "MM/dd/yyyy" -> raw"\A\d{2}/\d{2}/\d{4}\Z",
-    "MM-dd-yyyy" -> raw"\A\d{2}-\d{2}-\d{4}\Z",
-    "MMyyyy" -> raw"\A\d{6}\Z"
+  val CORRECTED_COMPATIBLE_FORMATS = Set(
+    "yyyy-MM-dd",
+    "yyyy/MM/dd",
+    "yyyy-MM",
+    "yyyy/MM",
+    "dd/MM/yyyy",
+    "yyyy-MM-dd HH:mm:ss",
+    "MM-dd",
+    "MM/dd",
+    "dd-MM",
+    "dd/MM",
+    "MM/yyyy",
+    "MM-yyyy",
+    "MM/dd/yyyy",
+    "MM-dd-yyyy",
+    "MMyyyy"
   )
 
   // We are compatible with Spark for these formats when the timeParserPolicy is LEGACY. It
@@ -663,60 +663,36 @@ object GpuToTimestamp {
     }
   }
 
-  def isTimestamp(col: ColumnVector, sparkFormat: String, strfFormat: String) : ColumnVector = {
-    CORRECTED_COMPATIBLE_FORMATS.get(sparkFormat) match {
-      case Some(validRegex) =>
-        // the cuDF `is_timestamp` function is less restrictive than Spark's behavior for UnixTime
-        // and ToUnixTime and will support parsing a subset of a string so we check the length of
-        // the string as well which works well for fixed-length formats but if/when we want to
-        // support variable-length formats (such as timestamps with milliseconds) then we will need
-        // to use regex instead.
-        val prog = new RegexProgram(validRegex, CaptureGroups.NON_CAPTURE)
-        val isTimestamp = withResource(col.matchesRe(prog)) { matches =>
-          withResource(col.isTimestamp(strfFormat)) { isTimestamp =>
-            isTimestamp.and(matches)
-          }
+  def isTimestamp(col: ColumnVector, strfFormat: String) : ColumnVector = {
+    // This is the incompatibleDateFormats case where we do not guarantee full
+    // compatibility with Spark. However, we still reject inputs where the
+    // date-time separator doesn't match the format: cuDF treats 'T' and space
+    // as interchangeable, but Spark's DateTimeFormatter requires an exact match.
+    // We also use cuDF isTimestamp to reject truly unparseable strings.
+    //
+    // NOTE: Formats like "yyyy-MM-dd HH:mm:ss.SSS" cannot be added to
+    // CORRECTED_COMPATIBLE_FORMATS because cuDF's %3f requires exactly 3
+    // fractional digits, while Java's DateTimeFormatter accepts 1-3 digits
+    // (e.g. "11:59:59.9" is valid on CPU but rejected by cuDF). The
+    // incompatible path here is the correct fallback for such formats.
+    if (strfFormat.startsWith("%Y-%m-%d %H") || strfFormat.startsWith("%Y/%m/%d %H")) {
+      // The 4 element-wise GPU kernels below (matchesRe, not, isTimestamp, and) add
+      // negligible overhead compared to the downstream parseStringAsTimestamp which
+      // performs full cuDF timestamp parsing. The regex is trivial (single fixed-position
+      // character check) and withResource is just RAII for prompt GPU memory release.
+      val tProg = new RegexProgram(raw"\A.{10}T", CaptureGroups.NON_CAPTURE)
+      val noT = withResource(col.matchesRe(tProg)) { hasT =>
+        hasT.not()
+      }
+      withResource(noT) { noT =>
+        withResource(col.isTimestamp(strfFormat)) { cudfValid =>
+          noT.and(cudfValid)
         }
-        withResource(isTimestamp) { _ =>
-          withResource(col.getCharLengths) { len =>
-            withResource(Scalar.fromInt(sparkFormat.length)) { expectedLen =>
-              withResource(len.equalTo(expectedLen)) { lenMatches =>
-                lenMatches.and(isTimestamp)
-              }
-            }
-          }
-        }
-      case _ =>
-        // This is the incompatibleDateFormats case where we do not guarantee full
-        // compatibility with Spark. However, we still reject inputs where the
-        // date-time separator doesn't match the format: cuDF treats 'T' and space
-        // as interchangeable, but Spark's DateTimeFormatter requires an exact match.
-        // We also use cuDF isTimestamp to reject truly unparseable strings.
-        //
-        // NOTE: Formats like "yyyy-MM-dd HH:mm:ss.SSS" cannot be added to
-        // CORRECTED_COMPATIBLE_FORMATS because cuDF's %3f requires exactly 3
-        // fractional digits, while Java's DateTimeFormatter accepts 1-3 digits
-        // (e.g. "11:59:59.9" is valid on CPU but rejected by cuDF). The
-        // incompatible path here is the correct fallback for such formats.
-        if (strfFormat.startsWith("%Y-%m-%d %H") || strfFormat.startsWith("%Y/%m/%d %H")) {
-          // The 4 element-wise GPU kernels below (matchesRe, not, isTimestamp, and) add
-          // negligible overhead compared to the downstream parseStringAsTimestamp which
-          // performs full cuDF timestamp parsing. The regex is trivial (single fixed-position
-          // character check) and withResource is just RAII for prompt GPU memory release.
-          val tProg = new RegexProgram(raw"\A.{10}T", CaptureGroups.NON_CAPTURE)
-          val noT = withResource(col.matchesRe(tProg)) { hasT =>
-            hasT.not()
-          }
-          withResource(noT) { noT =>
-            withResource(col.isTimestamp(strfFormat)) { cudfValid =>
-              noT.and(cudfValid)
-            }
-          }
-        } else {
-          withResource(Scalar.fromBool(true)) { s =>
-            ColumnVector.fromScalar(s, col.getRowCount.toInt)
-          }
-        }
+      }
+    } else {
+      withResource(Scalar.fromBool(true)) { s =>
+        ColumnVector.fromScalar(s, col.getRowCount.toInt)
+      }
     }
   }
 
@@ -742,7 +718,7 @@ object GpuToTimestamp {
       parsed
     } else {
       // Fallback for incompatibleDateFormats: keep the legacy regex+cuDF chain.
-      withResource(isTimestamp(lhs.getBase, sparkFormat, strfFormat)) { isTs =>
+      withResource(isTimestamp(lhs.getBase, strfFormat)) { isTs =>
         if(failOnError && !BoolUtils.isAllValidTrue(isTs)) {
           throw new IllegalArgumentException(
             "Exception occurred when parsing timestamp in ANSI mode")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -22,8 +22,6 @@ import java.util.TimeZone
 
 import scala.collection.mutable.ListBuffer
 
-import ai.rapids.cudf.{ColumnVector, RegexProgram}
-import com.nvidia.spark.rapids.Arm.withResource
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkConf
@@ -31,8 +29,6 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.functions.{col, to_date, to_timestamp, unix_timestamp}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.GpuToTimestamp.REMOVE_WHITESPACE_FROM_MONTH_DAY
-import org.apache.spark.sql.rapids.RegexReplace
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
 
 class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterEach {
@@ -238,12 +234,6 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     assert(!planStr.contains(RapidsConf.INCOMPATIBLE_DATE_FORMATS.key))
   }
 
-  test("Regex: Remove whitespace from month and day") {
-    testRegex(REMOVE_WHITESPACE_FROM_MONTH_DAY,
-    Seq("1- 1-1", "1-1- 1", "1- 1- 1", null),
-    Seq("1-1-1", "1-1-1", "1-1-1", null))
-  }
-
   test("literals: ensure time literals are correct") {
     val conf = new SparkConf()
     val df = withGpuSparkSession(spark => {
@@ -301,17 +291,6 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
       f(conf)
     } finally {
       TimeZone.setDefault(originTimeZone)
-    }
-  }
-
-  private def testRegex(rule: RegexReplace, values: Seq[String], expected: Seq[String]): Unit = {
-    withResource(ColumnVector.fromStrings(values: _*)) { v =>
-      withResource(ColumnVector.fromStrings(expected: _*)) { expected =>
-        val prog = new RegexProgram(rule.search)
-        withResource(v.stringReplaceWithBackrefs(prog, rule.replace)) { actual =>
-          CudfTestHelper.assertColumnsAreEqual(expected, actual)
-        }
-      }
     }
   }
 


### PR DESCRIPTION
Fixes #14689.

~~Depends on NVIDIA/spark-rapids-jni#4507.~~

### Description

Replaces the cuDF regex-validate + `stringReplaceWithBackrefs` + `asTimestamp` chain in `GpuToTimestamp` with the fused JNI parser added in NVIDIA/spark-rapids-jni#4507.

For the 24 supported `LEGACY_COMPATIBLE_FORMATS` / `CORRECTED_COMPATIBLE_FORMATS` patterns:

- `parseStringAsTimestampWithLegacyParserPolicy` becomes a single `CastStrings.parseTimestampWithFormat(input, sparkFormat, legacy=true)` call. `rejectLeadingNewlineThenStrip` + the `REMOVE_WHITESPACE_FROM_MONTH_DAY` regex rewrite + the anchored validation regex + the cuDF `asTimestamp` call collapse into one per-row state-machine pass on the GPU.
- `parseStringAsTimestamp` gains a fast path that calls the same JNI for any `sparkFormat` in `CORRECTED_COMPATIBLE_FORMATS`. The `incompatibleDateFormats` fallback (formats outside the supported sets) keeps the existing regex + cuDF chain unchanged.

In addition to dropping the regex engine and the `fixedUp` intermediate string column from the hot path, the fused kernel makes this code path's GPU memory footprint predictable — today the regex chain can produce a large allocation under cuDF whose size is not visible to the spark-rapids estimator, which has caused OOMs on large batches.

Helpers that became dead code (`REMOVE_WHITESPACE_FROM_MONTH_DAY`, `RegexReplace`, `rejectLeadingNewlineThenStrip`, `asTimestampOrNull`) are deleted along with the test that exercised the standalone regex.


## Performance

  Benchmark setup: 5,000,000 rows, GPU runs 100 `to_timestamp` projections per query, CPU runs 5 (asymmetric so neither side is overhead- nor
  wall-clock-bound). 1 warmup + 3 measured runs per cell, mean reported.

  | Scenario | main GPU (ms) | PR GPU (ms) | GPU improvement (main / PR) | PR CPU (ms) | Raw speedup (CPU / GPU) | Normalized speedup |
  |----------|--------------:|------------:|----------------------------:|------------:|------------------------:|-------------------:|
  | CORRECTED `yyyy-MM-dd`          | 709  | 559 | 1.27x      | 1930 | 3.45x | 69.05x  |
  | CORRECTED `yyyy-MM-dd HH:mm:ss` | 728  | 469 | 1.55x      | 2214 | 4.72x | 94.41x  |
  | CORRECTED `dd/MM/yyyy`          | 599  | 403 | 1.49x      | 1463 | 3.63x | 72.61x  |
  | CORRECTED `MMyyyy` (packed)     | 540  | 389 | 1.39x      | 1470 | 3.78x | 75.58x  |
  | LEGACY `yyyy-MM-dd`             | 5305 | 390 | **13.60x** | 2357 | 6.04x | 120.87x |
  | LEGACY `yyyy-MM-dd HH:mm:ss`    | 6565 | 419 | **15.67x** | 4107 | 9.80x | 196.04x |
  | LEGACY `yyyyMMdd` (packed)      | 746  | 379 | 1.97x      | 2347 | 6.19x | 123.85x |
  | LEGACY `yyyy-MM-dd` (whitespace)| 6497 | 390 | **16.66x** | 2409 | 6.18x | 123.54x |

  Column semantics:

  - **GPU improvement**: `main_GPU / PR_GPU` — kernel-level speedup this PR delivers on the GPU path.
  - **Raw speedup**: `PR_CPU / PR_GPU` wall-clock ratio. GPU runs 100 rounds and CPU runs 5, so this number is artificially small; included for transparency.
  - **Normalized speedup**: `(PR_CPU / cpuRounds) / (PR_GPU / gpuRounds)` = `raw × 20` — per-projection speed ratio after accounting for the round count
  asymmetry.

  Highlights:

  - **LEGACY with separators (`yyyy-MM-dd`, `yyyy-MM-dd HH:mm:ss`, whitespace variant) gains 13.6–16.7x on the GPU path.** The old chain ran a regex DFA, a
  `stringReplaceWithBackrefs` regex rewrite, `cudf::to_timestamp`, and an `ifElse` — four independent cuDF kernels plus a full regex pass. The new fused kernel
   collapses all of that into a single `for_each_n` over `cudf::string_view`.
  - **LEGACY `yyyy-MM-dd HH:mm:ss` reaches 196x vs CPU**, the largest gap in the suite — `SimpleDateFormat` is also slowest at parsing the longest pattern, so
  the GPU advantage compounds.
  - **CORRECTED scenarios gain 1.27–1.55x.** The old CORRECTED path was already short (no regex rewrite), so the kernel-level improvement is more modest.
  - **LEGACY `yyyyMMdd` (packed) gains 1.97x.** This format had `separator=None`, so it was not paying for `stringReplaceWithBackrefs` even on the old path.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

JNI-side unit tests for the new parser live in spark-rapids-jni#4507's `CastStringsTest` (`parseTimestampWithFormat_*`). On the spark-rapids side, existing coverage exercises the changed code paths:
- `tests/.../ParseDateTimeSuite` — `to_date`/`to_timestamp`/`unix_timestamp` for both CORRECTED and LEGACY policies.
- `integration_tests/.../date_time_test.py` — `test_string_to_timestamp_functions_ansi_{valid,invalid}`, `test_to_timestamp_{runtime_fallback,tz_rules}`, `test_formats_for_legacy_mode*`, `test_to_date*`, `test_to_date_format_MMyyyy`, `test_string_to_unix_timestamp_*`.

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)