### PR TITLE
Publish Optimizer trait at JAR root to fix NoClassDefFoundError

### DIFF
--- a/dist/unshimmed-common-from-single-shim.txt
+++ b/dist/unshimmed-common-from-single-shim.txt
@@ -4,6 +4,7 @@ META-INF/NOTICE
 com/nvidia/spark/rapids/ExplainPlan.class
 com/nvidia/spark/rapids/ExplainPlan$.class
 com/nvidia/spark/rapids/ExplainPlanBase.class
+com/nvidia/spark/rapids/Optimizer.class
 com/nvidia/spark/rapids/optimizer/SQLOptimizerPlugin*
 com/nvidia/spark/rapids/ShimLoaderTemp*
 com/nvidia/spark/rapids/SparkShims*


### PR DESCRIPTION
Fixes #14712

### Description
Setting `spark.rapids.sql.optimizer.enabled=true` currently throws `java.lang.NoClassDefFoundError: com/nvidia/spark/rapids/Optimizer` on the first DataFrame action and disables GPU plan rewriting for the rest of the session.

The trait `com.nvidia.spark.rapids.Optimizer` (defined in `sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala`) is the declared return type of `ShimLoaderTemp.newOptimizerClass`, which is invoked from `GpuOverrides.getOptimizations` when the CBO flag is on. Resolving that return type happens on the Spark thread-context classloader, which only sees the JAR root — not `spark-shared/`. In `dist/unshimmed-common-from-single-shim.txt`, sibling traits like `ExplainPlan` / `ExplainPlanBase` are already listed for unshimming, but `Optimizer.class` was missing, so it ended up only in `spark-shared/com/nvidia/spark/rapids/Optimizer.class` of the published JAR.

This PR adds `com/nvidia/spark/rapids/Optimizer.class` to the unshimmed-common list so the trait is also placed at the JAR root, making it resolvable by the application classloader.

### Verification
After rebuilding the dist JAR, `Optimizer.class` is present at both the root and under `spark-shared/`:

```bash
jar tf rapids-4-spark_2.12-*-cuda12.jar \
    | grep -E "(^|/)com/nvidia/spark/rapids/Optimizer\.class$"
# com/nvidia/spark/rapids/Optimizer.class

not:
# spark-shared/com/nvidia/spark/rapids/Optimizer.class
```


test command:
```scala
$SPARK_HOME/bin/spark-shell \
    --conf spark.plugins=com.nvidia.spark.SQLPlugin \
    --conf spark.rapids.sql.optimizer.enabled=true \
    --conf spark.sql.adaptive.enabled=false \
    --conf spark.shuffle.manager=com.nvidia.spark.rapids.spark356.RapidsShuffleManager \
    --conf spark.driver.extraClassPath=/home/chongg/code/spark-rapids4/dist/target/rapids-4-spark_2.12-26.06.0-SNAPSHOT-cuda12.jar \
    --conf spark.executor.extraClassPath=/home/chongg/code/spark-rapids4/dist/target/rapids-4-spark_2.12-26.06.0-SNAPSHOT-cuda12.jar

spark.range(10).selectExpr("id + 1 as x").show()
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

Signed-off-by: Chong Gao <res_life@163.com>