### PR TITLE
Use GpuShuffleBlockResolverBase.wrapped in unregisterShuffle

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -2111,7 +2111,7 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
     //    to disk.
     val isbr = shuffleBlockResolver match {
       case isbr: IndexShuffleBlockResolver => isbr
-      case gpur: GpuShuffleBlockResolver => gpur.resolver
+      case gpur: GpuShuffleBlockResolverBase => gpur.wrapped
       case _ =>
         throw new IllegalStateException(
           "unregisterShuffle called with unexpected resolver " +


### PR DESCRIPTION
### Description

In `unregisterShuffle`, switch the pattern match from `GpuShuffleBlockResolver` + `.resolver` to `GpuShuffleBlockResolverBase` + `.wrapped`.

The nested `IndexShuffleBlockResolver` is already stored on `GpuShuffleBlockResolverBase` as `wrapped`. The shim passes the same reference into the superclass constructor, so runtime behavior is unchanged.

Using the base type avoids scalac failing with “value resolver is not a member of …GpuShuffleBlockResolver” when the shim subtype’s accessor is not visible in proprietary dependency layouts; `wrapped` is defined in the same compilation unit as the shuffle manager code.

### Notes

- OSS and non-OSS runtime classpaths: semantics stay the same (`wrapped` ≡ shim `resolver` argument).

### Checklists


Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required