### PR TITLE
Temporarily xfail std variance edge case

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2554,8 +2554,7 @@ def test_no_fallback_when_ansi_enabled(data_gen, kudo_enabled):
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_std_variance(data_gen, conf, kudo_enabled):
-    if (data_gen is _std_variance_issue_14681_gen and
-            (conf is _float_smallbatch_conf or conf is _float_conf_skipagg)):
+    if data_gen is _std_variance_issue_14681_gen:
         pytest.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/14681')
 
     local_conf = copy_and_update(conf, {

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -194,11 +194,14 @@ _decimals_with_no_nulls = [
 _init_list_with_decimals = _init_list + [
     _decimals_with_nulls, _decimals_with_no_nulls]
 
+_std_variance_issue_14681_gen = [
+    ('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', DoubleGen()), ('c', DoubleGen())]
+
 # Grouped FP gens using bare DoubleGen()/FloatGen() on the aggregated columns.
 # Their default special_cases inject NaN, -0.0, +-Inf, and max-fraction values,
 # which exercise the corner-case paths for FP aggregate functions.
 _init_list_with_decimals_and_floats = _init_list_with_decimals + [
-    [('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', DoubleGen()), ('c', DoubleGen())],
+    _std_variance_issue_14681_gen,
     [('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', FloatGen()), ('c', FloatGen())]]
 
 # Used to test ANSI-mode fallback
@@ -2551,6 +2554,10 @@ def test_no_fallback_when_ansi_enabled(data_gen, kudo_enabled):
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize("kudo_enabled", ["true", "false"], ids=idfn)
 def test_std_variance(data_gen, conf, kudo_enabled):
+    if (data_gen is _std_variance_issue_14681_gen and
+            (conf is _float_smallbatch_conf or conf is _float_conf_skipagg)):
+        pytest.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/14681')
+
     local_conf = copy_and_update(conf, {
         'spark.rapids.sql.castDecimalToFloat.enabled': 'true',
         kudo_enabled_conf_key: kudo_enabled})


### PR DESCRIPTION
Contributes to #14681.

Summary
- Temporarily xfail the stddev/variance Python integration test combinations tracked by issue #14681.
- Scope is limited to `_std_variance_issue_14681_gen` across all `_confs` and both KUDO parameter values.
- The xfail guard now keys only on the problematic data generator because the failure follows that input shape rather than a specific aggregation config.

Validation
- `mvn package -DskipTests -pl dist,integration_tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm`
  - BUILD SUCCESS
- `PATH=/home/allxu/work/spark-set/spark-rapids-14681-xfail/.venv-py310/bin:$PATH PYSPARK_PYTHON=/home/allxu/work/spark-set/spark-rapids-14681-xfail/.venv-py310/bin/python PYSPARK_DRIVER_PYTHON=/home/allxu/work/spark-set/spark-rapids-14681-xfail/.venv-py310/bin/python SPARK_HOME=/home/allxu/Downloads/spark-3.3.0-bin-hadoop3 TESTS='hash_aggregate_test.py::test_std_variance' TEST_PARALLEL=1 DATAGEN_SEED=1777180076 ./integration_tests/run_pyspark_from_build.sh --tb=short`
  - `120 passed, 10 xfailed, 3 warnings in 1126.38s (0:18:46)`

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
