### PR TITLE
[DeltaLake] Address Delta 4.x follow-up nits and add type widening tests [databricks] 

### DIFF
--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/GpuDeltaCatalogBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/GpuDeltaCatalogBase.scala
@@ -78,9 +78,23 @@ abstract class GpuDeltaCatalogBase(
   }
 
   protected lazy val isUnityCatalog: Boolean = {
-    val cpuIsUnityCatalogField = classOf[DeltaCatalog].getDeclaredField("isUnityCatalog")
-    cpuIsUnityCatalogField.setAccessible(true)
-    cpuIsUnityCatalogField.getBoolean(cpuCatalog)
+    @scala.annotation.tailrec
+    def findRequiredField(clazz: Class[_]): java.lang.reflect.Field = {
+      if (clazz == null) {
+        throw new IllegalStateException(
+          s"Unable to locate Delta catalog field isUnityCatalog on " +
+            s"${cpuCatalog.getClass.getName}; add a version-specific shim if this changed.")
+      }
+      try {
+        clazz.getDeclaredField("isUnityCatalog")
+      } catch {
+        case _: NoSuchFieldException => findRequiredField(clazz.getSuperclass)
+      }
+    }
+
+    val field = findRequiredField(cpuCatalog.getClass)
+    field.setAccessible(true)
+    field.getBoolean(cpuCatalog)
   }
 
   protected def isPathIdentifier(ident: Identifier): Boolean = {

--- a/delta-lake/delta-40x/pom.xml
+++ b/delta-lake/delta-40x/pom.xml
@@ -83,7 +83,7 @@
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-io/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-33x-41x/scala</source>
-                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x-41x/scala</source>
+                                 <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x-41x/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x/scala</source>
                             </sources>
                         </configuration>

--- a/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/delta41x/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/delta41x/GpuDeltaCatalog.scala
@@ -35,26 +35,6 @@ class GpuDeltaCatalog(
     rapidsConf: RapidsConf)
   extends GpuDeltaCatalog4x(cpuCatalog, rapidsConf) {
 
-  override protected lazy val isUnityCatalog: Boolean = {
-    @scala.annotation.tailrec
-    def findRequiredField(clazz: Class[_]): java.lang.reflect.Field = {
-      if (clazz == null) {
-        throw new IllegalStateException(
-          s"Unable to locate Delta catalog field isUnityCatalog on " +
-            s"${cpuCatalog.getClass.getName}; add a version-specific shim if this changed.")
-      }
-      try {
-        clazz.getDeclaredField("isUnityCatalog")
-      } catch {
-        case _: NoSuchFieldException => findRequiredField(clazz.getSuperclass)
-      }
-    }
-
-    val field = findRequiredField(cpuCatalog.getClass)
-    field.setAccessible(true)
-    field.getBoolean(cpuCatalog)
-  }
-
   override protected def buildGpuCreateDeltaTableCommand(
       withDb: CatalogTable,
       existingTableOpt: Option[CatalogTable],

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -84,14 +84,18 @@ TYPE_WIDENING_CASES = [
     pytest.param(
         "INT",
         "BIGINT",
-        "(1L, 1), (2L, 2)",
-        "(3L, CAST(2147483648 AS BIGINT)), (4L, CAST(2147483649 AS BIGINT))",
+        "(1L, CAST(NULL AS INT)), (2L, -2147483648), (3L, -1), (4L, 2147483647)",
+        "(5L, CAST(NULL AS BIGINT)), (6L, CAST(-2147483649 AS BIGINT)), "
+        "(7L, CAST(2147483648 AS BIGINT)), (8L, CAST(2147483649 AS BIGINT))",
         id="int_to_bigint"),
     pytest.param(
         "FLOAT",
         "DOUBLE",
-        "(1L, CAST(1.25 AS FLOAT)), (2L, CAST(2.5 AS FLOAT))",
-        "(3L, CAST(16777217.25 AS DOUBLE)), (4L, CAST(16777218.5 AS DOUBLE))",
+        "(1L, CAST(NULL AS FLOAT)), (2L, CAST(-1.25 AS FLOAT)), "
+        "(3L, CAST('NaN' AS FLOAT)), (4L, CAST(3.4028235E38 AS FLOAT))",
+        "(5L, CAST(NULL AS DOUBLE)), (6L, CAST(-16777217.25 AS DOUBLE)), "
+        "(7L, CAST('NaN' AS DOUBLE)), (8L, CAST(-3.4028236E38 AS DOUBLE)), "
+        "(9L, CAST(3.4028236E38 AS DOUBLE))",
         id="float_to_double"),
 ]
 
@@ -108,6 +112,7 @@ def _insert_type_widened_rows(spark, path, appended_rows):
     spark.sql(f"INSERT INTO delta.`{path}` VALUES {appended_rows}")
 
 
+# Collecting rows still goes through ColumnarToRowExec after the Delta scan.
 @allow_non_gpu("ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
@@ -128,7 +133,8 @@ def test_delta_type_widening_read_round_trip(
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.sql(
             f"SELECT id, value, typeof(value) AS value_type "
-            f"FROM delta.`{data_path}` ORDER BY id"))
+            f"FROM delta.`{data_path}` ORDER BY id"),
+        conf=_delta_confs)
 
 
 @allow_non_gpu(*delta_meta_allow)

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -80,6 +80,87 @@ def _assert_sql(data_path, confs, query):
         confs)
 
 
+TYPE_WIDENING_CASES = [
+    pytest.param(
+        "INT",
+        "BIGINT",
+        "(1L, 1), (2L, 2)",
+        "(3L, CAST(2147483648 AS BIGINT)), (4L, CAST(2147483649 AS BIGINT))",
+        id="int_to_bigint"),
+    pytest.param(
+        "FLOAT",
+        "DOUBLE",
+        "(1L, CAST(1.25 AS FLOAT)), (2L, CAST(2.5 AS FLOAT))",
+        "(3L, CAST(16777217.25 AS DOUBLE)), (4L, CAST(16777218.5 AS DOUBLE))",
+        id="float_to_double"),
+]
+
+
+def _setup_type_widened_table(spark, path, source_type, target_type, initial_rows):
+    _create_table(spark, path, f"id BIGINT, value {source_type}")
+    spark.sql(f"INSERT INTO delta.`{path}` VALUES {initial_rows}")
+    spark.sql(
+        f"ALTER TABLE delta.`{path}` SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')")
+    spark.sql(f"ALTER TABLE delta.`{path}` ALTER COLUMN value TYPE {target_type}")
+
+
+def _insert_type_widened_rows(spark, path, appended_rows):
+    spark.sql(f"INSERT INTO delta.`{path}` VALUES {appended_rows}")
+
+
+@allow_non_gpu("ColumnarToRowExec", *delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(not is_spark_400_or_later(),
+                    reason="Delta type widening ALTER COLUMN requires Delta 4.0+")
+@pytest.mark.parametrize(
+    "source_type,target_type,initial_rows,appended_rows",
+    TYPE_WIDENING_CASES)
+def test_delta_type_widening_read_round_trip(
+        spark_tmp_path, source_type, target_type, initial_rows, appended_rows):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+
+    def setup_table(spark):
+        _setup_type_widened_table(spark, data_path, source_type, target_type, initial_rows)
+        _insert_type_widened_rows(spark, data_path, appended_rows)
+
+    with_cpu_session(setup_table, conf=writer_confs)
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.sql(
+            f"SELECT id, value, typeof(value) AS value_type "
+            f"FROM delta.`{data_path}` ORDER BY id"))
+
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(not is_spark_400_or_later(),
+                    reason="Delta type widening ALTER COLUMN requires Delta 4.0+")
+@pytest.mark.parametrize(
+    "source_type,target_type,initial_rows,appended_rows",
+    TYPE_WIDENING_CASES)
+def test_delta_write_round_trip_after_type_widening(
+        spark_tmp_path, source_type, target_type, initial_rows, appended_rows):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+
+    def setup_tables(spark):
+        for path in [data_path + "/CPU", data_path + "/GPU"]:
+            _setup_type_widened_table(spark, path, source_type, target_type, initial_rows)
+
+    def do_insert(spark, path):
+        _insert_type_widened_rows(spark, path, appended_rows)
+
+    with_cpu_session(setup_tables, conf=writer_confs)
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        do_insert,
+        lambda spark, path: spark.sql(
+            f"SELECT id, value, typeof(value) AS value_type "
+            f"FROM delta.`{path}` ORDER BY id"),
+        data_path,
+        conf=_delta_confs)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
+
+
 @allow_non_gpu(delta_write_fallback_allow, *delta_meta_allow)
 @delta_lake
 @ignore_order

