### PR TITLE
Fix unsafe close of HostColumnVectors in `GpuColumnVector::extractHostColumns()`

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -1072,6 +1072,14 @@ public class GpuColumnVector extends GpuColumnVectorBase {
         }
         Cuda.DEFAULT_STREAM.sync();
       } catch (Exception e) {
+        // Async D->H copies may still be in flight into the host buffers owned
+        // by hostCols; sync before closing to avoid a use-after-free on pinned
+        // memory.
+        try {
+          Cuda.DEFAULT_STREAM.sync();
+        } catch (Exception syncEx) {
+          e.addSuppressed(syncEx);
+        }
         for (RapidsHostColumnVector hostCol : hostCols) {
           if (hostCol != null) {
             try {

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -1075,17 +1075,27 @@ public class GpuColumnVector extends GpuColumnVectorBase {
         // Async D->H copies may still be in flight into the host buffers owned
         // by hostCols; sync before closing to avoid a use-after-free on pinned
         // memory.
+        boolean drained = false;
         try {
           Cuda.DEFAULT_STREAM.sync();
+          drained = true;
         } catch (Exception syncEx) {
           e.addSuppressed(syncEx);
         }
-        for (RapidsHostColumnVector hostCol : hostCols) {
-          if (hostCol != null) {
-            try {
-              hostCol.close();
-            } catch (Exception suppressed) {
-              e.addSuppressed(suppressed);
+        // If the recovery sync threw, the CUDA stream is in an error state
+        // and there is no guarantee that pending DMA writes into the host
+        // buffers have completed. Closing them now risks the DMA engine
+        // writing into freed memory. Leak the host buffers instead — the
+        // process is already in a broken state (sticky CUDA error typically
+        // requires a restart), and a leak is preferable to silent corruption.
+        if (drained) {
+          for (RapidsHostColumnVector hostCol : hostCols) {
+            if (hostCol != null) {
+              try {
+                hostCol.close();
+              } catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes #14758.

### Description

This commit fixes the unsafe closure of HostColumnVector instances in the exception-handling path in `GpuColumnVector::extractHostColumns()`.

In `GpuColumnVector::extractHostColumns()`, if an exception occurs during the copy of the device column data to host, the columns that have been copied so far are closed unsafely:
```java
     try {
        for (int i = 0; i < gpuCols.length; i++) {
          hostCols[i] = gpuCols[i].copyToHostAsync(Cuda.DEFAULT_STREAM);
        }
        Cuda.DEFAULT_STREAM.sync();
      } catch (Exception e) {
        for (RapidsHostColumnVector hostCol : hostCols) {
          if (hostCol != null) {
            try {
              hostCol.close();  // <-- Might be actively copied to, during close.
            } catch (Exception suppressed) {
              e.addSuppressed(suppressed);
            }
          }
        }
```

The fix introduces a sync on `Cuda.DEFAULT_STREAM`, to drain the existing copy operations before closing them.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
