### PR TITLE
Support projected schemas in struct extractors

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2636,10 +2636,7 @@ object GpuOverrides extends Logging {
         TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.BINARY),
         TypeSig.STRUCT.nested(TypeSig.all)),
-      (expr, conf, p, r) => new UnaryExprMeta[GetStructField](expr, conf, p, r) {
-        override def convertToGpu(arr: Expression): GpuExpression =
-          GpuGetStructField(arr, expr.ordinal, expr.name)
-      }),
+      (expr, conf, p, r) => new GpuGetStructFieldMeta(expr, conf, p, r)),
     expr[GetArrayItem](
       "Gets the field at `ordinal` in the Array",
       ExprChecks.binaryProject(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -413,7 +413,8 @@ class GpuGetStructFieldMeta(
 
   override def tagExprForGpu(): Unit = {
     childExprs.head.typeMeta.dataType.foreach { convertedChildType =>
-      GpuGetStructFieldMeta.resolveField(expr, convertedChildType) match {
+      GpuStructFieldRemap.resolveField(
+        expr.child.dataType, convertedChildType, expr.ordinal, "GetStructField") match {
         case EitherRight((_, field)) =>
           if (field.dataType != expr.dataType) {
             overrideDataType(field.dataType)
@@ -425,23 +426,11 @@ class GpuGetStructFieldMeta(
   }
 
   override def convertToGpu(child: Expression): GpuExpression = {
-    val effectiveOrd = GpuGetStructFieldMeta.effectiveOrdinal(expr, child)
+    val (effectiveOrd, _) = GpuStructFieldRemap.resolveField(
+      expr.child.dataType, child.dataType, expr.ordinal, "GetStructField").fold(
+        reason => throw new IllegalStateException(reason),
+        identity)
     GpuGetStructField(child, effectiveOrd, expr.name)
-  }
-}
-
-object GpuGetStructFieldMeta {
-  def resolveField(
-      expr: GetStructField,
-      convertedChildType: DataType): Either[String, (Int, StructField)] = {
-    GpuStructFieldRemap.resolveField(
-      expr.child.dataType, convertedChildType, expr.ordinal, "GetStructField")
-  }
-
-  def effectiveOrdinal(expr: GetStructField, child: Expression): Int = {
-    resolveField(expr, child.dataType).fold(
-      reason => throw new IllegalStateException(reason),
-      _._1)
   }
 }
 
@@ -454,7 +443,9 @@ class GpuGetArrayStructFieldsMeta(
 
   override def tagExprForGpu(): Unit = {
     childExprs.head.typeMeta.dataType.foreach { convertedChildType =>
-      GpuGetArrayStructFieldsMeta.resolveField(expr, convertedChildType) match {
+      GpuStructFieldRemap.resolveArrayStructField(
+        expr.child.dataType, convertedChildType, expr.ordinal,
+        "GetArrayStructFields") match {
         case EitherRight((_, field, _)) =>
           val convertedType = ArrayType(field.dataType, expr.containsNull)
           if (convertedType != expr.dataType) {
@@ -468,42 +459,17 @@ class GpuGetArrayStructFieldsMeta(
 
   override def convertToGpu(child: Expression): GpuExpression = {
     val (effectiveOrd, effectiveField, effectiveNumFields) =
-      GpuGetArrayStructFieldsMeta.resolveField(expr, child.dataType).fold(
-        reason => throw new IllegalStateException(reason),
-        identity)
+      GpuStructFieldRemap.resolveArrayStructField(
+        expr.child.dataType, child.dataType, expr.ordinal,
+        "GetArrayStructFields").fold(
+          reason => throw new IllegalStateException(reason),
+          identity)
     GpuGetArrayStructFields(child, effectiveField,
       effectiveOrd, effectiveNumFields, expr.containsNull)
   }
 }
 
-object GpuGetArrayStructFieldsMeta {
-  def resolveField(
-      expr: GetArrayStructFields,
-      convertedChildType: DataType): Either[String, (Int, StructField, Int)] = {
-    GpuStructFieldRemap.resolveArrayStructField(
-      expr.child.dataType, convertedChildType, expr.ordinal, "GetArrayStructFields")
-  }
-
-  def effectiveOrdinal(expr: GetArrayStructFields, child: Expression): Int = {
-    resolveField(expr, child.dataType).fold(
-      reason => throw new IllegalStateException(reason),
-      _._1)
-  }
-
-  def effectiveField(expr: GetArrayStructFields, child: Expression): StructField = {
-    resolveField(expr, child.dataType).fold(
-      reason => throw new IllegalStateException(reason),
-      _._2)
-  }
-
-  def effectiveNumFields(expr: GetArrayStructFields, child: Expression): Int = {
-    resolveField(expr, child.dataType).fold(
-      reason => throw new IllegalStateException(reason),
-      _._3)
-  }
-}
-
-private object GpuStructFieldRemap {
+object GpuStructFieldRemap {
   def resolveField(
       originalChildType: DataType,
       convertedChildType: DataType,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.rapids
 
+import scala.util.{Left => EitherLeft, Right => EitherRight}
+
 import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView, DType, Scalar}
 import ai.rapids.cudf.ColumnView.FindOptions
 import com.nvidia.spark.rapids.{BinaryExprMeta, DataFromReplacementRule, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuListUtils, GpuMapUtils, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta, UnaryExprMeta}
@@ -402,15 +404,166 @@ case class GpuArrayPosition(left: Expression, right: Expression)
   }
 }
 
+class GpuGetStructFieldMeta(
+    expr: GetStructField,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends UnaryExprMeta[GetStructField](expr, conf, parent, rule) {
+
+  override def tagExprForGpu(): Unit = {
+    childExprs.head.typeMeta.dataType.foreach { convertedChildType =>
+      GpuGetStructFieldMeta.resolveField(expr, convertedChildType) match {
+        case EitherRight((_, field)) =>
+          if (field.dataType != expr.dataType) {
+            overrideDataType(field.dataType)
+          }
+        case EitherLeft(reason) =>
+          willNotWorkOnGpu(reason)
+      }
+    }
+  }
+
+  override def convertToGpu(child: Expression): GpuExpression = {
+    val effectiveOrd = GpuGetStructFieldMeta.effectiveOrdinal(expr, child)
+    GpuGetStructField(child, effectiveOrd, expr.name)
+  }
+}
+
+object GpuGetStructFieldMeta {
+  def resolveField(
+      expr: GetStructField,
+      convertedChildType: DataType): Either[String, (Int, StructField)] = {
+    GpuStructFieldRemap.resolveField(
+      expr.child.dataType, convertedChildType, expr.ordinal, "GetStructField")
+  }
+
+  def effectiveOrdinal(expr: GetStructField, child: Expression): Int = {
+    resolveField(expr, child.dataType).fold(
+      reason => throw new IllegalStateException(reason),
+      _._1)
+  }
+}
+
 class GpuGetArrayStructFieldsMeta(
-     expr: GetArrayStructFields,
-     conf: RapidsConf,
-     parent: Option[RapidsMeta[_, _, _]],
-     rule: DataFromReplacementRule)
+    expr: GetArrayStructFields,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
   extends UnaryExprMeta[GetArrayStructFields](expr, conf, parent, rule) {
 
-  def convertToGpu(child: Expression): GpuExpression =
-    GpuGetArrayStructFields(child, expr.field, expr.ordinal, expr.numFields, expr.containsNull)
+  override def tagExprForGpu(): Unit = {
+    childExprs.head.typeMeta.dataType.foreach { convertedChildType =>
+      GpuGetArrayStructFieldsMeta.resolveField(expr, convertedChildType) match {
+        case EitherRight((_, field, _)) =>
+          val convertedType = ArrayType(field.dataType, expr.containsNull)
+          if (convertedType != expr.dataType) {
+            overrideDataType(convertedType)
+          }
+        case EitherLeft(reason) =>
+          willNotWorkOnGpu(reason)
+      }
+    }
+  }
+
+  override def convertToGpu(child: Expression): GpuExpression = {
+    val (effectiveOrd, effectiveField, effectiveNumFields) =
+      GpuGetArrayStructFieldsMeta.resolveField(expr, child.dataType).fold(
+        reason => throw new IllegalStateException(reason),
+        identity)
+    GpuGetArrayStructFields(child, effectiveField,
+      effectiveOrd, effectiveNumFields, expr.containsNull)
+  }
+}
+
+object GpuGetArrayStructFieldsMeta {
+  def resolveField(
+      expr: GetArrayStructFields,
+      convertedChildType: DataType): Either[String, (Int, StructField, Int)] = {
+    GpuStructFieldRemap.resolveArrayStructField(
+      expr.child.dataType, convertedChildType, expr.ordinal, "GetArrayStructFields")
+  }
+
+  def effectiveOrdinal(expr: GetArrayStructFields, child: Expression): Int = {
+    resolveField(expr, child.dataType).fold(
+      reason => throw new IllegalStateException(reason),
+      _._1)
+  }
+
+  def effectiveField(expr: GetArrayStructFields, child: Expression): StructField = {
+    resolveField(expr, child.dataType).fold(
+      reason => throw new IllegalStateException(reason),
+      _._2)
+  }
+
+  def effectiveNumFields(expr: GetArrayStructFields, child: Expression): Int = {
+    resolveField(expr, child.dataType).fold(
+      reason => throw new IllegalStateException(reason),
+      _._3)
+  }
+}
+
+private object GpuStructFieldRemap {
+  def resolveField(
+      originalChildType: DataType,
+      convertedChildType: DataType,
+      ordinal: Int,
+      context: String): Either[String, (Int, StructField)] = {
+    (originalChildType, convertedChildType) match {
+      case (originalStruct: StructType, convertedStruct: StructType) =>
+        resolveStructField(originalStruct, convertedStruct, ordinal, context)
+      case _ =>
+        EitherLeft(s"$context expected a converted StructType child but found $convertedChildType")
+    }
+  }
+
+  def resolveArrayStructField(
+      originalChildType: DataType,
+      convertedChildType: DataType,
+      ordinal: Int,
+      context: String): Either[String, (Int, StructField, Int)] = {
+    (originalChildType, convertedChildType) match {
+      case (
+          ArrayType(originalStruct: StructType, _),
+          ArrayType(convertedStruct: StructType, _)) =>
+        resolveStructField(originalStruct, convertedStruct, ordinal, context).map {
+          case (effectiveOrdinal, field) =>
+            (effectiveOrdinal, field, convertedStruct.fields.length)
+        }
+      case _ =>
+        EitherLeft(s"$context expected a converted ArrayType(StructType) child but found " +
+          s"$convertedChildType")
+    }
+  }
+
+  private def resolveStructField(
+      originalStruct: StructType,
+      convertedStruct: StructType,
+      ordinal: Int,
+      context: String): Either[String, (Int, StructField)] = {
+    if (ordinal < 0 || ordinal >= originalStruct.fields.length) {
+      return EitherLeft(s"$context ordinal $ordinal is outside the original struct schema")
+    }
+
+    val originalField = originalStruct.fields(ordinal)
+    if (ordinal < convertedStruct.fields.length &&
+        convertedStruct.fields(ordinal).name == originalField.name) {
+      EitherRight((ordinal, convertedStruct.fields(ordinal)))
+    } else {
+      val matches = convertedStruct.fields.zipWithIndex.filter {
+        case (field, _) => field.name == originalField.name
+      }
+      matches match {
+        case Array((field, effectiveOrdinal)) =>
+          EitherRight((effectiveOrdinal, field))
+        case Array() =>
+          EitherLeft(
+            s"$context field '${originalField.name}' is not present in the converted schema")
+        case _ =>
+          EitherLeft(s"$context field '${originalField.name}' is ambiguous in the converted schema")
+      }
+    }
+  }
 }
 
 /**

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/StructFieldProjectionSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/StructFieldProjectionSuite.scala
@@ -18,15 +18,8 @@ package com.nvidia.spark.rapids
 
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.spark.sql.catalyst.expressions.{
-  BoundReference,
-  GetArrayStructFields,
-  GetStructField
-}
-import org.apache.spark.sql.rapids.{
-  GpuGetArrayStructFieldsMeta,
-  GpuGetStructFieldMeta
-}
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, GetArrayStructFields, GetStructField}
+import org.apache.spark.sql.rapids.GpuStructFieldRemap
 import org.apache.spark.sql.types._
 
 class StructFieldProjectionSuite extends AnyFunSuite {
@@ -35,61 +28,62 @@ class StructFieldProjectionSuite extends AnyFunSuite {
     StructField("b", StringType),
     StructField("c", LongType)))
 
-  test("struct field meta keeps ordinal for matching converted child schema") {
-    val child = BoundReference(0, originalStruct, nullable = true)
-    val sparkExpr = GetStructField(child, ordinal = 1, Some("b"))
+  test("resolveField keeps ordinal when converted child schema matches the original") {
+    val sparkExpr = GetStructField(
+      BoundReference(0, originalStruct, nullable = true), ordinal = 1, Some("b"))
 
-    assert(GpuGetStructFieldMeta.effectiveOrdinal(sparkExpr, child) == 1)
-    GpuGetStructFieldMeta.resolveField(sparkExpr, child.dataType) match {
+    GpuStructFieldRemap.resolveField(
+      sparkExpr.child.dataType, originalStruct, sparkExpr.ordinal, "GetStructField") match {
       case Right((ordinal, field)) =>
         assert(ordinal == 1)
         assert(field == originalStruct.fields(1))
-      case Left(reason) =>
-        fail(reason)
+      case Left(reason) => fail(reason)
     }
   }
 
-  test("struct field meta resolves ordinal from projected child schema") {
-    val originalChild = BoundReference(0, originalStruct, nullable = true)
+  test("resolveField remaps ordinal when converted child schema drops earlier fields") {
     val projectedStruct = StructType(Seq(originalStruct.fields(2)))
-    val projectedChild = BoundReference(0, projectedStruct, nullable = true)
-    val sparkExpr = GetStructField(originalChild, ordinal = 2, Some("c"))
+    val sparkExpr = GetStructField(
+      BoundReference(0, originalStruct, nullable = true), ordinal = 2, Some("c"))
 
-    assert(GpuGetStructFieldMeta.effectiveOrdinal(sparkExpr, projectedChild) == 0)
-    GpuGetStructFieldMeta.resolveField(sparkExpr, projectedChild.dataType) match {
+    GpuStructFieldRemap.resolveField(
+      sparkExpr.child.dataType, projectedStruct, sparkExpr.ordinal, "GetStructField") match {
       case Right((ordinal, field)) =>
         assert(ordinal == 0)
         assert(field == projectedStruct.fields(0))
-      case Left(reason) =>
-        fail(reason)
+      case Left(reason) => fail(reason)
     }
   }
 
-  test("array struct field meta resolves ordinal and numFields from projected child schema") {
+  test("resolveArrayStructField returns ordinal, field and numFields from converted schema") {
     val originalArrayType = ArrayType(originalStruct, containsNull = true)
-    val originalChild = BoundReference(0, originalArrayType, nullable = true)
     val projectedStruct = StructType(Seq(originalStruct.fields(1)))
-    val projectedChild = BoundReference(0,
-      ArrayType(projectedStruct, containsNull = true), nullable = true)
     val sparkExpr = GetArrayStructFields(
-      originalChild,
+      BoundReference(0, originalArrayType, nullable = true),
       field = originalStruct.fields(1),
       ordinal = 1,
       numFields = originalStruct.fields.length,
       containsNull = true)
 
-    assert(GpuGetArrayStructFieldsMeta.effectiveOrdinal(sparkExpr, projectedChild) == 0)
-    assert(GpuGetArrayStructFieldsMeta.effectiveField(sparkExpr, projectedChild) ==
-      projectedStruct.fields(0))
-    assert(GpuGetArrayStructFieldsMeta.effectiveNumFields(sparkExpr, projectedChild) == 1)
+    GpuStructFieldRemap.resolveArrayStructField(
+      sparkExpr.child.dataType, ArrayType(projectedStruct, containsNull = true),
+      sparkExpr.ordinal, "GetArrayStructFields") match {
+      case Right((ordinal, field, numFields)) =>
+        assert(ordinal == 0)
+        assert(field == projectedStruct.fields(0))
+        assert(numFields == 1)
+      case Left(reason) => fail(reason)
+    }
   }
 
-  test("struct field meta rejects a converted child schema without the requested field") {
-    val originalChild = BoundReference(0, originalStruct, nullable = true)
+  test("resolveField rejects a converted child schema without the requested field") {
     val projectedStruct = StructType(Seq(originalStruct.fields(0)))
-    val sparkExpr = GetStructField(originalChild, ordinal = 2, Some("c"))
+    val sparkExpr = GetStructField(
+      BoundReference(0, originalStruct, nullable = true), ordinal = 2, Some("c"))
 
-    val error = GpuGetStructFieldMeta.resolveField(sparkExpr, projectedStruct).left.toOption
+    val error = GpuStructFieldRemap.resolveField(
+      sparkExpr.child.dataType, projectedStruct, sparkExpr.ordinal, "GetStructField")
+      .left.toOption
     assert(error.exists(_.contains("field 'c' is not present")))
   }
 }

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/StructFieldProjectionSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/StructFieldProjectionSuite.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.catalyst.expressions.{
+  BoundReference,
+  GetArrayStructFields,
+  GetStructField
+}
+import org.apache.spark.sql.rapids.{
+  GpuGetArrayStructFieldsMeta,
+  GpuGetStructFieldMeta
+}
+import org.apache.spark.sql.types._
+
+class StructFieldProjectionSuite extends AnyFunSuite {
+  private val originalStruct = StructType(Seq(
+    StructField("a", IntegerType),
+    StructField("b", StringType),
+    StructField("c", LongType)))
+
+  test("struct field meta keeps ordinal for matching converted child schema") {
+    val child = BoundReference(0, originalStruct, nullable = true)
+    val sparkExpr = GetStructField(child, ordinal = 1, Some("b"))
+
+    assert(GpuGetStructFieldMeta.effectiveOrdinal(sparkExpr, child) == 1)
+    GpuGetStructFieldMeta.resolveField(sparkExpr, child.dataType) match {
+      case Right((ordinal, field)) =>
+        assert(ordinal == 1)
+        assert(field == originalStruct.fields(1))
+      case Left(reason) =>
+        fail(reason)
+    }
+  }
+
+  test("struct field meta resolves ordinal from projected child schema") {
+    val originalChild = BoundReference(0, originalStruct, nullable = true)
+    val projectedStruct = StructType(Seq(originalStruct.fields(2)))
+    val projectedChild = BoundReference(0, projectedStruct, nullable = true)
+    val sparkExpr = GetStructField(originalChild, ordinal = 2, Some("c"))
+
+    assert(GpuGetStructFieldMeta.effectiveOrdinal(sparkExpr, projectedChild) == 0)
+    GpuGetStructFieldMeta.resolveField(sparkExpr, projectedChild.dataType) match {
+      case Right((ordinal, field)) =>
+        assert(ordinal == 0)
+        assert(field == projectedStruct.fields(0))
+      case Left(reason) =>
+        fail(reason)
+    }
+  }
+
+  test("array struct field meta resolves ordinal and numFields from projected child schema") {
+    val originalArrayType = ArrayType(originalStruct, containsNull = true)
+    val originalChild = BoundReference(0, originalArrayType, nullable = true)
+    val projectedStruct = StructType(Seq(originalStruct.fields(1)))
+    val projectedChild = BoundReference(0,
+      ArrayType(projectedStruct, containsNull = true), nullable = true)
+    val sparkExpr = GetArrayStructFields(
+      originalChild,
+      field = originalStruct.fields(1),
+      ordinal = 1,
+      numFields = originalStruct.fields.length,
+      containsNull = true)
+
+    assert(GpuGetArrayStructFieldsMeta.effectiveOrdinal(sparkExpr, projectedChild) == 0)
+    assert(GpuGetArrayStructFieldsMeta.effectiveField(sparkExpr, projectedChild) ==
+      projectedStruct.fields(0))
+    assert(GpuGetArrayStructFieldsMeta.effectiveNumFields(sparkExpr, projectedChild) == 1)
+  }
+
+  test("struct field meta rejects a converted child schema without the requested field") {
+    val originalChild = BoundReference(0, originalStruct, nullable = true)
+    val projectedStruct = StructType(Seq(originalStruct.fields(0)))
+    val sparkExpr = GetStructField(originalChild, ordinal = 2, Some("c"))
+
+    val error = GpuGetStructFieldMeta.resolveField(sparkExpr, projectedStruct).left.toOption
+    assert(error.exists(_.contains("field 'c' is not present")))
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuStructFieldMetaSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuStructFieldMetaSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GetStructField}
+import org.apache.spark.sql.rapids.{GpuGetStructField, GpuGetStructFieldMeta}
+import org.apache.spark.sql.types._
+
+class GpuStructFieldMetaSuite extends AnyFunSuite {
+  private val originalStruct = StructType(Seq(
+    StructField("a", IntegerType),
+    StructField("b", StringType),
+    StructField("c", LongType)))
+
+  private def conf: RapidsConf = new RapidsConf(Map.empty[String, String])
+
+  test("tagForGpu remaps ordinal when child schema is projected") {
+    val projectedStruct = StructType(Seq(originalStruct.fields(1), originalStruct.fields(2)))
+    val originalChild = AttributeReference("s", originalStruct, nullable = true)()
+    val sparkExpr = GetStructField(originalChild, ordinal = 2, Some("c"))
+
+    val meta = GpuOverrides.wrapExpr(sparkExpr, conf, None)
+      .asInstanceOf[GpuGetStructFieldMeta]
+    // simulate an upstream expression that produces a narrower converted child schema
+    meta.childExprs.head.overrideDataType(projectedStruct)
+    meta.tagForGpu()
+
+    assert(meta.canThisBeReplaced,
+      s"meta should be replaceable for projected schema, explain: ${meta.explain(all = false)}")
+    // field "c" survives the projection with the same dataType, so no override is needed
+    assert(meta.typeMeta.dataType.contains(LongType))
+
+    // pass a child whose dataType reflects the projection; the meta must remap ordinal 2 → 1
+    val projectedChild = AttributeReference("s_proj", projectedStruct, nullable = true)()
+    val gpuExpr = meta.convertToGpu(projectedChild).asInstanceOf[GpuGetStructField]
+    assert(gpuExpr.ordinal == 1)
+    assert(gpuExpr.name.contains("c"))
+  }
+
+  test("tagForGpu marks willNotWork when projected schema drops the requested field") {
+    val projectedStruct = StructType(Seq(originalStruct.fields(0)))
+    val originalChild = AttributeReference("s", originalStruct, nullable = true)()
+    val sparkExpr = GetStructField(originalChild, ordinal = 2, Some("c"))
+
+    val meta = GpuOverrides.wrapExpr(sparkExpr, conf, None)
+      .asInstanceOf[GpuGetStructFieldMeta]
+    meta.childExprs.head.overrideDataType(projectedStruct)
+    meta.tagForGpu()
+
+    assert(!meta.canThisBeReplaced)
+    val explain = meta.explain(all = false)
+    assert(explain.contains("field 'c' is not present"),
+      s"expected explain to mention missing field, got: $explain")
+  }
+}


### PR DESCRIPTION
Prerequisites for https://github.com/NVIDIA/spark-rapids/pull/14354

### Description

This PR adds common GPU conversion support for struct extractors whose child expression has a projected schema after GPU conversion.

Some expressions can produce a narrower converted child schema than their original Spark expression schema. In that case, downstream `GetStructField` and `GetArrayStructFields` expressions cannot keep using Spark original field ordinals directly, because the actual GPU child layout may have dropped fields before the requested one.

The change introduces `GpuGetStructFieldMeta` and updates `GpuGetArrayStructFieldsMeta` so they resolve the effective GPU ordinal from the converted child schema by field name. For arrays of structs, the meta also resolves the converted `StructField` and `numFields` from the converted child array element schema. Both metas delegate the lookup to a small `GpuStructFieldRemap` helper, which keeps generated GPU expressions consistent with the actual child layout without using expression tags or other side-channel state.

This is infrastructure for schema projection work such as `from_protobuf`: the source expression can expose a projected decoded schema during GPU conversion, and downstream struct extraction will use ordinals matching that projected schema.

There is no user-facing behavior or configuration change in this PR.

New unit coverage is added in `StructFieldProjectionSuite` for:

- unchanged struct schemas
- projected struct schemas
- projected array-of-struct schemas
- projected schemas that do not contain the requested field

New meta-level integration coverage is added in `GpuStructFieldMetaSuite` for:

- `tagForGpu` remaps ordinal and `convertToGpu` produces the projected `GpuGetStructField`
- `tagForGpu` marks the expression as willNotWork when the projected schema drops the requested field

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

Verification:

- `git diff --check`
- `mvn -pl sql-plugin -Dbuildver=352 -DwildcardSuites=com.nvidia.spark.rapids.StructFieldProjectionSuite test`
- `mvn -pl tests -Dbuildver=352 -DwildcardSuites=com.nvidia.spark.rapids.GpuStructFieldMetaSuite test`
