### PR TITLE
Update POM files to include Iceberg artifact properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -710,6 +710,8 @@
                 <spark.test.version>${spark411.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-stub</rapids.delta.artifactId1>
+                <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
+                <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
                 <slf4j.version>2.0.7</slf4j.version>
                 <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing,-options|-Werror</scala.javac.args>
             </properties>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -710,6 +710,8 @@
                 <spark.test.version>${spark411.version}</spark.test.version>
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-stub</rapids.delta.artifactId1>
+                <iceberg.artifact.suffix>${spark40x.iceberg.artifact.suffix}</iceberg.artifact.suffix>
+                <iceberg.runtime.version>${iceberg.110x.version}</iceberg.runtime.version>
                 <slf4j.version>2.0.7</slf4j.version>
                 <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing,-options|-Werror</scala.javac.args>
             </properties>


### PR DESCRIPTION

Fixes #14701 

### Description

Define `iceberg.artifact.suffix` and `iceberg.runtime.version` in the **`release411`** (`buildver=411`) profile in the root `pom.xml` and mirrored **`scala2.13/pom.xml`**.

On `main`, other Spark 4.x release profiles (for example `release402`) already set these properties to `${spark40x.iceberg.artifact.suffix}` and `${iceberg.110x.version}`. The `release411` profile omitted them, so builds or tooling that rely on the parent POM’s Iceberg-related property chain could see inconsistent or unresolved values compared to neighboring profiles.

This change aligns the 4.11 profile with the same Iceberg artifact/version wiring used for Spark 4.0.x lines.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
