### PR TITLE
Avoid to_json fallback for JSON without timestamps on unsupported timezones

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1118,6 +1118,28 @@ _to_json_datagens=[byte_gen,
 # We need to explicitly specify the format for Spark 400
 _gpu_supported_timestamp_format_conf = {'timestampFormat': "yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]"}
 
+@pytest.mark.parametrize('data_gen', [int_gen, date_gen], ids=idfn)
+def test_structs_to_json_without_timestamp_non_utc_timezone(spark_tmp_path, data_gen):
+    struct_gen = StructGen([
+        ('a', data_gen),
+        ("b", ArrayGen(data_gen, nullable=True)),
+        ("c", MapGen(StringGen('[A-Z]{1,10}', nullable=False), data_gen, nullable=True)),
+    ], nullable=False)
+    gen = StructGen([('my_struct', struct_gen)], nullable=False)
+
+    options = { 'timeZone': 'PRC' }
+
+    def struct_to_json(spark):
+        df = gen_df(spark, gen)
+        return df.select(f.to_json("my_struct", options).alias("ms"))
+
+    conf = copy_and_update(_enable_all_types_conf,
+        { 'spark.rapids.sql.expression.StructsToJson': True })
+
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : struct_to_json(spark),
+        conf=conf)
+
 @pytest.mark.parametrize('data_gen', _to_json_datagens, ids=idfn)
 @pytest.mark.parametrize('ignore_null_fields', [True, False])
 @pytest.mark.parametrize('timezone', [
@@ -1253,6 +1275,58 @@ def test_structs_to_json_fallback_timezone(spark_tmp_path, data_gen, timezone):
     def struct_to_json(spark):
         df = gen_df(spark, gen)
         return df.withColumn("my_json", f.to_json("my_struct", options)).drop("my_struct")
+
+    conf = copy_and_update(_enable_all_types_conf,
+                           { 'spark.rapids.sql.expression.StructsToJson': True })
+
+    assert_gpu_fallback_collect(
+        lambda spark : struct_to_json(spark),
+        'ProjectExec',
+        conf=conf)
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
+@pytest.mark.parametrize('timezone', ['UTC+07:00'])
+def test_structs_to_json_fallback_explicit_timezone(spark_tmp_path, data_gen, timezone):
+    struct_gen = StructGen([
+        ('a', data_gen),
+        ("b", StructGen([('child', data_gen)], nullable=True)),
+        ("c", ArrayGen(StructGen([('child', data_gen)], nullable=True))),
+    ], nullable=False)
+    gen = StructGen([('my_struct', struct_gen)], nullable=False)
+
+    options = { 'timeZone': timezone }
+    options.update(_gpu_supported_timestamp_format_conf)
+
+    def struct_to_json(spark):
+        df = gen_df(spark, gen)
+        return df.withColumn("my_json", f.to_json("my_struct", options)).drop("my_struct")
+
+    conf = copy_and_update(_enable_all_types_conf,
+                           { 'spark.rapids.sql.expression.StructsToJson': True })
+
+    assert_gpu_fallback_collect(
+        lambda spark : struct_to_json(spark),
+        'ProjectExec',
+        conf=conf)
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
+def test_structs_to_json_fallback_analyzed_non_utc_timezone(spark_tmp_path, data_gen):
+    struct_gen = StructGen([
+        ('a', data_gen),
+    ], nullable=False)
+    gen = StructGen([('my_struct', struct_gen)], nullable=False)
+
+    def struct_to_json(spark):
+        spark.conf.set('spark.sql.session.timeZone', 'PRC')
+        df = gen_df(spark, gen)
+        ret = df.withColumn(
+            "my_json", f.to_json("my_struct", _gpu_supported_timestamp_format_conf)
+        ).drop("my_struct")
+        ret._jdf.queryExecution().analyzed()
+        spark.conf.set('spark.sql.session.timeZone', 'UTC')
+        return ret
 
     conf = copy_and_update(_enable_all_types_conf,
                            { 'spark.rapids.sql.expression.StructsToJson': True })

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuStructsToJson.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuStructsToJson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,9 @@ class GpuStructsToJsonMeta(
     rule: DataFromReplacementRule
   ) extends UnaryExprMeta[StructsToJson](expr, conf, parent, rule) {
 
+  // Timezone only affects JSON output when the input contains timestamps.
+  override def isTimeZoneSupported: Boolean = true
+
   override def tagExprForGpu(): Unit = {
     if (expr.options.get("pretty").exists(_.equalsIgnoreCase("true"))) {
       willNotWorkOnGpu("to_json option pretty=true is not supported")
@@ -60,10 +63,14 @@ class GpuStructsToJsonMeta(
           // tracking issue is https://github.com/NVIDIA/spark-rapids/issues/9602
           willNotWorkOnGpu(s"Unsupported timestampFormat '$timestampFormat' in to_json")
       }
-      if (options.zoneId.normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
+      if (expr.options.exists { case (key, _) => key.equalsIgnoreCase("timeZone") } &&
+          options.zoneId.normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
+        willNotWorkOnGpu(s"Unsupported timeZone '${options.zoneId}' in to_json")
+      }
+      if (expr.zoneId.normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
         // we hard-code the timezone `Z` in GpuCast.castTimestampToJson
         // so we need to fall back if expr different timeZone is specified
-        willNotWorkOnGpu(s"Unsupported timeZone '${options.zoneId}' in to_json")
+        willNotWorkOnGpu(s"Unsupported timeZone '${expr.zoneId}' in to_json")
       }
     }
 


### PR DESCRIPTION
Fixes #14771.

### Description

`StructsToJson` currently inherits the generic timezone check for timezone-aware expressions. That check requires UTC even when the `to_json` input does not contain any timestamp fields, so JSON conversion can fall back to CPU under non-UTC timezone settings even though timezone does not affect the result.

This change lets `GpuStructsToJsonMeta` handle timezone validation itself. It allows GPU execution for non-timestamp schemas under non-UTC timezones, while preserving CPU fallback for timestamp-containing schemas when either the analyzed expression timezone or an explicitly provided JSON `timeZone` option is not UTC. The analyzed-timezone fallback uses `expr.zoneId`, not the current `SQLConf`, so queries analyzed under a non-UTC timezone still fall back even if the session timezone changes before planning or execution.

Tests added:
- `test_structs_to_json_without_timestamp_non_utc_timezone`
- `test_structs_to_json_fallback_explicit_timezone`
- `test_structs_to_json_fallback_analyzed_non_utc_timezone`

Validation:
- `mvn install -Dbuildver=352 -DskipTests`
- `./integration_tests/run_pyspark_from_build.sh -s -k 'test_structs_to_json_without_timestamp_non_utc_timezone or test_structs_to_json_fallback_explicit_timezone or test_structs_to_json_fallback_analyzed_non_utc_timezone'`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