--- a/scala2.13/delta-lake/delta-40x/pom.xml
+++ b/scala2.13/delta-lake/delta-40x/pom.xml
@@ -83,7 +83,7 @@
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-io/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-33x-41x/scala</source>
-                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x-41x/scala</source>
+                                 <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x-41x/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x/scala</source>
                             </sources>
                         </configuration>

--- a/scala2.13/delta-lake/delta-41x/pom.xml
+++ b/scala2.13/delta-lake/delta-41x/pom.xml
@@ -85,7 +85,7 @@
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-io/scala</source>
                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-33x-41x/scala</source>
-                                  <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x-41x/scala</source>
+                                 <source>${spark.rapids.source.basedir}/delta-lake/common/src/main/delta-40x-41x/scala</source>
                             </sources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This is a follow-up to address the NITs in PR https://github.com/NVIDIA/spark-rapids/pull/14646, and also to cover  the type-widening validation discussed offline.

### Description

- Move the reflective `isUnityCatalog` lookup into `GpuDeltaCatalogBase` so Delta 4.1 can keep using the shared path when the field is inherited, and clean up the follow-up pom indentation nits from review.
- Add Delta Lake integration coverage for type widening reads and writes so we verify GPU/CPU parity for both `INT -> BIGINT` and `FLOAT -> DOUBLE` cases.
- Gate the type widening coverage to Spark 4.0+ because Delta 3.3 on Spark 3.5.6 does not support the `ALTER COLUMN TYPE` DDL used by these tests.
- Validation: built the multi-shim Delta artifacts for `spark356`, `spark400`, and `spark411`, then ran `test_delta_type_widening_read_round_trip` and `test_delta_write_round_trip_after_type_widening` on `spark356` (4 skipped), `spark400` (4 passed), and `spark411` (4 passed).

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required