### PR TITLE
Update premerge CI m2 cache restore [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -130,8 +130,6 @@ pipeline {
                     label "premerge-docker-${BUILD_TAG}"
                     cloud "${common.CLOUD_NAME}"
                     yaml pod.getDockerBuildYAML()
-                    workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
-                    customWorkspace "${CUSTOM_WORKSPACE}"
                 }
             }
 
@@ -200,7 +198,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                 timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
                                     try {
                                         common.resolveIncompatibleDriverIssue(this)
-                                        common.pvcM2Cache(this, PVC_MOUNT_PATH)
+                                        common.restoreM2Cache(this)
                                         common.prepareArtNetrc(this)
                                         sh "$PREMERGE_SCRIPT mvn_verify"
                                         step([$class                : 'JacocoPublisher',
@@ -242,7 +240,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                 timeout(time: 6, unit: 'HOURS') {
                                     try {
                                         common.resolveIncompatibleDriverIssue(this)
-                                        common.pvcM2Cache(this, PVC_MOUNT_PATH)
+                                        common.restoreM2Cache(this)
                                         common.prepareArtNetrc(this)
                                         sh "$PREMERGE_SCRIPT ci_2"
                                     } catch(e) {
@@ -278,7 +276,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                 timeout(time: 6, unit: 'HOURS') {
                                     try {
                                         common.resolveIncompatibleDriverIssue(this)
-                                        common.pvcM2Cache(this, PVC_MOUNT_PATH)
+                                        common.restoreM2Cache(this)
                                         common.prepareArtNetrc(this)
                                         sh "$PREMERGE_SCRIPT ci_scala213"
                                     } catch(e) {

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -24,7 +24,7 @@ import hudson.model.Result
 import hudson.model.Run
 import jenkins.model.CauseOfInterruption.UserInterruption
 
-@Library('blossom-lib@m2-cache_v2')
+@Library('blossom-lib')
 @Library('blossom-github-lib@master')
 import ipp.blossom.*
 

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -24,7 +24,7 @@ import hudson.model.Result
 import hudson.model.Run
 import jenkins.model.CauseOfInterruption.UserInterruption
 
-@Library('blossom-lib')
+@Library('blossom-lib@m2-cache_v2')
 @Library('blossom-github-lib@master')
 import ipp.blossom.*
 


### PR DESCRIPTION
### Description

Move CI m2 cache implementation from unreliable PVC to artifactory. Also removed unnecessary PVC usage for docker stage

### Checklists


Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
