### PR TITLE
[AutoSparkUT] URI-decode JSON/CSV file path in GpuTextBasedPartitionReader (#11158, #13898)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids
 
+import java.net.URI
 import java.nio.charset.{Charset, StandardCharsets}
 import java.time.DateTimeException
 import java.util
@@ -384,7 +385,9 @@ abstract class GpuTextBasedPartitionReader[BUFF <: LineBufferer, FACT <: LineBuf
   metrics = execMetrics
 
   private lazy val estimatedHostBufferSize: Long = {
-    val rawPath = new Path(partFile.filePath.toString())
+    // URI-decode the file path so paths containing escaped glob metacharacters (e.g.
+    // `%5Babc%5D` for `[abc]`) resolve to a real FileStatus instead of FileNotFound.
+    val rawPath = new Path(new URI(partFile.filePath.toString()))
     val fs = rawPath.getFileSystem(conf)
     val path = fs.makeQualified(rawPath)
     val fileSize = fs.getFileStatus(path).getLen

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -132,7 +132,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsJsonFunctionsSuite]
     .exclude("SPARK-33134: return partial results only for root JSON objects", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14088"))
   enableSuite[RapidsJsonSuite]
-    .exclude("SPARK-32810: JSON data source should be able to read files with escaped glob metacharacter in the paths", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
     .exclude("SPARK-18352: Parse normal multi-line JSON files (uncompressed)", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
     .exclude("SPARK-18352: Parse normal multi-line JSON files (compressed)", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
     .exclude("Applying schemas", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
@@ -201,7 +200,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("save csv with empty fields with user defined empty values", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13895"))
     .exclude("SPARK-24329: skip lines with comments, and one or multiple whitespaces", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13896"))
     .exclude("SPARK-23786: warning should be printed if CSV header doesn't conform to schema", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13897"))
-    .exclude("SPARK-32810: CSV data source should be able to read files with escaped glob metacharacter in the paths", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13898"))
     .exclude("SPARK-33566: configure UnescapedQuoteHandling to parse unescaped quotes and unescaped delimiter data correctly", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13901"))
   enableSuite[RapidsCsvExpressionsSuite]
     .exclude("unsupported mode", ADJUST_UT("Replaced by a testRapids case which changed the expectation of SparkException instead of TestFailedException"))


### PR DESCRIPTION
Fixes #11158.
Fixes #13898.

### Description

`GpuTextBasedPartitionReader.estimatedHostBufferSize` constructed a Hadoop `Path` directly from `partFile.filePath.toString` — a URI-encoded string. When the file path contained escaped glob metacharacters (e.g. `%5Babc%5D` for `[abc]`), `new Path(String)` did not URI-decode the input, so `FileSystem.getFileStatus` looked up the literal percent-encoded filename on disk and threw `FileNotFoundException`. The peer scans `GpuOrcScan` (line 1367), `GpuParquetScan` (4 sites), and `GpuAvroScan` (2 sites) already use `new Path(new URI(partFile.filePath.toString()))`; the text-based reader was the lone outlier. This PR aligns it with that pattern and removes the two corresponding `KNOWN_ISSUE` exclusions, recovering the `SPARK-32810` test in both `RapidsJsonSuite` and `RapidsCSVSuite`.

### Per-test traceability

| RAPIDS test (suite) | Spark original | Spark source |
|---|---|---|
| SPARK-32810: JSON data source should be able to read files with escaped glob metacharacter in the paths (RapidsJsonSuite) | identical | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala:3231` |
| SPARK-32810: CSV data source should be able to read files with escaped glob metacharacter in the paths (RapidsCSVSuite) | identical | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala` |

### Maven evidence

```
mvn package -pl tests -am -Dbuildver=330 \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsJsonSuite,org.apache.spark.sql.rapids.suites.RapidsCSVSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

```
Tests: succeeded 251, failed 0, canceled 0, ignored 13, pending 0
All tests passed.
```

Remaining 13 ignored = unrelated JSON float-precision cluster (#10773) + unrelated CSV exclusions (#13889–#13901). No regressions.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required