### PR TITLE
Fix async profiler output copy to s3 [skip ci]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/asyncProfiler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/asyncProfiler.scala
@@ -362,7 +362,8 @@ object AsyncProfilerOnExecutor extends Logging {
                 } else {
                   // If compression fails, copy the original file
                   log.warn("JFR compression failed, copying uncompressed file")
-                  withResource(fs.create(new Path(asyncProfilerPrefix.get, baseFileName), false)) { out =>
+                  withResource(
+                    fs.create(new Path(asyncProfilerPrefix.get, baseFileName), false)) { out =>
                     Files.copy(tempFilePath, out)
                   }
                 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/asyncProfiler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/asyncProfiler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -355,16 +355,21 @@ object AsyncProfilerOnExecutor extends Logging {
                 // Compress the temp file first
                 val compressedTempPath = Files.createTempFile("compressed-jfr", ".gz")
                 if (compressJfrFile(tempFilePath, compressedTempPath)) {
-                  fs.copyFromLocalFile(new Path(compressedTempPath.toString), outPath)
+                  withResource(fs.create(outPath, false)) { out =>
+                    Files.copy(compressedTempPath, out)
+                  }
                   compressedTempPath.toFile.delete() // delete compressed temp file
                 } else {
                   // If compression fails, copy the original file
                   log.warn("JFR compression failed, copying uncompressed file")
-                  fs.copyFromLocalFile(new Path(tempFilePath.toString), 
-                    new Path(asyncProfilerPrefix.get, baseFileName))
+                  withResource(fs.create(new Path(asyncProfilerPrefix.get, baseFileName), false)) { out =>
+                    Files.copy(tempFilePath, out)
+                  }
                 }
               } else {
-                fs.copyFromLocalFile(new Path(tempFilePath.toString), outPath)
+                withResource(fs.create(outPath, false)) { out =>
+                  Files.copy(tempFilePath, out)
+                }
               }
               tempFilePath.toFile.delete() // delete the original temp file after moving
             } else {


### PR DESCRIPTION
### Description

The async profiler currently fails to save its output to s3. This is because it calls `copyFromLocalFile` to copy each result file to s3, which has a [known issue](https://issues.apache.org/jira/browse/HADOOP-18173). This PR uses `Files.copy` after opening a stream to work around the issue.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
