### PR TITLE
Run dependency checks without Jenkins Maven settings [skip ci]

### DIFF
--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -31,7 +31,7 @@
 set -ex
 
 ARTIFACT_FILE=${1:-"/tmp/artifacts-list"}
-SERVER_ID=${SERVER_ID:-"snapshots"}
+SERVER_ID=${SERVER_ID:-"local"}
 SERVER_URL=${SERVER_URL:-"file:/tmp/local-release-repo"}
 M2_CACHE=${M2_CACHE:-"/tmp/m2-cache"}
 DEST_PATH=${DEST_PATH:-"/tmp/test-get-dest"}
@@ -40,14 +40,16 @@ MVN_SETTINGS=${MVN_SETTINGS:-"$SCRIPT_DIR/settings.xml"}
 MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 rm -rf $DEST_PATH && mkdir -p $DEST_PATH
 
-# Download the Maven dependency plugin into $M2_CACHE using -s $MVN_SETTINGS.
+# Warm up $M2_CACHE by downloading the Maven Dependency Plugin using -s $MVN_SETTINGS to fix intermittent mvn failures caused by timeouts
+# or HTTP 429 errors while do wnloading Maven plugins from Maven Central. See https://github.com/NVIDIA/spark-rapids/pull/14727.
 $MVN -B dependency:get -Dmaven.repo.local=$M2_CACHE -Dartifact=org.apache.maven.plugins:maven-dependency-plugin:2.8
 remote_maven_repo=$SERVER_ID::default::$SERVER_URL
 while read -r line; do
     artifact=$line # artifact=groupId:artifactId:version:[[packaging]:classifier]
     # Clean up $M2_CACHE to avoid side-effect of previous dependency:get
     rm -rf $M2_CACHE/com/nvidia
-    # Dependency checks should run without -s $MVN_SETTINGS.
+    # Dependency checks should run without -s $MVN_SETTINGS, because we do not want to download temporary or test JARs from the internal Maven repository.
+    # These internal JARs will not be released, and we only want to check dependency issues for release JARs. Using -s $MVN_SETTINGS may interfere with the check.
     mvn -B dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
 done < $ARTIFACT_FILE
 

--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -40,17 +40,15 @@ MVN_SETTINGS=${MVN_SETTINGS:-"$SCRIPT_DIR/settings.xml"}
 MVN=${MVN:-"mvn -s $MVN_SETTINGS"}
 rm -rf $DEST_PATH && mkdir -p $DEST_PATH
 
+# Download the Maven dependency plugin into $M2_CACHE using -s $MVN_SETTINGS.
+$MVN -B dependency:get -Dmaven.repo.local=$M2_CACHE -Dartifact=org.apache.maven.plugins:maven-dependency-plugin:2.8
 remote_maven_repo=$SERVER_ID::default::$SERVER_URL
-# Get the spark-rapids-jni, spark-rapids-private, hybrid jars from OSS Snapshot maven repo
-if [ "$SERVER_ID" == "snapshots" ]; then
-    oss_snapshot_url="https://central.sonatype.com/repository/maven-snapshots/"
-    remote_maven_repo="$remote_maven_repo,$SERVER_ID::default::$oss_snapshot_url"
-fi
 while read -r line; do
     artifact=$line # artifact=groupId:artifactId:version:[[packaging]:classifier]
     # Clean up $M2_CACHE to avoid side-effect of previous dependency:get
     rm -rf $M2_CACHE/com/nvida
-    $MVN -B dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
+    # Dependency checks should run without -s $MVN_SETTINGS.
+    mvn -B dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
 done < $ARTIFACT_FILE
 
 ls -l $DEST_PATH

--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -46,7 +46,7 @@ remote_maven_repo=$SERVER_ID::default::$SERVER_URL
 while read -r line; do
     artifact=$line # artifact=groupId:artifactId:version:[[packaging]:classifier]
     # Clean up $M2_CACHE to avoid side-effect of previous dependency:get
-    rm -rf $M2_CACHE/com/nvida
+    rm -rf $M2_CACHE/com/nvidia
     # Dependency checks should run without -s $MVN_SETTINGS.
     mvn -B dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact -Ddest=$DEST_PATH
 done < $ARTIFACT_FILE


### PR DESCRIPTION
Quick fix for: https://github.com/NVIDIA/spark-rapids/issues/14755

Pre-fetch the Maven dependency plugin into the isolated Maven cache using the Jenkins settings file. This allows plugin resolution to use the configured internal repositories before the validation loop starts.

Run each artifact dependency:get invocation with plain Maven and the explicit -DremoteRepositories value. This makes dependency-check.sh validate the repository passed through SERVER_ID and SERVER_URL instead of relying on repositories, mirrors, or profiles from settings.xml.

Remove the automatic OSS snapshot repository fallback so the check only succeeds when the requested artifacts and their transitive dependencies resolve from the target repository.



Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
