### PR TITLE
Quick fix of the cannot find settings file issue [skip ci]

### DIFF
--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -35,7 +35,9 @@ SERVER_ID=${SERVER_ID:-"snapshots"}
 SERVER_URL=${SERVER_URL:-"file:/tmp/local-release-repo"}
 M2_CACHE=${M2_CACHE:-"/tmp/m2-cache"}
 DEST_PATH=${DEST_PATH:-"/tmp/test-get-dest"}
-MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MVN_SETTINGS="$SCRIPT_DIR/settings.xml"
 MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 rm -rf $DEST_PATH && mkdir -p $DEST_PATH
 

--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -35,9 +35,8 @@ SERVER_ID=${SERVER_ID:-"snapshots"}
 SERVER_URL=${SERVER_URL:-"file:/tmp/local-release-repo"}
 M2_CACHE=${M2_CACHE:-"/tmp/m2-cache"}
 DEST_PATH=${DEST_PATH:-"/tmp/test-get-dest"}
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MVN_SETTINGS="$SCRIPT_DIR/settings.xml"
+MVN_SETTINGS=${MVN_SETTINGS:-"$SCRIPT_DIR/settings.xml"}
 MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 rm -rf $DEST_PATH && mkdir -p $DEST_PATH
 

--- a/jenkins/hybrid_execution.sh
+++ b/jenkins/hybrid_execution.sh
@@ -17,10 +17,6 @@
 
 set -ex
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MVN_SETTINGS="$SCRIPT_DIR/settings.xml"
-MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
-
 # Explicitly export HYBRID_BACKEND_JARS for hybrid execution tests.
 export HYBRID_BACKEND_JARS
 
@@ -36,8 +32,9 @@ hybrid_prepare(){
     fi
 
     echo "Downloading hybrid execution dependency jars..."
-    # This script may run outside the project root path, so we use -f $WORKSPACE to target the project's pom.xml
-    RAPIDS_HYBRID_VER=${RAPIDS_HYBRID_VER:-$($MVN -f $WORKSPACE -B -q help:evaluate -Dexpression=spark-rapids-hybrid.version -DforceStdout)}
+    # Read spark-rapids-hybrid.version directly from pom.xml; avoids an mvn call (and Maven Central plugin downloads).
+    # Assumes the property is a literal value, not a Maven property reference.
+    RAPIDS_HYBRID_VER=${RAPIDS_HYBRID_VER:-$(sed -n 's|.*<spark-rapids-hybrid\.version>\([^<]*\)</spark-rapids-hybrid\.version>.*|\1|p' "$WORKSPACE/pom.xml")}
     RAPIDS_HYBRID_URL=${RAPIDS_HYBRID_URL:-$ART_URL}
     GLUTEN_BUNDLE_JAR="gluten-velox-bundle-${GLUTEN_VERSION}-spark${spark_prefix}_${SCALA_BINARY_VER}-${os_version}_${cup_arch}.jar"
     HYBRID_JAR="rapids-4-spark-hybrid_${SCALA_BINARY_VER}-${RAPIDS_HYBRID_VER}.jar"

--- a/jenkins/hybrid_execution.sh
+++ b/jenkins/hybrid_execution.sh
@@ -17,7 +17,8 @@
 
 set -ex
 
-MVN_SETTINGS=${MVN_SETTINGS:-"jenkins/settings.xml"}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MVN_SETTINGS="$SCRIPT_DIR/settings.xml"
 MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 
 # Explicitly export HYBRID_BACKEND_JARS for hybrid execution tests.


### PR DESCRIPTION
Fixes #14751 #14730.

### Description

dep check and hybrid test script will switch workspace during process, so we need to have a hardcoded settings file path for them

### Checklists


Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
