### PR TITLE
[AutoSparkUT] Fix std variance floating overflow coverage

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -68,6 +68,14 @@ floating point aggregation then the join may fail to work properly with the plug
 worked with plain Spark. This is behavior is enabled by default but can be disabled with the config
 [`spark.rapids.sql.variableFloatAgg.enabled`](additional-functionality/advanced_configs.md#sql.variableFloatAgg.enabled).
 
+For standard deviation and variance aggregations (`stddev`, `stddev_pop`, `stddev_samp`,
+`variance`, `var_pop`, and `var_samp`) on very large finite floating-point values, the exact
+mathematical result can exceed the range of a double. In these overflow cases Spark CPU and the
+RAPIDS Accelerator may report different IEEE floating-point sentinels, such as `NaN` versus
+`+Infinity` or `-Infinity`, because partial aggregate state can be merged in a different order.
+This is limited to overflow behavior for extreme inputs; ordinary finite inputs should still match
+within normal floating-point tolerance.
+
 ### `0.0` vs `-0.0`
 
 Floating point allows zero to be encoded as `0.0` and `-0.0`, but the IEEE standard says that they

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -72,9 +72,10 @@ For standard deviation and variance aggregations (`stddev`, `stddev_pop`, `stdde
 `variance`, `var_pop`, and `var_samp`) on very large finite floating-point values, the exact
 mathematical result can exceed the range of a double. In these overflow cases Spark CPU and the
 RAPIDS Accelerator may report different IEEE floating-point sentinels, such as `NaN` versus
-`+Infinity` or `-Infinity`, because partial aggregate state can be merged in a different order.
-This is limited to overflow behavior for extreme inputs; ordinary finite inputs should still match
-within normal floating-point tolerance.
+`+Infinity`, because partial aggregate state can be merged in a different order. `-Infinity` is
+not an expected outcome for stddev/variance over finite inputs and is not treated as an accepted
+overflow sentinel. This is limited to overflow behavior for extreme inputs; ordinary finite
+inputs should still match within normal floating-point tolerance.
 
 ### `0.0` vs `-0.0`
 

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -85,8 +85,7 @@ def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=F
         # so sort the items to do our best with ignoring the order of dicts
         cpu_items = list(cpu.items()).sort(key=_RowCmp)
         gpu_items = list(gpu.items()).sort(key=_RowCmp)
-        _assert_equal(cpu_items, gpu_items, float_check, path + ["map"],
-            nan_inf_equivalent_for_overflow)
+        _assert_equal(cpu_items, gpu_items, float_check, path + ["map"])
     elif (t is int):
         assert cpu == gpu, f"GPU ({gpu}) and CPU ({cpu}) int values are different at {path}"
     elif (t is float):

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -28,25 +28,34 @@ import difflib
 import sys
 import re
 
-def _assert_equal(cpu, gpu, float_check, path):
+def _is_nan_inf_overflow_pair(cpu, gpu):
+    return type(gpu) is float and (
+        (math.isnan(cpu) and math.isinf(gpu)) or
+        (math.isinf(cpu) and math.isnan(gpu)))
+
+def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=False):
     t = type(cpu)
     if (t is Row):
         assert len(cpu) == len(gpu), "CPU and GPU row have different lengths at {} CPU: {} GPU: {}".format(path, len(cpu), len(gpu))
         if hasattr(cpu, "__fields__") and hasattr(gpu, "__fields__"):
             assert cpu.__fields__ == gpu.__fields__, "CPU and GPU row have different fields at {} CPU: {} GPU: {}".format(path, cpu.__fields__, gpu.__fields__)
             for field in cpu.__fields__:
-                _assert_equal(cpu[field], gpu[field], float_check, path + [field])
+                _assert_equal(cpu[field], gpu[field], float_check, path + [field],
+                    nan_inf_equivalent_for_overflow)
         else:
             for index in range(len(cpu)):
-                _assert_equal(cpu[index], gpu[index], float_check, path + [index])
+                _assert_equal(cpu[index], gpu[index], float_check, path + [index],
+                    nan_inf_equivalent_for_overflow)
     elif (t is list):
         assert len(cpu) == len(gpu), "CPU and GPU list have different lengths at {} CPU: {} GPU: {}".format(path, len(cpu), len(gpu))
         for index in range(len(cpu)):
-            _assert_equal(cpu[index], gpu[index], float_check, path + [index])
+            _assert_equal(cpu[index], gpu[index], float_check, path + [index],
+                nan_inf_equivalent_for_overflow)
     elif (t is tuple):
         assert len(cpu) == len(gpu), "CPU and GPU list have different lengths at {} CPU: {} GPU: {}".format(path, len(cpu), len(gpu))
         for index in range(len(cpu)):
-            _assert_equal(cpu[index], gpu[index], float_check, path + [index])
+            _assert_equal(cpu[index], gpu[index], float_check, path + [index],
+                nan_inf_equivalent_for_overflow)
     elif (t is pytypes.GeneratorType):
         index = 0
         # generator has no zip :( so we have to do this the hard way
@@ -67,7 +76,8 @@ def _assert_equal(cpu, gpu, float_check, path):
             if done:
                 assert sub_cpu == sub_gpu and sub_cpu == None, "CPU and GPU generators have different lengths at {}".format(path)
             else:
-                _assert_equal(sub_cpu, sub_gpu, float_check, path + [index])
+                _assert_equal(sub_cpu, sub_gpu, float_check, path + [index],
+                    nan_inf_equivalent_for_overflow)
 
             index = index + 1
     elif (t is dict):
@@ -75,10 +85,13 @@ def _assert_equal(cpu, gpu, float_check, path):
         # so sort the items to do our best with ignoring the order of dicts
         cpu_items = list(cpu.items()).sort(key=_RowCmp)
         gpu_items = list(gpu.items()).sort(key=_RowCmp)
-        _assert_equal(cpu_items, gpu_items, float_check, path + ["map"])
+        _assert_equal(cpu_items, gpu_items, float_check, path + ["map"],
+            nan_inf_equivalent_for_overflow)
     elif (t is int):
         assert cpu == gpu, f"GPU ({gpu}) and CPU ({cpu}) int values are different at {path}"
     elif (t is float):
+        if (nan_inf_equivalent_for_overflow and _is_nan_inf_overflow_pair(cpu, gpu)):
+            return
         if (math.isnan(cpu)):
             assert math.isnan(gpu), f"GPU ({gpu}) and CPU (nan) float values are different at {path}"
         else:
@@ -106,14 +119,15 @@ def _assert_equal(cpu, gpu, float_check, path):
     else:
         assert False, "Found unexpected type {} at {}".format(t, path)
 
-def assert_equal_with_local_sort(cpu, gpu):
+def assert_equal_with_local_sort(cpu, gpu, nan_inf_equivalent_for_overflow=False):
     _sort_locally(cpu, gpu)
-    assert_equal(cpu, gpu)
+    assert_equal(cpu, gpu, nan_inf_equivalent_for_overflow)
 
-def assert_equal(cpu, gpu):
+def assert_equal(cpu, gpu, nan_inf_equivalent_for_overflow=False):
     """Verify that the result from the CPU and the GPU are equal"""
     try:
-        _assert_equal(cpu, gpu, float_check=get_float_check(), path=[])
+        _assert_equal(cpu, gpu, float_check=get_float_check(), path=[],
+            nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
     except:
         def to_txt(data):
             try:
@@ -587,7 +601,8 @@ def _assert_gpu_and_cpu_are_equal(func,
     mode,
     conf={},
     is_cpu_first=True,
-    result_canonicalize_func_before_compare=None):
+    result_canonicalize_func_before_compare=None,
+    nan_inf_equivalent_for_overflow=False):
     (bring_back, collect_type) = _prep_func_for_compare(func, mode)
     conf = _prep_incompat_conf(conf)
 
@@ -625,7 +640,7 @@ def _assert_gpu_and_cpu_are_equal(func,
     if should_sort_locally():
         _sort_locally(from_cpu, from_gpu)
 
-    assert_equal(from_cpu, from_gpu)
+    assert_equal(from_cpu, from_gpu, nan_inf_equivalent_for_overflow)
 
 def run_with_cpu(func,
     mode,
@@ -687,7 +702,9 @@ def run_with_cpu_and_gpu(func,
 
     return (from_cpu, from_gpu)
 
-def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True, result_canonicalize_func_before_compare=None):
+def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True,
+        result_canonicalize_func_before_compare=None,
+        nan_inf_equivalent_for_overflow=False):
     """
     Assert when running func on both the CPU and the GPU that the results are equal.
     In this case the data is collected back to the driver and compared here, so be
@@ -702,8 +719,12 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True, resul
                                                     +Row(a=Row(first=-341142443, second=3.333994866005594e-37))
                                                   Use this func to canonicalize the results.
                                                   Usage of this func is: (cpu, gpu) = result_canonicalize_func_before_compare(original_cpu_result, original_gpu_result)
+    :param nan_inf_equivalent_for_overflow: Treat NaN vs +/-Inf as equivalent for
+                                            documented floating-point overflow tests.
     """
-    _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf, is_cpu_first=is_cpu_first, result_canonicalize_func_before_compare=result_canonicalize_func_before_compare)
+    _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf, is_cpu_first=is_cpu_first,
+        result_canonicalize_func_before_compare=result_canonicalize_func_before_compare,
+        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
 
 def assert_gpu_and_cpu_are_equal_iterator(func, conf={}, is_cpu_first=True):
     """
@@ -721,7 +742,9 @@ def assert_gpu_and_cpu_row_counts_equal(func, conf={}, is_cpu_first=True):
     """
     _assert_gpu_and_cpu_are_equal(func, 'COUNT', conf=conf, is_cpu_first=is_cpu_first)
 
-def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=False, is_cpu_first=True, validate_execs_in_gpu_plan=[]):
+def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=False,
+        is_cpu_first=True, validate_execs_in_gpu_plan=[],
+        nan_inf_equivalent_for_overflow=False):
     """
     Assert that the specified SQL query produces equal results on CPU and GPU.
     :param df_fun: a function that will create the dataframe
@@ -731,6 +754,8 @@ def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=F
     :param debug: Boolean to indicate if the SQL output should be printed
     :param is_cpu_first: Boolean to indicate if the CPU should be run first or not
     :param validate_execs_in_gpu_plan: String list of expressions to be validated in the GPU plan.
+    :param nan_inf_equivalent_for_overflow: Treat NaN vs +/-Inf as equivalent for
+                                            documented floating-point overflow tests.
     :return: Assertion failure, if results from CPU and GPU do not match.
     """
     if conf is None:
@@ -745,7 +770,8 @@ def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=F
             return data_gen.debug_df(spark.sql(sql))
         else:
             return spark.sql(sql)
-    assert_gpu_and_cpu_are_equal_collect(do_it_all, conf, is_cpu_first=is_cpu_first)
+    assert_gpu_and_cpu_are_equal_collect(do_it_all, conf, is_cpu_first=is_cpu_first,
+        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
 
 
 def check_exception(actual_error, error_message):

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -687,8 +687,7 @@ def run_with_cpu_and_gpu(func,
 
     return (from_cpu, from_gpu)
 
-def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True,
-        result_canonicalize_func_before_compare=None):
+def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True, result_canonicalize_func_before_compare=None):
     """
     Assert when running func on both the CPU and the GPU that the results are equal.
     In this case the data is collected back to the driver and compared here, so be
@@ -704,8 +703,7 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True,
                                                   Use this func to canonicalize the results.
                                                   Usage of this func is: (cpu, gpu) = result_canonicalize_func_before_compare(original_cpu_result, original_gpu_result)
     """
-    _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf, is_cpu_first=is_cpu_first,
-        result_canonicalize_func_before_compare=result_canonicalize_func_before_compare)
+    _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf, is_cpu_first=is_cpu_first, result_canonicalize_func_before_compare=result_canonicalize_func_before_compare)
 
 def assert_gpu_and_cpu_are_equal_iterator(func, conf={}, is_cpu_first=True):
     """

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -83,8 +83,8 @@ def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=F
     elif (t is dict):
         # The order of key/values is not guaranteed in python dicts, nor are they guaranteed by Spark
         # so sort the items to do our best with ignoring the order of dicts
-        cpu_items = sorted(cpu.items(), key=_RowCmp)
-        gpu_items = sorted(gpu.items(), key=_RowCmp)
+        cpu_items = list(cpu.items()).sort(key=_RowCmp)
+        gpu_items = list(gpu.items()).sort(key=_RowCmp)
         _assert_equal(cpu_items, gpu_items, float_check, path + ["map"],
             nan_inf_equivalent_for_overflow)
     elif (t is int):

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -28,34 +28,25 @@ import difflib
 import sys
 import re
 
-def _is_nan_inf_overflow_pair(cpu, gpu):
-    return type(gpu) is float and (
-        (math.isnan(cpu) and math.isinf(gpu)) or
-        (math.isinf(cpu) and math.isnan(gpu)))
-
-def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=False):
+def _assert_equal(cpu, gpu, float_check, path):
     t = type(cpu)
     if (t is Row):
         assert len(cpu) == len(gpu), "CPU and GPU row have different lengths at {} CPU: {} GPU: {}".format(path, len(cpu), len(gpu))
         if hasattr(cpu, "__fields__") and hasattr(gpu, "__fields__"):
             assert cpu.__fields__ == gpu.__fields__, "CPU and GPU row have different fields at {} CPU: {} GPU: {}".format(path, cpu.__fields__, gpu.__fields__)
             for field in cpu.__fields__:
-                _assert_equal(cpu[field], gpu[field], float_check, path + [field],
-                    nan_inf_equivalent_for_overflow)
+                _assert_equal(cpu[field], gpu[field], float_check, path + [field])
         else:
             for index in range(len(cpu)):
-                _assert_equal(cpu[index], gpu[index], float_check, path + [index],
-                    nan_inf_equivalent_for_overflow)
+                _assert_equal(cpu[index], gpu[index], float_check, path + [index])
     elif (t is list):
         assert len(cpu) == len(gpu), "CPU and GPU list have different lengths at {} CPU: {} GPU: {}".format(path, len(cpu), len(gpu))
         for index in range(len(cpu)):
-            _assert_equal(cpu[index], gpu[index], float_check, path + [index],
-                nan_inf_equivalent_for_overflow)
+            _assert_equal(cpu[index], gpu[index], float_check, path + [index])
     elif (t is tuple):
         assert len(cpu) == len(gpu), "CPU and GPU list have different lengths at {} CPU: {} GPU: {}".format(path, len(cpu), len(gpu))
         for index in range(len(cpu)):
-            _assert_equal(cpu[index], gpu[index], float_check, path + [index],
-                nan_inf_equivalent_for_overflow)
+            _assert_equal(cpu[index], gpu[index], float_check, path + [index])
     elif (t is pytypes.GeneratorType):
         index = 0
         # generator has no zip :( so we have to do this the hard way
@@ -76,8 +67,7 @@ def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=F
             if done:
                 assert sub_cpu == sub_gpu and sub_cpu == None, "CPU and GPU generators have different lengths at {}".format(path)
             else:
-                _assert_equal(sub_cpu, sub_gpu, float_check, path + [index],
-                    nan_inf_equivalent_for_overflow)
+                _assert_equal(sub_cpu, sub_gpu, float_check, path + [index])
 
             index = index + 1
     elif (t is dict):
@@ -89,8 +79,6 @@ def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=F
     elif (t is int):
         assert cpu == gpu, f"GPU ({gpu}) and CPU ({cpu}) int values are different at {path}"
     elif (t is float):
-        if (nan_inf_equivalent_for_overflow and _is_nan_inf_overflow_pair(cpu, gpu)):
-            return
         if (math.isnan(cpu)):
             assert math.isnan(gpu), f"GPU ({gpu}) and CPU (nan) float values are different at {path}"
         else:
@@ -118,15 +106,14 @@ def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=F
     else:
         assert False, "Found unexpected type {} at {}".format(t, path)
 
-def assert_equal_with_local_sort(cpu, gpu, nan_inf_equivalent_for_overflow=False):
+def assert_equal_with_local_sort(cpu, gpu):
     _sort_locally(cpu, gpu)
-    assert_equal(cpu, gpu, nan_inf_equivalent_for_overflow)
+    assert_equal(cpu, gpu)
 
-def assert_equal(cpu, gpu, nan_inf_equivalent_for_overflow=False):
+def assert_equal(cpu, gpu):
     """Verify that the result from the CPU and the GPU are equal"""
     try:
-        _assert_equal(cpu, gpu, float_check=get_float_check(), path=[],
-            nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
+        _assert_equal(cpu, gpu, float_check=get_float_check(), path=[])
     except:
         def to_txt(data):
             try:
@@ -600,8 +587,7 @@ def _assert_gpu_and_cpu_are_equal(func,
     mode,
     conf={},
     is_cpu_first=True,
-    result_canonicalize_func_before_compare=None,
-    nan_inf_equivalent_for_overflow=False):
+    result_canonicalize_func_before_compare=None):
     (bring_back, collect_type) = _prep_func_for_compare(func, mode)
     conf = _prep_incompat_conf(conf)
 
@@ -639,7 +625,7 @@ def _assert_gpu_and_cpu_are_equal(func,
     if should_sort_locally():
         _sort_locally(from_cpu, from_gpu)
 
-    assert_equal(from_cpu, from_gpu, nan_inf_equivalent_for_overflow)
+    assert_equal(from_cpu, from_gpu)
 
 def run_with_cpu(func,
     mode,
@@ -702,8 +688,7 @@ def run_with_cpu_and_gpu(func,
     return (from_cpu, from_gpu)
 
 def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True,
-        result_canonicalize_func_before_compare=None,
-        nan_inf_equivalent_for_overflow=False):
+        result_canonicalize_func_before_compare=None):
     """
     Assert when running func on both the CPU and the GPU that the results are equal.
     In this case the data is collected back to the driver and compared here, so be
@@ -718,12 +703,9 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True,
                                                     +Row(a=Row(first=-341142443, second=3.333994866005594e-37))
                                                   Use this func to canonicalize the results.
                                                   Usage of this func is: (cpu, gpu) = result_canonicalize_func_before_compare(original_cpu_result, original_gpu_result)
-    :param nan_inf_equivalent_for_overflow: Treat NaN vs +/-Inf as equivalent for
-                                            documented floating-point overflow tests.
     """
     _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf, is_cpu_first=is_cpu_first,
-        result_canonicalize_func_before_compare=result_canonicalize_func_before_compare,
-        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
+        result_canonicalize_func_before_compare=result_canonicalize_func_before_compare)
 
 def assert_gpu_and_cpu_are_equal_iterator(func, conf={}, is_cpu_first=True):
     """
@@ -743,7 +725,7 @@ def assert_gpu_and_cpu_row_counts_equal(func, conf={}, is_cpu_first=True):
 
 def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=False,
         is_cpu_first=True, validate_execs_in_gpu_plan=[],
-        nan_inf_equivalent_for_overflow=False):
+        result_canonicalize_func_before_compare=None):
     """
     Assert that the specified SQL query produces equal results on CPU and GPU.
     :param df_fun: a function that will create the dataframe
@@ -753,8 +735,8 @@ def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=F
     :param debug: Boolean to indicate if the SQL output should be printed
     :param is_cpu_first: Boolean to indicate if the CPU should be run first or not
     :param validate_execs_in_gpu_plan: String list of expressions to be validated in the GPU plan.
-    :param nan_inf_equivalent_for_overflow: Treat NaN vs +/-Inf as equivalent for
-                                            documented floating-point overflow tests.
+    :param result_canonicalize_func_before_compare: Function to canonicalize the CPU and GPU
+        results before comparison.
     :return: Assertion failure, if results from CPU and GPU do not match.
     """
     if conf is None:
@@ -770,7 +752,7 @@ def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=F
         else:
             return spark.sql(sql)
     assert_gpu_and_cpu_are_equal_collect(do_it_all, conf, is_cpu_first=is_cpu_first,
-        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
+        result_canonicalize_func_before_compare=result_canonicalize_func_before_compare)
 
 
 def check_exception(actual_error, error_message):

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -83,8 +83,8 @@ def _assert_equal(cpu, gpu, float_check, path, nan_inf_equivalent_for_overflow=F
     elif (t is dict):
         # The order of key/values is not guaranteed in python dicts, nor are they guaranteed by Spark
         # so sort the items to do our best with ignoring the order of dicts
-        cpu_items = list(cpu.items()).sort(key=_RowCmp)
-        gpu_items = list(gpu.items()).sort(key=_RowCmp)
+        cpu_items = sorted(cpu.items(), key=_RowCmp)
+        gpu_items = sorted(gpu.items(), key=_RowCmp)
         _assert_equal(cpu_items, gpu_items, float_check, path + ["map"],
             nan_inf_equivalent_for_overflow)
     elif (t is int):

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -194,14 +194,19 @@ _decimals_with_no_nulls = [
 _init_list_with_decimals = _init_list + [
     _decimals_with_nulls, _decimals_with_no_nulls]
 
-_std_variance_issue_14681_gen = [
-    ('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', DoubleGen()), ('c', DoubleGen())]
+_std_variance_common_fp_gens = [
+    [('a', RepeatSeqGen(IntegerGen(), length=20)),
+        ('b', DoubleGen(min_exp=-200, max_exp=200, no_nans=True)),
+        ('c', DoubleGen(min_exp=-200, max_exp=200, no_nans=True))],
+    [('a', RepeatSeqGen(IntegerGen(), length=20)),
+        ('b', FloatGen(no_nans=True)),
+        ('c', FloatGen(no_nans=True))]]
 
-# Grouped FP gens using bare DoubleGen()/FloatGen() on the aggregated columns.
-# Their default special_cases inject NaN, -0.0, +-Inf, and max-fraction values,
-# which exercise the corner-case paths for FP aggregate functions.
-_init_list_with_decimals_and_floats = _init_list_with_decimals + [
-    _std_variance_issue_14681_gen,
+_init_list_with_decimals_and_common_floats = (
+    _init_list_with_decimals + _std_variance_common_fp_gens)
+
+_std_variance_extreme_fp_gens = [
+    [('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', DoubleGen()), ('c', DoubleGen())],
     [('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', FloatGen()), ('c', FloatGen())]]
 
 # Used to test ANSI-mode fallback
@@ -2346,16 +2351,7 @@ def test_no_fallback_when_ansi_enabled(data_gen):
     assert_gpu_and_cpu_are_equal_collect(do_it,
         conf={'spark.sql.ansi.enabled': 'true'})
 
-# Tests for standard deviation and variance aggregations.
-@ignore_order(local=True)
-@approximate_float
-@incompat
-@pytest.mark.parametrize('data_gen', _init_list_with_decimals_and_floats, ids=idfn)
-@pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-def test_std_variance(data_gen, conf):
-    if data_gen is _std_variance_issue_14681_gen:
-        pytest.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/14681')
-
+def _assert_std_variance(data_gen, conf, nan_inf_equivalent_for_overflow=False):
     local_conf = copy_and_update(conf, {
         'spark.rapids.sql.castDecimalToFloat.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_sql(
@@ -2369,7 +2365,8 @@ def test_std_variance(data_gen, conf):
         'var_pop(b),' +
         'var_samp(b)' +
         ' from data_table group by a',
-        conf=local_conf)
+        conf=local_conf,
+        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1000),
         "data_table",
@@ -2377,7 +2374,31 @@ def test_std_variance(data_gen, conf):
         'stddev(b),' +
         'stddev_samp(b)'
         ' from data_table',
-        conf=local_conf)
+        conf=local_conf,
+        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
+
+
+# Tests for standard deviation and variance aggregations on common finite values.
+@ignore_order(local=True)
+@approximate_float
+@incompat
+@pytest.mark.parametrize('data_gen', _init_list_with_decimals_and_common_floats, ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
+def test_std_variance(data_gen, conf):
+    _assert_std_variance(data_gen, conf)
+
+
+# Extremely large FP inputs can make the true variance overflow double precision.
+# Spark CPU and GPU may surface that overflow as NaN or +/-Inf depending only on
+# accumulation order. Keep this corner coverage, but compare those overflow
+# sentinels loosely. See https://github.com/NVIDIA/spark-rapids/issues/14681.
+@ignore_order(local=True)
+@approximate_float
+@incompat
+@pytest.mark.parametrize('data_gen', _std_variance_extreme_fp_gens, ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
+def test_std_variance_extreme_floating_point(data_gen, conf):
+    _assert_std_variance(data_gen, conf, nan_inf_equivalent_for_overflow=True)
 
 
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -2363,7 +2363,11 @@ _STD_VARIANCE_FIELDS = {
 }
 
 def _canonicalize_std_variance_overflow_value(value):
-    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+    # Only NaN and +Infinity are accepted overflow sentinels for std/variance
+    # over finite inputs: they can be explained by overflow plus partial merge
+    # order. -Infinity would indicate a different issue (e.g. negative M2 /
+    # sign bug) and must not be canonicalized away.
+    if isinstance(value, float) and (math.isnan(value) or value == math.inf):
         return _STD_VARIANCE_OVERFLOW_SENTINEL
     return value
 
@@ -2420,9 +2424,11 @@ def test_std_variance(data_gen, conf):
 
 
 # Extremely large FP inputs can make the true variance overflow double precision.
-# Spark CPU and GPU may surface that overflow as NaN or +/-Inf depending only on
+# Spark CPU and GPU may surface that overflow as NaN or +Infinity depending only on
 # accumulation order. Keep this corner coverage, but compare those overflow
-# sentinels loosely. See https://github.com/NVIDIA/spark-rapids/issues/14681.
+# sentinels loosely. -Infinity is not an accepted overflow sentinel because
+# stddev/variance over finite inputs cannot reach it via overflow alone.
+# See https://github.com/NVIDIA/spark-rapids/issues/14681.
 @ignore_order(local=True)
 @approximate_float
 @incompat

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -206,8 +206,12 @@ _init_list_with_decimals_and_common_floats = (
     _init_list_with_decimals + _std_variance_common_fp_gens)
 
 _std_variance_extreme_fp_gens = [
-    [('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', DoubleGen()), ('c', DoubleGen())],
-    [('a', RepeatSeqGen(IntegerGen(), length=20)), ('b', FloatGen()), ('c', FloatGen())]]
+    [('a', RepeatSeqGen(IntegerGen(), length=20)),
+        ('b', DoubleGen(no_nans=True)),
+        ('c', DoubleGen(no_nans=True))],
+    [('a', RepeatSeqGen(IntegerGen(), length=20)),
+        ('b', FloatGen(no_nans=True)),
+        ('c', FloatGen(no_nans=True))]]
 
 # Used to test ANSI-mode fallback
 _no_overflow_ansi_gens = [

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -21,6 +21,7 @@ from conftest import is_databricks_runtime, spark_jvm
 from conftest import is_not_utc
 from data_gen import *
 from functools import reduce
+from pyspark.sql import Row
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.types import *
 from marks import *
@@ -2355,7 +2356,33 @@ def test_no_fallback_when_ansi_enabled(data_gen):
     assert_gpu_and_cpu_are_equal_collect(do_it,
         conf={'spark.sql.ansi.enabled': 'true'})
 
-def _assert_std_variance(data_gen, conf, nan_inf_equivalent_for_overflow=False):
+_STD_VARIANCE_OVERFLOW_SENTINEL = '__STD_VARIANCE_OVERFLOW__'
+_STD_VARIANCE_FIELDS = {
+    'stddev(b)', 'stddev_pop(b)', 'stddev_samp(b)',
+    'variance(b)', 'var_pop(b)', 'var_samp(b)'
+}
+
+def _canonicalize_std_variance_overflow_value(value):
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return _STD_VARIANCE_OVERFLOW_SENTINEL
+    return value
+
+def _canonicalize_std_variance_overflow_rows(rows):
+    return [
+        Row(**{
+            field: _canonicalize_std_variance_overflow_value(row[field])
+            if field in _STD_VARIANCE_FIELDS else row[field]
+            for field in row.__fields__
+        }) if isinstance(row, Row) and hasattr(row, "__fields__") else row
+        for row in rows
+    ]
+
+def _canonicalize_std_variance_overflow_results(cpu, gpu):
+    return (
+        _canonicalize_std_variance_overflow_rows(cpu),
+        _canonicalize_std_variance_overflow_rows(gpu))
+
+def _assert_std_variance(data_gen, conf, result_canonicalize_func_before_compare=None):
     local_conf = copy_and_update(conf, {
         'spark.rapids.sql.castDecimalToFloat.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_sql(
@@ -2370,7 +2397,7 @@ def _assert_std_variance(data_gen, conf, nan_inf_equivalent_for_overflow=False):
         'var_samp(b)' +
         ' from data_table group by a',
         conf=local_conf,
-        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
+        result_canonicalize_func_before_compare=result_canonicalize_func_before_compare)
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1000),
         "data_table",
@@ -2379,7 +2406,7 @@ def _assert_std_variance(data_gen, conf, nan_inf_equivalent_for_overflow=False):
         'stddev_samp(b)'
         ' from data_table',
         conf=local_conf,
-        nan_inf_equivalent_for_overflow=nan_inf_equivalent_for_overflow)
+        result_canonicalize_func_before_compare=result_canonicalize_func_before_compare)
 
 
 # Tests for standard deviation and variance aggregations on common finite values.
@@ -2402,7 +2429,10 @@ def test_std_variance(data_gen, conf):
 @pytest.mark.parametrize('data_gen', _std_variance_extreme_fp_gens, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 def test_std_variance_extreme_floating_point(data_gen, conf):
-    _assert_std_variance(data_gen, conf, nan_inf_equivalent_for_overflow=True)
+    _assert_std_variance(
+        data_gen,
+        conf,
+        result_canonicalize_func_before_compare=_canonicalize_std_variance_overflow_results)
 
 
 @ignore_order(local=True)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -250,11 +250,18 @@ class CudfMergeM2 extends CudfAggregate {
                   if (n > 0) {
                     val mean = partialMean.getDouble(i)
                     val m2 = partialM2.getDouble(i)
-                    val delta = mean - mergeMean
-                    val newN = n + mergeN
-                    mergeM2 += m2 + delta * delta * n * mergeN / newN
-                    mergeMean = (mergeMean * mergeN + mean * n) / newN
-                    mergeN = newN
+                    if (mergeN == 0.0) {
+                      mergeN = n
+                      mergeMean = mean
+                      mergeM2 = m2
+                    } else {
+                      val delta = mean - mergeMean
+                      val newN = mergeN + n
+                      val deltaN = delta / newN
+                      mergeM2 += m2 + delta * deltaN * mergeN * n
+                      mergeMean += deltaN * n
+                      mergeN = newN
+                    }
                   }
                 }
 


### PR DESCRIPTION
Closes #14681

This follows the discussion in this [issue comment](https://github.com/NVIDIA/spark-rapids/issues/14681#issuecomment-4406922778) to keep strict std/variance coverage for common floating-point inputs and split the overflow-oriented NaN/Inf cases into a smaller documented test set.

Upstream dependency:
- cuDF MERGE_M2 fix: [rapidsai/cudf#22393](https://github.com/rapidsai/cudf/pull/22393) (`0a1620e5b3`), which adds the first non-empty partial identity path for extreme finite means. `spark-rapids-jni` `origin/main` already points `thirdparty/cudf` at this fix.
- Scope split: the cuDF fix covers the native `GroupByAggregation.mergeM2()` path. The Scala change in this PR is still needed for `CudfMergeM2.reductionAggregate`, the host-side/global reduction merge path, because that path copies partial buffers to the JVM and does not call cuDF `MERGE_M2`. Without the Scala identity branch, the first non-empty partial can still evaluate the generic formula with `mergeN == 0`, causing `delta * delta` to overflow to `Inf` and then `Inf * 0` to become `NaN`.
- The Scala merge formula is also reordered to match Spark CPU `CentralMomentAgg` (`deltaN = delta / newN`; `m2 += delta * deltaN * n1 * n2`), reducing remaining CPU/GPU differences that are purely caused by merge-order arithmetic.

Changes:
- Match Spark's central-moment merge order in the host-side M2 reduction merge, including an identity path for the first non-empty partial.
- Split std/variance integration coverage into common finite floating-point cases with strict comparison and extreme floating-point cases with a scoped NaN/Inf overflow allowance.
- Pass the existing generic `result_canonicalize_func_before_compare` hook through the SQL assertion helper and keep std/variance overflow canonicalization local to the extreme-input test.
- Tighten post-review test plumbing by making the extreme FP generators finite-only with `no_nans=True`, so NaN/Inf output is attributable to overflow rather than input special cases. The broader dict/map comparison cleanup was kept out of this PR after Blossom exposed unrelated existing map/JSON/ORC differences.

Performance impact:
The Scala change runs only in the host-side `reductionAggregate` merge over partial aggregate rows. Complexity and allocation behavior are unchanged; the first non-empty partial now takes an identity branch and later partials use scalar double arithmetic equivalent to Spark's merge order. No GPU kernel or per-row expression hot path is changed.

Validation:
- `python -m py_compile integration_tests/src/main/python/asserts.py integration_tests/src/main/python/hash_aggregate_test.py`
- `git diff --check`
- `mvn package -DskipTests -pl dist,integration_tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -s jenkins/settings.xml -P mirror-apache-to-urm`: BUILD SUCCESS
- `TESTS='hash_aggregate_test.py::test_std_variance hash_aggregate_test.py::test_std_variance_extreme_floating_point' TEST_PARALLEL=1 DATAGEN_SEED=1777180076 ./integration_tests/run_pyspark_from_build.sh --tb=short`: `75 passed, 3 warnings in 985.02s (0:16:25)`
- Confirmed `spark-rapids-jni` `origin/main` has the cuDF fix via `thirdparty/cudf` -> `0a1620e5b3 Fix MERGE_M2 for extreme finite partial means (#22393)`.
- Rebuilt local spark-rapids dist with a JNI jar containing the equivalent cuDF fix revision `c12348ed68e05227139a54e19d35374530c23e7b`; confirmed the resulting `rapids-4-spark_2.12-26.06.0-SNAPSHOT-cuda12.jar` embeds that cuDF revision.
- Re-ran targeted IT with that rebuilt dist jar: `TESTS='hash_aggregate_test.py::test_std_variance hash_aggregate_test.py::test_std_variance_extreme_floating_point' TEST_PARALLEL=1 DATAGEN_SEED=1777180076 ./integration_tests/run_pyspark_from_build.sh --tb=short`: `75 passed, 3 warnings in 670.56s (0:11:10)`
- Post-review fix validation: `TESTS="hash_aggregate_test.py::test_std_variance_extreme_floating_point" TEST_PARALLEL=1 ./integration_tests/run_pyspark_from_build.sh -s`: `10 passed, 3 warnings in 101.80s (0:01:41)`
- Blossom blocker fix validation: `TESTS="hash_aggregate_test.py::test_std_variance_extreme_floating_point json_matrix_test.py::test_from_json_map_string_string[int_formatted.json]" TEST_PARALLEL=1 ./integration_tests/run_pyspark_from_build.sh --tb=short -q`: `11 passed, 3 warnings in 95.10s (0:01:35)`
- New review-comment follow-up validation after removing this PR's dict/map assertion diff: `TESTS="hash_aggregate_test.py::test_std_variance_extreme_floating_point json_matrix_test.py::test_from_json_map_string_string[int_formatted.json]" TEST_PARALLEL=1 ./integration_tests/run_pyspark_from_build.sh --tb=short -q`: `11 passed, 3 warnings in 116.69s (0:01:56)`
- Review fix validation after moving overflow handling out of the generic assert framework, using Python 3.10 and Spark 3.3.0: `TESTS='hash_aggregate_test.py::test_std_variance hash_aggregate_test.py::test_std_variance_extreme_floating_point' TEST_PARALLEL=1 DATAGEN_SEED=1777180076 ./integration_tests/run_pyspark_from_build.sh --tb=short -q`: `75 passed, 3 warnings in 656.13s (0:10:56)`
- Review nit follow-up (drop `-Infinity` from overflow sentinels; revert two unrelated wraps in `asserts.py`), Python 3.10 + Spark 3.3.0, `f402c5fb5`: `TEST='test_std_variance_extreme_floating_point or (test_std_variance and not extreme)' TEST_PARALLEL=0 DATAGEN_SEED=1777180076 ./integration_tests/run_pyspark_from_build.sh --tb=short -q`: `265 passed, 39510 deselected, 8 warnings in 1425.14s (0:23:45)`.

Documentation
- [x] Updated for new or modified user-facing features or behaviors
- [ ] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required



