### PR TITLE
Use mirror for internal usage to avoid 429 from maven central [skip ci]

### DIFF
--- a/jenkins/databricks/deploy.sh
+++ b/jenkins/databricks/deploy.sh
@@ -24,7 +24,8 @@ cd spark-rapids
 echo "Maven mirror is $MVN_URM_MIRROR"
 SERVER_ID='snapshots'
 SERVER_URL="$ART_URL-local"
-MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3"
+MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+MVN="mvn -s $MVN_SETTINGS -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3"
 # Determine Scala version and POM file from Spark version
 if [[ "$BASE_SPARK_VERSION" == 4.* ]]; then
     SCALA_VERSION="2.13"
@@ -38,7 +39,7 @@ fi
 # remove the periods so change something like 3.2.1 to 321
 VERSION_NUM=${BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS//.}
 SPARK_VERSION_STR=spark$VERSION_NUM
-SPARK_PLUGIN_JAR_VERSION=`mvn help:evaluate -q -f $POM_FILE -pl dist -Dexpression=project.version -DforceStdout`
+SPARK_PLUGIN_JAR_VERSION=$($MVN help:evaluate -q -pl dist -Dexpression=project.version -DforceStdout)
 # Append 143 or 173 into the db shim version because Databricks 14.3.x and 15.4.x are both based on spark version 3.5.0
 # and Databricks 17.3 based on Spark 4.0.0
 if [[ "$DB_RUNTIME" == "14.3"* ]]; then

--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -35,6 +35,8 @@ SERVER_ID=${SERVER_ID:-"snapshots"}
 SERVER_URL=${SERVER_URL:-"file:/tmp/local-release-repo"}
 M2_CACHE=${M2_CACHE:-"/tmp/m2-cache"}
 DEST_PATH=${DEST_PATH:-"/tmp/test-get-dest"}
+MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 rm -rf $DEST_PATH && mkdir -p $DEST_PATH
 
 remote_maven_repo=$SERVER_ID::default::$SERVER_URL
@@ -47,7 +49,7 @@ while read -r line; do
     artifact=$line # artifact=groupId:artifactId:version:[[packaging]:classifier]
     # Clean up $M2_CACHE to avoid side-effect of previous dependency:get
     rm -rf $M2_CACHE/com/nvida
-    mvn -B dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
+    $MVN -B dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
 done < $ARTIFACT_FILE
 
 ls -l $DEST_PATH

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -102,7 +102,7 @@ if [ "$SIGN_FILE" == true ]; then
             ;;
     esac
 else
-    DEPLOY_CMD="$MVN -B deploy:deploy-file -s jenkins/settings.xml"
+    DEPLOY_CMD="$MVN -B deploy:deploy-file"
 fi
 DEPLOY_CMD="$DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID"
 echo "Deploy CMD: $DEPLOY_CMD"

--- a/jenkins/hybrid_execution.sh
+++ b/jenkins/hybrid_execution.sh
@@ -17,6 +17,9 @@
 
 set -ex
 
+MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
+
 # Explicitly export HYBRID_BACKEND_JARS for hybrid execution tests.
 export HYBRID_BACKEND_JARS
 
@@ -32,8 +35,8 @@ hybrid_prepare(){
     fi
 
     echo "Downloading hybrid execution dependency jars..."
-    # This script may run outside the project root path, so we use mvn -f $WORKSPACE to target the project's pom.xml
-    RAPIDS_HYBRID_VER=${RAPIDS_HYBRID_VER:-$(mvn -f $WORKSPACE -B -q help:evaluate -Dexpression=spark-rapids-hybrid.version -DforceStdout)}
+    # This script may run outside the project root path, so we use -f $WORKSPACE to target the project's pom.xml
+    RAPIDS_HYBRID_VER=${RAPIDS_HYBRID_VER:-$($MVN -f $WORKSPACE -B -q help:evaluate -Dexpression=spark-rapids-hybrid.version -DforceStdout)}
     RAPIDS_HYBRID_URL=${RAPIDS_HYBRID_URL:-$ART_URL}
     GLUTEN_BUNDLE_JAR="gluten-velox-bundle-${GLUTEN_VERSION}-spark${spark_prefix}_${SCALA_BINARY_VER}-${os_version}_${cup_arch}.jar"
     HYBRID_JAR="rapids-4-spark-hybrid_${SCALA_BINARY_VER}-${RAPIDS_HYBRID_VER}.jar"

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -18,7 +18,8 @@
 set -ex
 
 ## MVN_OPT : maven options environment, e.g. MVN_OPT='-Dspark-rapids-jni.version=xxx' to specify spark-rapids-jni dependency's version.
-export MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3 ${MVN_OPT} -Psource-javadoc"
+MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+export MVN="mvn -s $MVN_SETTINGS -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3 ${MVN_OPT} -Psource-javadoc"
 
 . jenkins/version-def.sh
 
@@ -26,7 +27,7 @@ export MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentC
 # scala2.12 and scala2.13 (with maven.compiler.source as 1.8)
 export JAVA_HOME=$(echo /usr/lib/jvm/java-1.17.0-*)
 update-java-alternatives --set $JAVA_HOME
-mvn -version
+$MVN -version
 
 DIST_PL="dist"
 DIST_PATH="$DIST_PL" # The path of the dist module is used only outside of the mvn cmd

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -29,7 +29,8 @@ fi
 
 CUDA_CLASSIFIER=${CUDA_CLASSIFIER:-'cuda12'}
 CLASSIFIER=${CLASSIFIER:-"$CUDA_CLASSIFIER"} # default as CUDA_CLASSIFIER for compatibility
-MVN_CMD="mvn -Dmaven.wagon.http.retryHandler.count=3"
+MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+MVN=${MVN:-"mvn -s $MVN_SETTINGS -Dmaven.wagon.http.retryHandler.count=3"}
 MVN_BUILD_ARGS="-Drat.skip=true -Dmaven.scaladoc.skip -Dmaven.scalastyle.skip=true -Dcuda.version=$CLASSIFIER"
 
 mvn_verify() {
@@ -46,7 +47,7 @@ mvn_verify() {
     # file size check for pull request. The size of a committed file should be less than 1.5MiB
     pre-commit run check-added-large-files --from-ref $BASE_REF --to-ref HEAD
 
-    MVN_INSTALL_CMD="env -u SPARK_HOME $MVN_CMD -U -B $MVN_URM_MIRROR clean install $MVN_BUILD_ARGS -DskipTests -pl aggregator -am"
+    MVN_INSTALL_CMD="env -u SPARK_HOME $MVN -U -B $MVN_URM_MIRROR clean install $MVN_BUILD_ARGS -DskipTests -pl aggregator -am"
 
     # For snapshot versions, we do mvn[compile,RAT,scalastyle,docgen] CI in github actions
     for version in "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}"
@@ -63,10 +64,10 @@ mvn_verify() {
         done
         if [[ $match == 0 ]]; then
             env -u SPARK_HOME \
-              $MVN_CMD -U -B $MVN_URM_MIRROR -Dbuildver=$version clean install $MVN_BUILD_ARGS -Dpytest.TEST_TAGS=''
+              $MVN -U -B $MVN_URM_MIRROR -Dbuildver=$version clean install $MVN_BUILD_ARGS -Dpytest.TEST_TAGS=''
             # Run filecache tests
             env -u SPARK_HOME SPARK_CONF=spark.rapids.filecache.enabled=true \
-              $MVN_CMD -B $MVN_URM_MIRROR -Dbuildver=$version test -rf tests $MVN_BUILD_ARGS -Dpytest.TEST_TAGS='' \
+              $MVN -B $MVN_URM_MIRROR -Dbuildver=$version test -rf tests $MVN_BUILD_ARGS -Dpytest.TEST_TAGS='' \
               -DwildcardSuites=org.apache.spark.sql.rapids.filecache.FileCacheIntegrationSuite
         # build only for other versions
         # elif [[ "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}" =~ "$version" ]]; then
@@ -80,14 +81,14 @@ mvn_verify() {
     for version in "${SPARK_SHIM_VERSIONS_PREMERGE_UTF8[@]}"
     do
         echo "Spark version (regex): $version"
-        env -u SPARK_HOME LC_ALL="en_US.UTF-8" $MVN_CMD $MVN_URM_MIRROR -Dbuildver=$version package $MVN_BUILD_ARGS \
+        env -u SPARK_HOME LC_ALL="en_US.UTF-8" $MVN $MVN_URM_MIRROR -Dbuildver=$version package $MVN_BUILD_ARGS \
           -Dpytest.TEST_TAGS='' \
           -DwildcardSuites=com.nvidia.spark.rapids.ConditionalsSuite,com.nvidia.spark.rapids.RegularExpressionSuite,com.nvidia.spark.rapids.RegularExpressionTranspilerSuite
     done
 
     # Here run Python integration tests tagged with 'premerge_ci_1' only, that would help balance test duration and memory
     # consumption from two k8s pods running in parallel, which executes 'mvn_verify()' and 'ci_2()' respectively.
-    $MVN_CMD -B $MVN_URM_MIRROR $PREMERGE_PROFILES clean verify -Dpytest.TEST_TAGS="premerge_ci_1" \
+    $MVN -B $MVN_URM_MIRROR $PREMERGE_PROFILES clean verify -Dpytest.TEST_TAGS="premerge_ci_1" \
         -Dpytest.TEST_TYPE="pre-commit" -Dcuda.version=$CLASSIFIER
 
     # The jacoco coverage should have been collected, but because of how the shade plugin
@@ -194,7 +195,7 @@ ci_2() {
     update-java-alternatives --set $JAVA_HOME
     java -version
 
-    $MVN_CMD -U -B $MVN_URM_MIRROR clean package $MVN_BUILD_ARGS -DskipTests=true
+    $MVN -U -B $MVN_URM_MIRROR clean package $MVN_BUILD_ARGS -DskipTests=true
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
 
@@ -211,7 +212,7 @@ ci_2() {
     echo "Run mvn package..."
     for version in "${SPARK_SHIM_VERSIONS_PREMERGE_UT_2[@]}"
     do
-        env -u SPARK_HOME $MVN_CMD -U -B $MVN_URM_MIRROR -Dbuildver=$version clean package $MVN_BUILD_ARGS \
+        env -u SPARK_HOME $MVN -U -B $MVN_URM_MIRROR -Dbuildver=$version clean package $MVN_BUILD_ARGS \
           -Dpytest.TEST_TAGS=''
     done
 }
@@ -227,10 +228,10 @@ ci_scala213() {
     do
         echo "Spark version (Scala 2.13): $version"
         env -u SPARK_HOME \
-            $MVN_CMD -f scala2.13/ -U -B $MVN_URM_MIRROR -Dbuildver=$version clean install $MVN_BUILD_ARGS -Dpytest.TEST_TAGS=''
+            $MVN -f scala2.13/ -U -B $MVN_URM_MIRROR -Dbuildver=$version clean install $MVN_BUILD_ARGS -Dpytest.TEST_TAGS=''
         # Run filecache tests
         env -u SPARK_HOME SPARK_CONF=spark.rapids.filecache.enabled=true \
-            $MVN_CMD -f scala2.13/ -B $MVN_URM_MIRROR -Dbuildver=$version test -rf tests $MVN_BUILD_ARGS -Dpytest.TEST_TAGS='' \
+            $MVN -f scala2.13/ -B $MVN_URM_MIRROR -Dbuildver=$version test -rf tests $MVN_BUILD_ARGS -Dpytest.TEST_TAGS='' \
             -DwildcardSuites=org.apache.spark.sql.rapids.filecache.FileCacheIntegrationSuite
     done
 
@@ -241,7 +242,7 @@ ci_scala213() {
     prepare_spark $SPARK_VER 2.13
 
     # We are going to run integration tests against Spark 4.0.1
-    $MVN_CMD -f scala2.13/ -U -B $MVN_URM_MIRROR -Dbuildver=$buildver clean package $MVN_BUILD_ARGS -DskipTests=true
+    $MVN -f scala2.13/ -U -B $MVN_URM_MIRROR -Dbuildver=$buildver clean package $MVN_BUILD_ARGS -DskipTests=true
 
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -97,7 +97,9 @@ tar xzf "$RAPIDS_INT_TESTS_TGZ" -C $ARTF_ROOT && rm -f "$RAPIDS_INT_TESTS_TGZ"
 $WGET_CMD $SPARK_REPO/org/apache/spark/$SPARK_VER/spark-$SPARK_VER-$BIN_HADOOP_VER.tgz
 
 # Download parquet-hadoop jar for parquet-read encryption tests
-PARQUET_HADOOP_VER=`mvn help:evaluate -q -N -Dexpression=parquet.hadoop.version -DforceStdout -Dbuildver=${SHUFFLE_SPARK_SHIM/spark/}`
+PARQUET_HADOOP_VER=$($MVN -B org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate \
+  -q -N $MVN_URM_MIRROR -Dexpression=parquet.hadoop.version -DforceStdout \
+  -Dbuildver=${SHUFFLE_SPARK_SHIM/spark/})
 if [[ "$(printf '%s\n' "1.12.0" "$PARQUET_HADOOP_VER" | sort -V | head -n1)" = "1.12.0" ]]; then
   $WGET_CMD $SPARK_REPO/org/apache/parquet/parquet-hadoop/$PARQUET_HADOOP_VER/parquet-hadoop-$PARQUET_HADOOP_VER-tests.jar
 fi

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -96,16 +96,19 @@ tar xzf "$RAPIDS_INT_TESTS_TGZ" -C $ARTF_ROOT && rm -f "$RAPIDS_INT_TESTS_TGZ"
 . jenkins/hadoop-def.sh $SPARK_VER ${SCALA_BINARY_VER}
 $WGET_CMD $SPARK_REPO/org/apache/spark/$SPARK_VER/spark-$SPARK_VER-$BIN_HADOOP_VER.tgz
 
-# Download parquet-hadoop jar for parquet-read encryption tests
-PARQUET_HADOOP_VER=`mvn help:evaluate -q -N -Dexpression=parquet.hadoop.version -DforceStdout -Dbuildver=${SHUFFLE_SPARK_SHIM/spark/}`
-if [[ "$(printf '%s\n' "1.12.0" "$PARQUET_HADOOP_VER" | sort -V | head -n1)" = "1.12.0" ]]; then
-  $WGET_CMD $SPARK_REPO/org/apache/parquet/parquet-hadoop/$PARQUET_HADOOP_VER/parquet-hadoop-$PARQUET_HADOOP_VER-tests.jar
-fi
-
 export SPARK_HOME="$ARTF_ROOT/spark-$SPARK_VER-$BIN_HADOOP_VER"
 export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
 tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
     rm -f $SPARK_HOME.tgz
+
+# Download parquet-hadoop jar for parquet-read encryption tests
+PARQUET_HADOOP_JAR=$(find "$SPARK_HOME/jars" -maxdepth 1 -type f -name 'parquet-hadoop-[0-9]*.jar' | head -n1)
+PARQUET_HADOOP_VER=${PARQUET_HADOOP_JAR##*/parquet-hadoop-}
+PARQUET_HADOOP_VER=${PARQUET_HADOOP_VER%.jar}
+if [[ -n "$PARQUET_HADOOP_VER" && "$(printf '%s\n' "1.12.0" "$PARQUET_HADOOP_VER" | sort -V | head -n1)" = "1.12.0" ]]; then
+  $WGET_CMD $SPARK_REPO/org/apache/parquet/parquet-hadoop/$PARQUET_HADOOP_VER/parquet-hadoop-$PARQUET_HADOOP_VER-tests.jar
+fi
+
 # copy python path libs to container /tmp instead of workspace to avoid ephemeral PVC issue
 TMP_PYTHON=/tmp/$(date +"%Y%m%d")
 rm -rf $TMP_PYTHON && mkdir -p $TMP_PYTHON && cp -r $SPARK_HOME/python $TMP_PYTHON

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -19,6 +19,8 @@ set -ex
 
 nvidia-smi
 
+MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+
 . jenkins/version-def.sh
 . jenkins/shuffle-common.sh
 
@@ -97,7 +99,7 @@ tar xzf "$RAPIDS_INT_TESTS_TGZ" -C $ARTF_ROOT && rm -f "$RAPIDS_INT_TESTS_TGZ"
 $WGET_CMD $SPARK_REPO/org/apache/spark/$SPARK_VER/spark-$SPARK_VER-$BIN_HADOOP_VER.tgz
 
 # Download parquet-hadoop jar for parquet-read encryption tests
-PARQUET_HADOOP_VER=$($MVN -B org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate \
+PARQUET_HADOOP_VER=$($MVN -B help:evaluate \
   -q -N $MVN_URM_MIRROR -Dexpression=parquet.hadoop.version -DforceStdout \
   -Dbuildver=${SHUFFLE_SPARK_SHIM/spark/})
 if [[ "$(printf '%s\n' "1.12.0" "$PARQUET_HADOOP_VER" | sort -V | head -n1)" = "1.12.0" ]]; then

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -19,8 +19,6 @@ set -ex
 
 nvidia-smi
 
-MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
-
 . jenkins/version-def.sh
 . jenkins/shuffle-common.sh
 
@@ -99,9 +97,7 @@ tar xzf "$RAPIDS_INT_TESTS_TGZ" -C $ARTF_ROOT && rm -f "$RAPIDS_INT_TESTS_TGZ"
 $WGET_CMD $SPARK_REPO/org/apache/spark/$SPARK_VER/spark-$SPARK_VER-$BIN_HADOOP_VER.tgz
 
 # Download parquet-hadoop jar for parquet-read encryption tests
-PARQUET_HADOOP_VER=$($MVN -B help:evaluate \
-  -q -N $MVN_URM_MIRROR -Dexpression=parquet.hadoop.version -DforceStdout \
-  -Dbuildver=${SHUFFLE_SPARK_SHIM/spark/})
+PARQUET_HADOOP_VER=`mvn help:evaluate -q -N -Dexpression=parquet.hadoop.version -DforceStdout -Dbuildver=${SHUFFLE_SPARK_SHIM/spark/}`
 if [[ "$(printf '%s\n' "1.12.0" "$PARQUET_HADOOP_VER" | sort -V | head -n1)" = "1.12.0" ]]; then
   $WGET_CMD $SPARK_REPO/org/apache/parquet/parquet-hadoop/$PARQUET_HADOOP_VER/parquet-hadoop-$PARQUET_HADOOP_VER-tests.jar
 fi

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -26,8 +26,11 @@ for VAR in $OVERWRITE_PARAMS; do
 done
 IFS=$PRE_IFS
 
-MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
-MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
+if [[ -z "${MVN:-}" && -n "${MVN_SETTINGS:-}" ]]; then
+    MVN="mvn -s $MVN_SETTINGS"
+else
+    MVN=${MVN:-"mvn"}
+fi
 
 GLUTEN_VERSION=${GLUTEN_VERSION:-"1.2.0"}
 # TODO: https://github.com/NVIDIA/spark-rapids/issues/12278

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -26,7 +26,8 @@ for VAR in $OVERWRITE_PARAMS; do
 done
 IFS=$PRE_IFS
 
-MVN=${MVN:-"mvn"}
+MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 
 GLUTEN_VERSION=${GLUTEN_VERSION:-"1.2.0"}
 # TODO: https://github.com/NVIDIA/spark-rapids/issues/12278


### PR DESCRIPTION
### Description

We have seen multiple intermittent mvn ops failures caused by timeouts(or code 429) while downloading mvn plugins from maven central. We suspect this may be related to sonatype applying a more aggressive rate-limiting policy to internal egress IPs.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
