### PR TITLE
Use ivysettings for spark packages resolution [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -30,6 +30,7 @@ WORKSPACE=${WORKSPACE:-`pwd`}
 
 ARTF_ROOT="$WORKSPACE/jars"
 WGET_CMD="wget -q -P $ARTF_ROOT -t 3"
+PROJECT_REPO_HOST=$(sed -E 's#^(.*://)?([^/@]*@)?([^/:]+).*#\3#' <<< "$PROJECT_REPO")
 
 rm -rf $ARTF_ROOT && mkdir -p $ARTF_ROOT
 $WGET_CMD $PROJECT_TEST_REPO/com/nvidia/rapids-4-spark-integration-tests_$SCALA_BINARY_VER/$PROJECT_TEST_VER/rapids-4-spark-integration-tests_$SCALA_BINARY_VER-$PROJECT_TEST_VER-${SHUFFLE_SPARK_SHIM}.jar
@@ -243,7 +244,9 @@ run_delta_lake_tests() {
       else 
         DELTA_JAR="io.delta:delta-core_${SCALA_BINARY_VER}:$v"
       fi 
-      PYSP_TEST_spark_jars_packages=${DELTA_JAR} \
+      HOST_NAME=$PROJECT_REPO_HOST \
+        PYSP_TEST_spark_jars_packages=${DELTA_JAR} \
+        PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \
         PYSP_TEST_spark_sql_extensions="io.delta.sql.DeltaSparkSessionExtension" \
         PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         ./run_pyspark_from_build.sh -m delta_lake --delta_lake
@@ -306,10 +309,12 @@ run_iceberg_tests() {
     if [[ "$test_type" == "default" ]]; then
       echo "!!! Running iceberg tests"
       env \
+        HOST_NAME=$PROJECT_REPO_HOST \
         EXPECTED_ICEBERG_VERSION=${ICEBERG_VERSION} \
         PYSP_TEST_spark_driver_memory=1G \
         PYSP_TEST_spark_executor_memory=2G \
         PYSP_TEST_spark_jars_packages=org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_${SCALA_BINARY_VER}:${ICEBERG_VERSION} \
+        PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \
         PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
         PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
         PYSP_TEST_spark_sql_catalog_spark__catalog_type="hadoop" \
@@ -323,6 +328,7 @@ org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
           # PYSP_TEST_ env var rather than as a session-level Spark config, because
           # FileCacheManager is initialized at executor startup time.
           env \
+            HOST_NAME=$PROJECT_REPO_HOST \
             EXPECTED_ICEBERG_VERSION=${ICEBERG_VERSION} \
             ICEBERG_TEST_CATALOG_TYPE="rest" \
             ICEBERG_TEST_REMOTE_CATALOG=1 \
@@ -330,7 +336,7 @@ org.apache.iceberg:iceberg-aws-bundle:${ICEBERG_VERSION}"
             PYSP_TEST_spark_executor_memory=2G \
             PYSP_TEST_spark_rapids_filecache_enabled=true \
             PYSP_TEST_spark_jars_packages="${ICEBERG_REST_JARS}" \
-            PYSP_TEST_spark_jars_repositories="${PROJECT_REPO}" \
+            PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \
             PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
             PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
             "PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl=org.apache.iceberg.rest.RESTCatalog" \
@@ -371,13 +377,14 @@ com.amazonaws:aws-java-sdk-bundle:${AWS_SDK_BUNDLE_VERSION}"
       # PYSP_TEST_ env var rather than as a session-level Spark config, because
       # FileCacheManager is initialized at executor startup time.
       env \
+        HOST_NAME=$PROJECT_REPO_HOST \
         EXPECTED_ICEBERG_VERSION=${ICEBERG_VERSION} \
         ICEBERG_TEST_REMOTE_CATALOG=1 \
         PYSP_TEST_spark_driver_memory=1G \
         PYSP_TEST_spark_executor_memory=2G \
         PYSP_TEST_spark_rapids_filecache_enabled=true \
         PYSP_TEST_spark_jars_packages="${ICEBERG_S3TABLES_JARS}" \
-        PYSP_TEST_spark_jars_repositories="${PROJECT_REPO}" \
+        PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \
         PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
         PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
         "PYSP_TEST_spark_sql_catalog_spark__catalog_catalog-impl=software.amazon.s3tables.iceberg.S3TablesCatalog" \
@@ -394,8 +401,10 @@ run_avro_tests() {
   # version of Apache Spark which requires accessing the snapshot repository to
   # fetch the spark-avro jar.
   rm -vf $LOCAL_JAR_PATH/spark-avro*.jar
-  PYSP_TEST_spark_jars_packages="org.apache.spark:spark-avro_${SCALA_BINARY_VER}:${SPARK_VER}" \
+  HOST_NAME=$PROJECT_REPO_HOST \
+    PYSP_TEST_spark_jars_packages="org.apache.spark:spark-avro_${SCALA_BINARY_VER}:${SPARK_VER}" \
     PYSP_TEST_spark_jars_repositories="https://repository.apache.org/snapshots" \
+    PYSP_TEST_spark_jars_ivySettings="${WORKSPACE}/jenkins/ivysettings.xml" \
     ./run_pyspark_from_build.sh -k avro
 }
 
@@ -455,6 +464,8 @@ if [[ $TEST_MODE == "DEFAULT" ]]; then
   # Spark Connect smoke test (available in Spark 3.5.6+)
   if printf '%s\n' "3.5.6" "$SPARK_VER" | sort -V | head -1 | grep -q "3.5.6"; then
     SPARK_CONNECT_SMOKE_TEST=1 \
+      HOST_NAME=$PROJECT_REPO_HOST \
+      PYSP_TEST_spark_jars_ivySettings=${WORKSPACE}/jenkins/ivysettings.xml \
       ./run_pyspark_from_build.sh
   fi
 
@@ -466,9 +477,8 @@ if [[ $TEST_MODE == "DEFAULT" ]]; then
   SKIP_PACKAGES_TESTS=${SKIP_PACKAGES_TESTS:-"false"}
   if { [[ "$CLASSIFIER" == "" || "$CLASSIFIER" == "cuda12" ]]; } && [[ "$SKIP_PACKAGES_TESTS" == "false" ]]; then
     # Add the ivysettings.xml file to support --packages downloads from Artifactory using credentials
-    # Get the HOST_NAME variable for ivysettings.xml (e.g., from https://usr:psw@HOST_NAME/path/to/repo)
-    HOST_NAME=$(sed -E 's#^(.*://)?([^/@]*@)?([^/:]+).*#\3#' <<< "$PROJECT_REPO")
-    SPARK_SHELL_SMOKE_TEST=1 HOST_NAME=$HOST_NAME \
+    # Set the HOST_NAME variable for ivysettings.xml (e.g., from https://usr:psw@HOST_NAME/path/to/repo)
+    SPARK_SHELL_SMOKE_TEST=1 HOST_NAME=$PROJECT_REPO_HOST \
     PYSP_TEST_spark_jars_packages=com.nvidia:rapids-4-spark_${SCALA_BINARY_VER}:${PROJECT_VER} \
     PYSP_TEST_spark_jars_repositories=${PROJECT_REPO} \
     PYSP_TEST_spark_jars_ivySettings=${WORKSPACE}/jenkins/ivysettings.xml \


### PR DESCRIPTION
## Context
Fixes https://github.com/NVIDIA/spark-rapids/issues/14766, https://github.com/NVIDIA/spark-rapids/issues/14765, https://github.com/NVIDIA/spark-rapids/issues/14763

## Summary
This PR updates package-based Spark integration test flows to use the Jenkins Ivy settings file so package resolution can use internal artifactory. Fixed tests:
1. iceberg default / s3tables / rest catalog tests
2. delta lake tests
3. spark connect smoke test
4. avro tests

## Changes
- Add `PROJECT_REPO_HOST` in `jenkins/spark-tests.sh` and use it when setting `HOST_NAME` for Ivy credentials.
- Pass `jenkins/ivysettings.xml` into Delta Lake, Iceberg, Avro, Spark Connect, and Spark shell package-resolution test paths.
- Keep the Apache snapshots repository for Avro package resolution while adding the custom Ivy settings.

## Verification
### iceberg tests
<img width="2352" height="52" alt="image" src="https://github.com/user-attachments/assets/09d4b662-a4c9-436e-baa1-7a68ef4b04d2" />

### delta lake tests
<img width="1628" height="70" alt="image" src="https://github.com/user-attachments/assets/9345ee96-babb-4ff6-88f1-60be83d13114" />



### spark connect smoke test
<img width="1202" height="640" alt="image" src="https://github.com/user-attachments/assets/d3a7a64a-79d7-45a6-a2f0-34d5d9f54b23" />


### avro tests
<img width="1654" height="74" alt="image" src="https://github.com/user-attachments/assets/126ae032-0a85-4b87-8829-d7494d5739e4" />

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required

