### PR TITLE
Xfail quoted get_json_object test on Dataproc Serverless

### DIFF
--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -19,7 +19,7 @@ from data_gen import *
 from pyspark.sql.types import *
 from marks import *
 from spark_init_internal import spark_version
-from conftest import is_dataproc_runtime
+from conftest import is_dataproc_runtime, is_dataproc_serverless_runtime
 from spark_session import is_before_spark_400, is_databricks113_or_later, is_databricks_runtime
 
 def mk_json_str_gen(pattern):
@@ -123,7 +123,7 @@ def test_get_json_object_normalize_non_string_output():
             f.col('jsonStr'),
             f.get_json_object('jsonStr', '$')))
 
-@pytest.mark.xfail(condition=is_dataproc_runtime(),
+@pytest.mark.xfail(condition=is_dataproc_runtime() or is_dataproc_serverless_runtime(),
     reason="https://github.com/NVIDIA/spark-rapids/issues/14290")
 def test_get_json_object_quoted_question():
     schema = StructType([StructField("jsonStr", StringType())])


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14290

### Description
Dataproc Serverless is seeing the same `get_json_object` GPU/CPU mismatch previously seen on Dataproc: extracting `$['?']` from `{"?":"QUESTION"}` returns `QUESTION` on CPU but `None` on GPU.

The test was already marked `xfail` for Dataproc as part of https://github.com/NVIDIA/spark-rapids/pull/14298 for https://github.com/NVIDIA/spark-rapids/issues/14290. This PR extends that existing `xfail` condition to Dataproc Serverless as well.


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x ] Not required
