### PR TITLE
Support join condition which has cast [databricks]

### DIFF
--- a/integration_tests/ScaleTest.md
+++ b/integration_tests/ScaleTest.md
@@ -61,6 +61,7 @@ The queries are define in the source code. You can check the table below to see 
 | q39        | unbounded window with simple partition by and order by columns, but complexity window operations as combinations of a few input columns | select {complexity aggregations mins/max of any column or SUM of two or more numeric columns multiplied together} over (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING PARTITION BY c_foreign_a ORDER BY c_data_row_num_1 |
 | q40        | COLLECT SET WINDOW (We may never really be able to do this well)                                       | select array_sort(collect_set(f_data_low_unique_1)) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW PARTITION BY f_key4_* order by f_data_row_num_1) |
 | q41        | COLLECT LIST WINDOW (We may never really be able to do this well)                                      | select collect_list(f_data_low_unique_1) OVER (ROWS BETWEEN complexity PRECEDING and CURRENT ROW PARTITION BY f_key4_* order by f_data_row_num_1) |
+| q42        | Conditional equi-join with CAST in non-equality condition (regression test for #14283).                | SELECT a_key4_1, a_data_low_unique_1, f_data_low_unique_1 FROM a_facts JOIN f_facts on a_key4_1 = f_key4_1 AND a_data_low_unique_1 < CAST(f_data_low_unique_1 AS BIGINT) AND CAST(f_data_row_num_1 AS BIGINT) > a_data_low_unique_1 |
 
 
 ## Submit

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/scaletest/QuerySpecs.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/scaletest/QuerySpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -770,7 +770,20 @@ class QuerySpecs(config: Config, spark: SparkSession) {
             s"from f_facts",
         config.iterations,
         config.timeout,
-        "COLLECT LIST WINDOW (We may never really be able to do this well)")).map { tc =>
+        "COLLECT LIST WINDOW (We may never really be able to do this well)"),
+      TestQuery("q42",
+        s"SELECT " +
+            s"a_key4_1, " +
+            s"a_data_low_unique_1, " +
+            s"f_data_low_unique_1 " +
+            s"FROM a_facts JOIN f_facts " +
+            s"on a_key4_1 = f_key4_1 AND " +
+            s"a_data_low_unique_1 < CAST(f_data_low_unique_1 AS BIGINT) AND " +
+            s"CAST(f_data_row_num_1 AS BIGINT) > a_data_low_unique_1",
+        config.iterations,
+        config.timeout,
+        "Conditional equi-join with CAST in non-equality condition (regression test for " +
+            "#14283: non-AST CAST extraction into pre-join GpuProjectExec).")).map { tc =>
       (tc.name, tc)
     }: _*)
     if (config.queries.isEmpty) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -89,13 +89,9 @@ class GpuShuffledHashJoinMeta(
   }
 
   override def convertToGpu(): GpuExec = {
-    val condition = conditionMeta.map(_.convertToGpu())
-    val (joinCondition, filterCondition) = if (conditionMeta.forall(_.canThisBeAst)) {
-      (condition, None)
-    } else {
-      (None, condition)
-    }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val extractedCondition = GpuHashJoin.extractJoinConditionIfNeeded(
+      conditionMeta, join.joinType, left, right)
     val useSizedJoin = GpuShuffledSizedHashJoinExec.useSizedJoin(conf, join.joinType,
       join.leftKeys, join.rightKeys)
     val readOpt = CoalesceReadOption(conf)
@@ -105,9 +101,9 @@ class GpuShuffledHashJoinMeta(
           join.joinType,
           leftKeys.map(_.convertToGpu()),
           rightKeys.map(_.convertToGpu()),
-          joinCondition,
-          left,
-          right,
+          extractedCondition.joinCondition,
+          extractedCondition.left,
+          extractedCondition.right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
           conf.sizedJoinPartitionAmplification,
@@ -121,9 +117,9 @@ class GpuShuffledHashJoinMeta(
           join.joinType,
           leftKeys.map(_.convertToGpu()),
           rightKeys.map(_.convertToGpu()),
-          joinCondition,
-          left,
-          right,
+          extractedCondition.joinCondition,
+          extractedCondition.left,
+          extractedCondition.right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
           conf.sizedJoinPartitionAmplification,
@@ -137,9 +133,9 @@ class GpuShuffledHashJoinMeta(
           rightKeys.map(_.convertToGpu()),
           join.joinType,
           buildSide,
-          joinCondition,
-          left,
-          right,
+          extractedCondition.joinCondition,
+          extractedCondition.left,
+          extractedCondition.right,
           readOpt,
           isSkewJoin = false)(
           join.leftKeys,
@@ -147,8 +143,9 @@ class GpuShuffledHashJoinMeta(
     }
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c,
+    val filteredJoinExec = extractedCondition.filterCondition.map(c => GpuFilterExec(c,
       joinExec)()).getOrElse(joinExec)
+    extractedCondition.projectIfNeeded(filteredJoinExec)
   }
 }
 
@@ -542,4 +539,3 @@ object GpuShuffledHashJoinExec extends Logging {
     retIter
   }
 }
-

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledSizedHashJoinExec.scala
@@ -414,13 +414,8 @@ abstract class GpuShuffledSizedHashJoinExec[HOST_BATCH_TYPE <: AutoCloseable] ex
       GpuHashPartitioning.getDistribution(cpuRightKeys))
 
   override def output: Seq[Attribute] = joinType match {
-    case _: InnerLike => left.output ++ right.output
-    case LeftOuter =>
-      left.output ++ right.output.map(_.withNullability(true))
-    case RightOuter =>
-      left.output.map(_.withNullability(true)) ++ right.output
-    case FullOuter =>
-      left.output.map(_.withNullability(true)) ++ right.output.map(_.withNullability(true))
+    case _: InnerLike | LeftOuter | RightOuter | FullOuter =>
+      GpuHashJoin.output(joinType, left.output, right.output)
     case x =>
       throw new IllegalArgumentException(s"unsupported join type: $x")
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,13 +76,9 @@ class GpuSortMergeJoinMeta(
   }
 
   override def convertToGpu(): GpuExec = {
-    val condition = conditionMeta.map(_.convertToGpu())
-    val (joinCondition, filterCondition) = if (conditionMeta.forall(_.canThisBeAst)) {
-      (condition, None)
-    } else {
-      (None, condition)
-    }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val extractedCondition = GpuHashJoin.extractJoinConditionIfNeeded(
+      conditionMeta, join.joinType, left, right)
     val useSizedJoin = GpuShuffledSizedHashJoinExec.useSizedJoin(conf, join.joinType,
       join.leftKeys, join.rightKeys)
     val readOpt = CoalesceReadOption(conf)
@@ -92,9 +88,9 @@ class GpuSortMergeJoinMeta(
           join.joinType,
           leftKeys.map(_.convertToGpu()),
           rightKeys.map(_.convertToGpu()),
-          joinCondition,
-          left,
-          right,
+          extractedCondition.joinCondition,
+          extractedCondition.left,
+          extractedCondition.right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
           conf.sizedJoinPartitionAmplification,
@@ -108,9 +104,9 @@ class GpuSortMergeJoinMeta(
           join.joinType,
           leftKeys.map(_.convertToGpu()),
           rightKeys.map(_.convertToGpu()),
-          joinCondition,
-          left,
-          right,
+          extractedCondition.joinCondition,
+          extractedCondition.left,
+          extractedCondition.right,
           conf.isGPUShuffle,
           conf.gpuTargetBatchSizeBytes,
           conf.sizedJoinPartitionAmplification,
@@ -124,9 +120,9 @@ class GpuSortMergeJoinMeta(
           rightKeys.map(_.convertToGpu()),
           join.joinType,
           buildSide,
-          joinCondition,
-          left,
-          right,
+          extractedCondition.joinCondition,
+          extractedCondition.left,
+          extractedCondition.right,
           readOpt,
           join.isSkewJoin)(
           join.leftKeys,
@@ -135,7 +131,8 @@ class GpuSortMergeJoinMeta(
 
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c,
+    val filteredJoinExec = extractedCondition.filterCondition.map(c => GpuFilterExec(c,
       joinExec)()).getOrElse(joinExec)
+    extractedCondition.projectIfNeeded(filteredJoinExec)
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
@@ -133,13 +133,41 @@ abstract class GpuBroadcastHashJoinExecBase(
 
   override def outputPartitioning: Partitioning = streamedPlan.outputPartitioning
 
-  def broadcastExchange: GpuBroadcastExchangeExec = buildPlan match {
+  private def splitBroadcastPlan(plan: SparkPlan): (SparkPlan, List[GpuProjectExec]) = plan match {
+    case project: GpuProjectExec =>
+      val (broadcastPlan, projects) = splitBroadcastPlan(project.child)
+      (broadcastPlan, project :: projects)
+    case _ =>
+      (plan, List.empty)
+  }
+
+  protected def getBroadcastPlan(plan: SparkPlan): SparkPlan = splitBroadcastPlan(plan)._1
+
+  def broadcastExchange: GpuBroadcastExchangeExec = getBroadcastPlan(buildPlan) match {
     case bqse: BroadcastQueryStageExec if bqse.plan.isInstanceOf[GpuBroadcastExchangeExec] =>
       bqse.plan.asInstanceOf[GpuBroadcastExchangeExec]
     case bqse: BroadcastQueryStageExec if bqse.plan.isInstanceOf[ReusedExchangeExec] =>
       bqse.plan.asInstanceOf[ReusedExchangeExec].child.asInstanceOf[GpuBroadcastExchangeExec]
     case gpu: GpuBroadcastExchangeExec => gpu
     case reused: ReusedExchangeExec => reused.child.asInstanceOf[GpuBroadcastExchangeExec]
+  }
+
+  protected def buildSidePostProjection: Option[ColumnarBatch => ColumnarBatch] = {
+    val projects = splitBroadcastPlan(buildPlan)._2.reverse
+    if (projects.nonEmpty) {
+      val boundProjects = projects.map { project =>
+        // Match GpuProjectExec's tiered binding so build-side extraction has the same
+        // splitting and retry behavior as a normal project.
+        GpuBindReferences.bindGpuReferencesTiered(
+          project.projectList, project.child.output, conf, allMetrics)
+      }
+      Some((batch: ColumnarBatch) => boundProjects.foldLeft(batch) {
+        case (currentBatch, boundProject) =>
+          withResource(currentBatch)(boundProject.project)
+      })
+    } else {
+      None
+    }
   }
 
   override def doExecute(): RDD[InternalRow] =
@@ -159,14 +187,17 @@ abstract class GpuBroadcastHashJoinExecBase(
     val broadcastRelation = broadcastExchange.executeColumnarBroadcast[Any]()
 
     val rdd = streamedPlan.executeColumnar()
-    val buildSchema = buildPlan.schema
+    val buildSchema = getBroadcastPlan(buildPlan).schema
+    val postProjectionAndClose = buildSidePostProjection
     val localIsNullAwareAntiJoin = isNullAwareAntiJoin
     rdd.mapPartitions { it =>
-      val (builtBatch, streamIter) =
+      val (broadcastBuiltBatch, streamIter) =
         GpuBroadcastHelper.getBroadcastBuiltBatchAndStreamIter(
           broadcastRelation,
           buildSchema,
           new CollectTimeIterator(NvtxRegistry.BROADCAST_JOIN_STREAM, it, streamTime))
+      val builtBatch = postProjectionAndClose.map(_(broadcastBuiltBatch))
+          .getOrElse(broadcastBuiltBatch)
       if (localIsNullAwareAntiJoin) {
         // This is to support the null-aware anti join for the LeftAnti join with
         // BuildRight. See the config "spark.sql.optimizeNullAwareAntiJoin".

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
@@ -163,7 +163,9 @@ abstract class GpuBroadcastHashJoinExecBase(
       }
       Some((batch: ColumnarBatch) => boundProjects.foldLeft(batch) {
         case (currentBatch, boundProject) =>
-          withResource(currentBatch)(boundProject.project)
+          val spillableBatch = SpillableColumnarBatch(
+            currentBatch, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+          boundProject.projectAndCloseWithRetrySingleBatch(spillableBatch)
       })
     } else {
       None

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -601,6 +601,15 @@ object JoinImpl {
 }
 
 object GpuHashJoin {
+  /**
+   * Captures the normalized join condition and child plans after extracting any non-AST
+   * expressions that can be safely computed on one side of the join.
+   *
+   * `joinCondition` is evaluated inside the hash join. `filterCondition` is the original
+   * condition when it cannot be rewritten for in-join AST evaluation. `left` and `right`
+   * may include projection wrappers that compute extracted expressions before the join.
+   * `finalProjectList` removes those temporary projected columns from the join output.
+   */
   case class ExtractedJoinCondition(
       joinCondition: Option[Expression],
       filterCondition: Option[Expression],
@@ -612,6 +621,13 @@ object GpuHashJoin {
     }
   }
 
+  /**
+   * Computes the visible output attributes for a hash join, including the nullability changes
+   * required by outer joins and the additional marker column produced by existence joins.
+   *
+   * This is shared by join exec nodes and by the final projection used after condition
+   * extraction so that temporary projection columns do not leak into the user-visible schema.
+   */
   def output(joinType: JoinType, left: Seq[Attribute], right: Seq[Attribute]): Seq[Attribute] = {
     joinType match {
       case _: InnerLike =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -26,6 +26,7 @@ import com.nvidia.spark.rapids.shims.ShimBinaryExecNode
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.{Cross, ExistenceJoin, FullOuter, Inner, InnerLike, JoinType, LeftAnti, LeftExistence, LeftOuter, LeftSemi, RightOuter}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -600,6 +601,79 @@ object JoinImpl {
 }
 
 object GpuHashJoin {
+  case class ExtractedJoinCondition(
+      joinCondition: Option[Expression],
+      filterCondition: Option[Expression],
+      left: SparkPlan,
+      right: SparkPlan,
+      finalProjectList: Option[List[NamedExpression]]) {
+    def projectIfNeeded(joinExec: GpuExec): GpuExec = {
+      finalProjectList.map(GpuProjectExec(_, joinExec)).getOrElse(joinExec)
+    }
+  }
+
+  def output(joinType: JoinType, left: Seq[Attribute], right: Seq[Attribute]): Seq[Attribute] = {
+    joinType match {
+      case _: InnerLike =>
+        left ++ right
+      case LeftOuter =>
+        left ++ right.map(_.withNullability(true))
+      case RightOuter =>
+        left.map(_.withNullability(true)) ++ right
+      case j: ExistenceJoin =>
+        left :+ j.exists
+      case LeftExistence(_) =>
+        left
+      case FullOuter =>
+        left.map(_.withNullability(true)) ++ right.map(_.withNullability(true))
+      case x =>
+        throw new IllegalArgumentException(s"GpuHashJoin should not take $x as the JoinType")
+    }
+  }
+
+  private def canConditionBeRewrittenAsAst(
+      conditionMeta: Option[BaseExprMeta[_]],
+      left: Seq[Attribute],
+      right: Seq[Attribute]): Boolean = {
+    conditionMeta.forall { condition =>
+      AstUtil.canExtractNonAstConditionIfNeed(
+        condition, left.map(_.exprId), right.map(_.exprId))
+    }
+  }
+
+  private def canConditionBeRewrittenAsAst(
+      meta: SparkPlanMeta[_],
+      conditionMeta: Option[BaseExprMeta[_]]): Boolean = {
+    val Seq(left, right) = meta.childPlans
+    canConditionBeRewrittenAsAst(conditionMeta, left.outputAttributes, right.outputAttributes)
+  }
+
+  def extractJoinConditionIfNeeded(
+      conditionMeta: Option[BaseExprMeta[_]],
+      joinType: JoinType,
+      left: SparkPlan,
+      right: SparkPlan): ExtractedJoinCondition = {
+    val condition = conditionMeta.map(_.convertToGpu())
+    if (conditionMeta.forall(_.canThisBeAst)) {
+      ExtractedJoinCondition(condition, None, left, right, None)
+    } else if (canConditionBeRewrittenAsAst(conditionMeta, left.output, right.output)) {
+      val (remains, leftExpr, rightExpr) =
+        AstUtil.extractNonAstFromJoinCond(conditionMeta, left.output, right.output)
+      val leftChild =
+        if (leftExpr.nonEmpty) GpuProjectExec(leftExpr ++ left.output.toList, left) else left
+      val rightChild =
+        if (rightExpr.nonEmpty) GpuProjectExec(rightExpr ++ right.output.toList, right) else right
+      val finalProjectList = if (leftExpr.isEmpty && rightExpr.isEmpty) {
+        None
+      } else {
+        Some(output(joinType, left.output, right.output).toList)
+      }
+      ExtractedJoinCondition(remains, None, leftChild, rightChild, finalProjectList)
+    } else {
+      ExtractedJoinCondition(None, condition, left, right, None)
+    }
+  }
+
   // Designed for the null-aware anti-join in GpuBroadcastHashJoin.
   def anyNullInKey(cb: ColumnarBatch, boundKeys: Seq[GpuExpression]): Boolean = {
     withResource(GpuProjectExec.project(cb, boundKeys)) { keysCb =>
@@ -660,12 +734,19 @@ object GpuHashJoin {
         "which is not yet supported on GPU")
     }
 
+    val canConditionBeRewrittenAsAst = GpuHashJoin.canConditionBeRewrittenAsAst(
+      meta, conditionMeta)
+
     joinType match {
       case _: InnerLike =>
       case RightOuter | LeftOuter | LeftSemi | LeftAnti | ExistenceJoin(_) =>
-        conditionMeta.foreach(meta.requireAstForGpuOn)
+        if (!canConditionBeRewrittenAsAst) {
+          conditionMeta.foreach(meta.requireAstForGpuOn)
+        }
       case FullOuter =>
-        conditionMeta.foreach(meta.requireAstForGpuOn)
+        if (!canConditionBeRewrittenAsAst) {
+          conditionMeta.foreach(meta.requireAstForGpuOn)
+        }
         // FullOuter join cannot support with struct keys as two issues below
         //  * https://github.com/NVIDIA/spark-rapids/issues/2126
         //  * https://github.com/rapidsai/cudf/issues/7947
@@ -2448,24 +2529,7 @@ trait GpuHashJoin extends GpuJoinExec {
     }
   }
 
-  override def output: Seq[Attribute] = {
-    joinType match {
-      case _: InnerLike =>
-        left.output ++ right.output
-      case LeftOuter =>
-        left.output ++ right.output.map(_.withNullability(true))
-      case RightOuter =>
-        left.output.map(_.withNullability(true)) ++ right.output
-      case j: ExistenceJoin =>
-        left.output :+ j.exists
-      case LeftExistence(_) =>
-        left.output
-      case FullOuter =>
-        left.output.map(_.withNullability(true)) ++ right.output.map(_.withNullability(true))
-      case x =>
-        throw new IllegalArgumentException(s"GpuHashJoin should not take $x as the JoinType")
-    }
-  }
+  override def output: Seq[Attribute] = GpuHashJoin.output(joinType, left.output, right.output)
 
   // If we have a single batch streamed in then we will produce a single batch of output
   // otherwise it can get smaller or bigger, we just don't know.  When we support out of

--- a/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,13 +38,9 @@ class GpuBroadcastHashJoinMeta(
     rule: DataFromReplacementRule) extends GpuBroadcastHashJoinMetaBase(join, conf, parent, rule) {
 
   override def convertToGpu(): GpuExec = {
-    val condition = conditionMeta.map(_.convertToGpu())
-    val (joinCondition, filterCondition) = if (conditionMeta.forall(_.canThisBeAst)) {
-      (condition, None)
-    } else {
-      (None, condition)
-    }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val extractedCondition = GpuHashJoin.extractJoinConditionIfNeeded(
+      conditionMeta, join.joinType, left, right)
     // The broadcast part of this must be a BroadcastExchangeExec
     val buildSideMeta = buildSide match {
       case GpuBuildLeft => left
@@ -56,12 +52,14 @@ class GpuBroadcastHashJoinMeta(
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       buildSide,
-      joinCondition,
-      left, right,
+      extractedCondition.joinCondition,
+      extractedCondition.left, extractedCondition.right,
       join.isNullAwareAntiJoin)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
+    val filteredJoinExec =
+      extractedCondition.filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
+    extractedCondition.projectIfNeeded(filteredJoinExec)
   }
 }
 

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -46,13 +46,9 @@ class GpuBroadcastHashJoinMeta(
     rule: DataFromReplacementRule) extends GpuBroadcastHashJoinMetaBase(join, conf, parent, rule) {
 
   override def convertToGpu(): GpuExec = {
-    val condition = conditionMeta.map(_.convertToGpu())
-    val (joinCondition, filterCondition) = if (conditionMeta.forall(_.canThisBeAst)) {
-      (condition, None)
-    } else {
-      (None, condition)
-    }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val extractedCondition = GpuHashJoin.extractJoinConditionIfNeeded(
+      conditionMeta, join.joinType, left, right)
     // The broadcast part of this must be a BroadcastExchangeExec
     val buildSideMeta = buildSide match {
       case GpuBuildLeft => left
@@ -64,14 +60,16 @@ class GpuBroadcastHashJoinMeta(
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       buildSide,
-      joinCondition,
-      left,
-      right,
+      extractedCondition.joinCondition,
+      extractedCondition.left,
+      extractedCondition.right,
       join.isNullAwareAntiJoin,
       join.isExecutorBroadcast)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
+    val filteredJoinExec =
+      extractedCondition.filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
+    extractedCondition.projectIfNeeded(filteredJoinExec)
   }
 }
 
@@ -121,7 +119,7 @@ case class GpuBroadcastHashJoinExec(
       case ReusedExchangeExec(_, g: GpuShuffleExchangeExec) => g
       case _ => throw new IllegalStateException(s"cannot locate GPU shuffle in $p")
     }
-    buildPlan match {
+    getBroadcastPlan(buildPlan) match {
       case gpu: GpuShuffleExchangeExec => gpu
       case sqse: ShuffleQueryStageExec => from(sqse)
       case reused: ReusedExchangeExec => reused.child.asInstanceOf[GpuShuffleExchangeExec]
@@ -151,7 +149,8 @@ case class GpuBroadcastHashJoinExec(
       }
       val buildBatch = GpuExecutorBroadcastHelper.getExecutorBroadcastBatch(buildRelation,
           buildSchema, buildOutput, metricsMap, targetSize)
-      (buildBatch, bufferedStreamIter)
+      val projectedBuildBatch = buildSidePostProjection.map(_(buildBatch)).getOrElse(buildBatch)
+      (projectedBuildBatch, bufferedStreamIter)
     }
   }
 
@@ -171,8 +170,8 @@ case class GpuBroadcastHashJoinExec(
         .asInstanceOf[RDD[ColumnarBatch]]
 
     val rdd = streamedPlan.executeColumnar()
-    val localBuildSchema = buildPlan.schema
-    val localBuildOutput = buildPlan.output
+    val localBuildSchema = getBroadcastPlan(buildPlan).schema
+    val localBuildOutput = getBroadcastPlan(buildPlan).output
     val localIsNullAwareAntiJoin = isNullAwareAntiJoin
     rdd.mapPartitions { it =>
       val (builtBatch, streamIter) =
@@ -220,4 +219,3 @@ case class GpuBroadcastHashJoinExec(
     }
   }
 }
-

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -87,6 +87,8 @@ case class GpuBroadcastHashJoinExec(
       leftKeys, rightKeys, joinType, buildSide, condition, left, right, isNullAwareAntiJoin) {
   import GpuMetric._
 
+  private type BuildBatchAndStream = (ColumnarBatch, Iterator[ColumnarBatch])
+
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
     OP_TIME_LEGACY -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_OP_TIME_LEGACY),
     STREAM_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_STREAM_TIME),
@@ -134,7 +136,8 @@ case class GpuBroadcastHashJoinExec(
       buildSchema: StructType,
       buildOutput: Seq[Attribute],
       streamIter: Iterator[ColumnarBatch],
-      coalesceMetricsMap: Map[String, GpuMetric]): (ColumnarBatch, Iterator[ColumnarBatch]) = {
+      coalesceMetricsMap: Map[String, GpuMetric],
+      postProjectionAndClose: Option[ColumnarBatch => ColumnarBatch]): BuildBatchAndStream = {
     val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
     val metricsMap = allMetrics
 
@@ -149,7 +152,7 @@ case class GpuBroadcastHashJoinExec(
       }
       val buildBatch = GpuExecutorBroadcastHelper.getExecutorBroadcastBatch(buildRelation,
           buildSchema, buildOutput, metricsMap, targetSize)
-      val projectedBuildBatch = buildSidePostProjection.map(_(buildBatch)).getOrElse(buildBatch)
+      val projectedBuildBatch = postProjectionAndClose.map(_(buildBatch)).getOrElse(buildBatch)
       (projectedBuildBatch, bufferedStreamIter)
     }
   }
@@ -173,6 +176,7 @@ case class GpuBroadcastHashJoinExec(
     val localBuildSchema = getBroadcastPlan(buildPlan).schema
     val localBuildOutput = getBroadcastPlan(buildPlan).output
     val localIsNullAwareAntiJoin = isNullAwareAntiJoin
+    val postProjectionAndClose = buildSidePostProjection
     rdd.mapPartitions { it =>
       val (builtBatch, streamIter) =
         getExecutorBuiltBatchAndStreamIter(
@@ -180,7 +184,8 @@ case class GpuBroadcastHashJoinExec(
           localBuildSchema,
           localBuildOutput,
           new CollectTimeIterator(NvtxRegistry.BROADCAST_JOIN_STREAM, it, streamTime),
-          allMetrics)
+          allMetrics,
+          postProjectionAndClose)
       if (localIsNullAwareAntiJoin) {
         // This is to support the null-aware anti join for the LeftAnti join with
         // BuildRight. See the config "spark.sql.optimizeNullAwareAntiJoin".

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -50,13 +50,9 @@ class GpuBroadcastHashJoinMeta(
     rule: DataFromReplacementRule) extends GpuBroadcastHashJoinMetaBase(join, conf, parent, rule) {
 
   override def convertToGpu(): GpuExec = {
-    val condition = conditionMeta.map(_.convertToGpu())
-    val (joinCondition, filterCondition) = if (conditionMeta.forall(_.canThisBeAst)) {
-      (condition, None)
-    } else {
-      (None, condition)
-    }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val extractedCondition = GpuHashJoin.extractJoinConditionIfNeeded(
+      conditionMeta, join.joinType, left, right)
     // The broadcast part of this must be a BroadcastExchangeExec
     val buildSideMeta = buildSide match {
       case GpuBuildLeft => left
@@ -68,12 +64,14 @@ class GpuBroadcastHashJoinMeta(
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       buildSide,
-      joinCondition,
-      left, right,
+      extractedCondition.joinCondition,
+      extractedCondition.left, extractedCondition.right,
       join.isNullAwareAntiJoin)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
+    val filteredJoinExec =
+      extractedCondition.filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
+    extractedCondition.projectIfNeeded(filteredJoinExec)
   }
 }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AstUtilSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AstUtilSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package com.nvidia.spark.rapids
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression}
-import org.apache.spark.sql.rapids.{GpuGreaterThan, GpuLength, GpuStringTrim}
-import org.apache.spark.sql.types.{BooleanType, IntegerType, StringType}
+import org.apache.spark.sql.rapids.{GpuAnd, GpuGreaterThan, GpuLength, GpuLessThan, GpuStringTrim}
+import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType, LongType, StringType}
 
 
 class AstUtilSuite extends GpuUnitTests {
@@ -302,5 +302,176 @@ class AstUtilSuite extends GpuUnitTests {
      val expectedAttr = AttributeReference(rightAlias.name, rightAlias.child.dataType,
        rightAlias.child.nullable, rightAlias.metadata)(rightAlias.exprId, rightAlias.qualifier)
      assertResult(expectedAttr)(expr.get)
+  }
+
+  // ============================================================================
+  // Tests for equi-join integration path (issue #14283)
+  // These simulate the exact pattern: a.range_start < CAST(b.b_end AS BIGINT)
+  // AND a.range_end > CAST(b.b_start AS BIGINT)
+  // ============================================================================
+
+  private[this] def issue14283ExpressionWithReferences(
+      dataType: DataType,
+      refs: AttributeReference*): Expression = {
+    val expr = mock(classOf[Expression])
+    when(expr.references).thenReturn(AttributeSet(refs))
+    when(expr.dataType).thenReturn(dataType)
+    expr
+  }
+
+  private[this] def issue14283ExpressionMeta(
+      wrapped: Expression,
+      canSelfBeAst: Boolean,
+      convertToGpu: Option[Expression] = None,
+      childExprs: Seq[BaseExprMeta[_]] = Seq.empty): BaseExprMeta[Expression] = {
+    val exprMeta = mock(classOf[BaseExprMeta[Expression]])
+    when(exprMeta.childExprs).thenReturn(childExprs)
+    when(exprMeta.canSelfBeAst).thenReturn(canSelfBeAst)
+    when(exprMeta.convertToGpu).thenReturn(convertToGpu.getOrElse(wrapped))
+    when(exprMeta.wrapped).thenReturn(wrapped)
+    exprMeta
+  }
+
+  private[this] def issue14283AttrMeta(attr: AttributeReference): BaseExprMeta[Expression] = {
+    issue14283ExpressionMeta(
+      issue14283ExpressionWithReferences(attr.dataType, attr),
+      canSelfBeAst = true,
+      convertToGpu = Some(attr))
+  }
+
+  private[this] def issue14283CastMeta(
+      dataType: DataType,
+      refs: AttributeReference*): BaseExprMeta[Expression] = {
+    issue14283ExpressionMeta(
+      issue14283ExpressionWithReferences(dataType, refs: _*),
+      canSelfBeAst = false)
+  }
+
+  /**
+   * Build a tree representing: left_attr < cast(right_attr as bigint)
+   * This simulates the equi-join non-equality condition from issue #14283.
+   * The comparison (LessThan) is AST-able, but the Cast child is not.
+   */
+  private[this] def buildComparisonWithCast(
+      leftAttr: AttributeReference,
+      rightAttr: AttributeReference,
+      comparison: (Expression, Expression) => Expression = GpuLessThan
+  ): BaseExprMeta[Expression] = {
+    val castMeta = issue14283CastMeta(LongType, rightAttr)
+    val comparisonExpr = comparison(leftAttr, castMeta.convertToGpu)
+    issue14283ExpressionMeta(
+      comparisonExpr,
+      canSelfBeAst = true,
+      childExprs = Seq(issue14283AttrMeta(leftAttr), castMeta))
+  }
+
+  /**
+   * Build a compound condition: (left1 < cast(right1)) AND (left2 > cast(right2))
+   * This simulates the full join condition from issue #14283.
+   */
+  private[this] def buildFullRangeJoinCondition(
+      leftStart: AttributeReference,
+      leftEnd: AttributeReference,
+      rightStart: AttributeReference,
+      rightEnd: AttributeReference): BaseExprMeta[Expression] = {
+    val ltMeta = buildComparisonWithCast(leftStart, rightEnd)
+    val gtMeta = buildComparisonWithCast(leftEnd, rightStart, GpuGreaterThan)
+    issue14283ExpressionMeta(
+      GpuAnd(ltMeta.convertToGpu, gtMeta.convertToGpu),
+      canSelfBeAst = true,
+      childExprs = Seq(ltMeta, gtMeta))
+  }
+
+  test("Equi-join pattern: canExtractNonAstConditionIfNeed with cast on single side") {
+    // Simulates: a.range_start < CAST(b.b_end AS BIGINT)
+    // Cast references only the right side → extractable
+    val lStart = AttributeReference("range_start", LongType)()
+    val rEnd = AttributeReference("b_end", IntegerType)()
+
+    val condMeta = buildComparisonWithCast(lStart, rEnd)
+    val canExtract = AstUtil.canExtractNonAstConditionIfNeed(
+      condMeta, Seq(lStart).map(_.exprId), Seq(rEnd).map(_.exprId))
+
+    assertResult(true)(canExtract)
+  }
+
+  test("Equi-join pattern: extractNonAstFromJoinCond extracts cast to right side") {
+    // Simulates: a.range_start < CAST(b.b_end AS BIGINT)
+    val lStart = AttributeReference("range_start", LongType)()
+    val rEnd = AttributeReference("b_end", IntegerType)()
+
+    val condMeta = buildComparisonWithCast(lStart, rEnd)
+    val (expr, leftExprs, rightExprs) =
+      AstUtil.extractNonAstFromJoinCond(Some(condMeta), Seq(lStart), Seq(rEnd))
+
+    // Cast on right attr should be extracted to right side
+    assertResult(0)(leftExprs.size)
+    assertResult(1)(rightExprs.size)
+    assertResult(true)(expr.isDefined)
+    // Rewritten condition should be a LessThan with left unchanged, right replaced
+    assertResult(true)(expr.get.isInstanceOf[GpuLessThan])
+  }
+
+  test("Equi-join pattern: full range condition with casts on right side") {
+    // Simulates: a.range_start < CAST(b.b_end AS BIGINT)
+    //        AND a.range_end > CAST(b.b_start AS BIGINT)
+    val lStart = AttributeReference("range_start", LongType)()
+    val lEnd = AttributeReference("range_end", LongType)()
+    val rStart = AttributeReference("b_start", IntegerType)()
+    val rEnd = AttributeReference("b_end", IntegerType)()
+
+    val condMeta = buildFullRangeJoinCondition(lStart, lEnd, rStart, rEnd)
+    val canExtract = AstUtil.canExtractNonAstConditionIfNeed(
+      condMeta,
+      Seq(lStart, lEnd).map(_.exprId),
+      Seq(rStart, rEnd).map(_.exprId))
+
+    // Both casts reference only right side → extractable
+    assertResult(true)(canExtract)
+  }
+
+  test("Equi-join pattern: full range condition extraction produces right-side projections") {
+    val lStart = AttributeReference("range_start", LongType)()
+    val lEnd = AttributeReference("range_end", LongType)()
+    val rStart = AttributeReference("b_start", IntegerType)()
+    val rEnd = AttributeReference("b_end", IntegerType)()
+
+    val condMeta = buildFullRangeJoinCondition(lStart, lEnd, rStart, rEnd)
+    val (expr, leftExprs, rightExprs) =
+      AstUtil.extractNonAstFromJoinCond(
+        Some(condMeta), Seq(lStart, lEnd), Seq(rStart, rEnd))
+
+    // Both CASTs are on right-side attributes → should be extracted to right
+    assertResult(0)(leftExprs.size)
+    assertResult(2)(rightExprs.size)
+    assertResult(true)(expr.isDefined)
+    // Rewritten condition should be an AND expression
+    assertResult(true)(expr.get.isInstanceOf[GpuAnd])
+  }
+
+  test("Equi-join pattern: cast referencing both sides is NOT extractable") {
+    // Simulates: CAST(a.col + b.col AS BIGINT) — references both sides
+    val l1 = AttributeReference("l1", IntegerType)()
+    val r1 = AttributeReference("r1", IntegerType)()
+
+    val canExtract = AstUtil.canExtractNonAstConditionIfNeed(
+      issue14283CastMeta(LongType, l1, r1), Seq(l1).map(_.exprId), Seq(r1).map(_.exprId))
+
+    // Cannot extract — references both sides
+    assertResult(false)(canExtract)
+  }
+
+  test("Equi-join pattern: fully AST-able condition needs no extraction") {
+    // When all expressions are AST-able, canExtractNonAstConditionIfNeed returns true
+    // but extractNonAstFromJoinCond should produce empty left/right lists
+    val l1 = AttributeReference("l1", StringType)()
+    val r1 = AttributeReference("r1", StringType)()
+
+    val (e, l, r) =
+      AstUtil.extractNonAstFromJoinCond(Some(buildTree3(l1, r1, true)), Seq(l1), Seq(r1))
+    // No extraction needed — all AST-able
+    assertResult(0)(l.size)
+    assertResult(0)(r.size)
+    assertResult(true)(e.isDefined)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AstUtilSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AstUtilSuite.scala
@@ -305,12 +305,12 @@ class AstUtilSuite extends GpuUnitTests {
   }
 
   // ============================================================================
-  // Tests for equi-join integration path (issue #14283)
-  // These simulate the exact pattern: a.range_start < CAST(b.b_end AS BIGINT)
-  // AND a.range_end > CAST(b.b_start AS BIGINT)
+  // Tests for extracting non-AST expressions from equi-join residual conditions.
+  // These simulate range predicates where the comparison is AST-able, but a child
+  // expression on one join side must be precomputed before the join.
   // ============================================================================
 
-  private[this] def issue14283ExpressionWithReferences(
+  private[this] def expressionWithReferences(
       dataType: DataType,
       refs: AttributeReference*): Expression = {
     val expr = mock(classOf[Expression])
@@ -319,7 +319,7 @@ class AstUtilSuite extends GpuUnitTests {
     expr
   }
 
-  private[this] def issue14283ExpressionMeta(
+  private[this] def expressionMeta(
       wrapped: Expression,
       canSelfBeAst: Boolean,
       convertToGpu: Option[Expression] = None,
@@ -332,79 +332,106 @@ class AstUtilSuite extends GpuUnitTests {
     exprMeta
   }
 
-  private[this] def issue14283AttrMeta(attr: AttributeReference): BaseExprMeta[Expression] = {
-    issue14283ExpressionMeta(
-      issue14283ExpressionWithReferences(attr.dataType, attr),
+  private[this] def attrMeta(attr: AttributeReference): BaseExprMeta[Expression] = {
+    expressionMeta(
+      expressionWithReferences(attr.dataType, attr),
       canSelfBeAst = true,
       convertToGpu = Some(attr))
   }
 
-  private[this] def issue14283CastMeta(
+  private[this] def nonAstExpressionMeta(
       dataType: DataType,
       refs: AttributeReference*): BaseExprMeta[Expression] = {
-    issue14283ExpressionMeta(
-      issue14283ExpressionWithReferences(dataType, refs: _*),
+    expressionMeta(
+      expressionWithReferences(dataType, refs: _*),
       canSelfBeAst = false)
   }
 
   /**
-   * Build a tree representing: left_attr < cast(right_attr as bigint)
-   * This simulates the equi-join non-equality condition from issue #14283.
-   * The comparison (LessThan) is AST-able, but the Cast child is not.
+   * Build a tree representing: left_attr < non_ast_expr(right_attr)
+   * The comparison is AST-able, but the right-side child expression is not.
    */
-  private[this] def buildComparisonWithCast(
+  private[this] def buildComparisonWithRightNonAstExpr(
       leftAttr: AttributeReference,
       rightAttr: AttributeReference,
       comparison: (Expression, Expression) => Expression = GpuLessThan
   ): BaseExprMeta[Expression] = {
-    val castMeta = issue14283CastMeta(LongType, rightAttr)
-    val comparisonExpr = comparison(leftAttr, castMeta.convertToGpu)
-    issue14283ExpressionMeta(
+    val rightNonAstMeta = nonAstExpressionMeta(LongType, rightAttr)
+    val comparisonExpr = comparison(leftAttr, rightNonAstMeta.convertToGpu)
+    expressionMeta(
       comparisonExpr,
       canSelfBeAst = true,
-      childExprs = Seq(issue14283AttrMeta(leftAttr), castMeta))
+      childExprs = Seq(attrMeta(leftAttr), rightNonAstMeta))
   }
 
   /**
-   * Build a compound condition: (left1 < cast(right1)) AND (left2 > cast(right2))
-   * This simulates the full join condition from issue #14283.
+   * Build a compound condition:
+   *   (left1 < non_ast_expr(right1)) AND (left2 > non_ast_expr(right2))
    */
-  private[this] def buildFullRangeJoinCondition(
+  private[this] def buildCompoundJoinConditionWithRightNonAstExprs(
       leftStart: AttributeReference,
       leftEnd: AttributeReference,
       rightStart: AttributeReference,
       rightEnd: AttributeReference): BaseExprMeta[Expression] = {
-    val ltMeta = buildComparisonWithCast(leftStart, rightEnd)
-    val gtMeta = buildComparisonWithCast(leftEnd, rightStart, GpuGreaterThan)
-    issue14283ExpressionMeta(
+    val ltMeta = buildComparisonWithRightNonAstExpr(leftStart, rightEnd)
+    val gtMeta = buildComparisonWithRightNonAstExpr(leftEnd, rightStart, GpuGreaterThan)
+    expressionMeta(
       GpuAnd(ltMeta.convertToGpu, gtMeta.convertToGpu),
       canSelfBeAst = true,
       childExprs = Seq(ltMeta, gtMeta))
   }
 
-  test("Equi-join pattern: canExtractNonAstConditionIfNeed with cast on single side") {
-    // Simulates: a.range_start < CAST(b.b_end AS BIGINT)
-    // Cast references only the right side → extractable
-    val lStart = AttributeReference("range_start", LongType)()
-    val rEnd = AttributeReference("b_end", IntegerType)()
+  private[this] case class JoinConditionTestInput(
+      conditionMeta: BaseExprMeta[Expression],
+      leftAttrs: Seq[AttributeReference],
+      rightAttrs: Seq[AttributeReference]) {
+    def canExtract: Boolean = {
+      AstUtil.canExtractNonAstConditionIfNeed(
+        conditionMeta, leftAttrs.map(_.exprId), rightAttrs.map(_.exprId))
+    }
 
-    val condMeta = buildComparisonWithCast(lStart, rEnd)
-    val canExtract = AstUtil.canExtractNonAstConditionIfNeed(
-      condMeta, Seq(lStart).map(_.exprId), Seq(rEnd).map(_.exprId))
-
-    assertResult(true)(canExtract)
+    def extract = {
+      AstUtil.extractNonAstFromJoinCond(Some(conditionMeta), leftAttrs, rightAttrs)
+    }
   }
 
-  test("Equi-join pattern: extractNonAstFromJoinCond extracts cast to right side") {
-    // Simulates: a.range_start < CAST(b.b_end AS BIGINT)
+  private[this] def singleRightNonAstInput(): JoinConditionTestInput = {
     val lStart = AttributeReference("range_start", LongType)()
     val rEnd = AttributeReference("b_end", IntegerType)()
+    JoinConditionTestInput(
+      buildComparisonWithRightNonAstExpr(lStart, rEnd),
+      Seq(lStart),
+      Seq(rEnd))
+  }
 
-    val condMeta = buildComparisonWithCast(lStart, rEnd)
-    val (expr, leftExprs, rightExprs) =
-      AstUtil.extractNonAstFromJoinCond(Some(condMeta), Seq(lStart), Seq(rEnd))
+  private[this] def compoundRightNonAstInput(): JoinConditionTestInput = {
+    val lStart = AttributeReference("range_start", LongType)()
+    val lEnd = AttributeReference("range_end", LongType)()
+    val rStart = AttributeReference("b_start", IntegerType)()
+    val rEnd = AttributeReference("b_end", IntegerType)()
+    JoinConditionTestInput(
+      buildCompoundJoinConditionWithRightNonAstExprs(lStart, lEnd, rStart, rEnd),
+      Seq(lStart, lEnd),
+      Seq(rStart, rEnd))
+  }
 
-    // Cast on right attr should be extracted to right side
+  private[this] def bothSidesNonAstInput(): JoinConditionTestInput = {
+    val l1 = AttributeReference("l1", IntegerType)()
+    val r1 = AttributeReference("r1", IntegerType)()
+    JoinConditionTestInput(nonAstExpressionMeta(LongType, l1, r1), Seq(l1), Seq(r1))
+  }
+
+  test("Equi-join pattern: canExtractNonAstConditionIfNeed with non-AST single side") {
+    // Simulates: a.range_start < non_ast_expr(b.b_end)
+    // The non-AST expression references only the right side, so it is extractable.
+    assertResult(true)(singleRightNonAstInput().canExtract)
+  }
+
+  test("Equi-join pattern: extractNonAstFromJoinCond extracts right-side expression") {
+    // Simulates: a.range_start < non_ast_expr(b.b_end)
+    val (expr, leftExprs, rightExprs) = singleRightNonAstInput().extract
+
+    // The non-AST child should be extracted to the right side.
     assertResult(0)(leftExprs.size)
     assertResult(1)(rightExprs.size)
     assertResult(true)(expr.isDefined)
@@ -412,36 +439,18 @@ class AstUtilSuite extends GpuUnitTests {
     assertResult(true)(expr.get.isInstanceOf[GpuLessThan])
   }
 
-  test("Equi-join pattern: full range condition with casts on right side") {
-    // Simulates: a.range_start < CAST(b.b_end AS BIGINT)
-    //        AND a.range_end > CAST(b.b_start AS BIGINT)
-    val lStart = AttributeReference("range_start", LongType)()
-    val lEnd = AttributeReference("range_end", LongType)()
-    val rStart = AttributeReference("b_start", IntegerType)()
-    val rEnd = AttributeReference("b_end", IntegerType)()
-
-    val condMeta = buildFullRangeJoinCondition(lStart, lEnd, rStart, rEnd)
-    val canExtract = AstUtil.canExtractNonAstConditionIfNeed(
-      condMeta,
-      Seq(lStart, lEnd).map(_.exprId),
-      Seq(rStart, rEnd).map(_.exprId))
-
-    // Both casts reference only right side → extractable
-    assertResult(true)(canExtract)
+  test("Equi-join pattern: compound range condition with right-side non-AST expressions") {
+    // Simulates:
+    //   a.range_start < non_ast_expr(b.b_end)
+    //     AND a.range_end > non_ast_expr(b.b_start)
+    // Both non-AST expressions reference only the right side.
+    assertResult(true)(compoundRightNonAstInput().canExtract)
   }
 
   test("Equi-join pattern: full range condition extraction produces right-side projections") {
-    val lStart = AttributeReference("range_start", LongType)()
-    val lEnd = AttributeReference("range_end", LongType)()
-    val rStart = AttributeReference("b_start", IntegerType)()
-    val rEnd = AttributeReference("b_end", IntegerType)()
+    val (expr, leftExprs, rightExprs) = compoundRightNonAstInput().extract
 
-    val condMeta = buildFullRangeJoinCondition(lStart, lEnd, rStart, rEnd)
-    val (expr, leftExprs, rightExprs) =
-      AstUtil.extractNonAstFromJoinCond(
-        Some(condMeta), Seq(lStart, lEnd), Seq(rStart, rEnd))
-
-    // Both CASTs are on right-side attributes → should be extracted to right
+    // Both non-AST expressions are on right-side attributes.
     assertResult(0)(leftExprs.size)
     assertResult(2)(rightExprs.size)
     assertResult(true)(expr.isDefined)
@@ -449,16 +458,10 @@ class AstUtilSuite extends GpuUnitTests {
     assertResult(true)(expr.get.isInstanceOf[GpuAnd])
   }
 
-  test("Equi-join pattern: cast referencing both sides is NOT extractable") {
-    // Simulates: CAST(a.col + b.col AS BIGINT) — references both sides
-    val l1 = AttributeReference("l1", IntegerType)()
-    val r1 = AttributeReference("r1", IntegerType)()
-
-    val canExtract = AstUtil.canExtractNonAstConditionIfNeed(
-      issue14283CastMeta(LongType, l1, r1), Seq(l1).map(_.exprId), Seq(r1).map(_.exprId))
-
-    // Cannot extract — references both sides
-    assertResult(false)(canExtract)
+  test("Equi-join pattern: non-AST expression referencing both sides is NOT extractable") {
+    // Simulates: non_ast_expr(a.col, b.col)
+    // Cannot extract because the non-AST expression references both sides.
+    assertResult(false)(bothSidesNonAstInput().canExtract)
   }
 
   test("Equi-join pattern: fully AST-able condition needs no extraction") {
@@ -467,8 +470,8 @@ class AstUtilSuite extends GpuUnitTests {
     val l1 = AttributeReference("l1", StringType)()
     val r1 = AttributeReference("r1", StringType)()
 
-    val (e, l, r) =
-      AstUtil.extractNonAstFromJoinCond(Some(buildTree3(l1, r1, true)), Seq(l1), Seq(r1))
+    val input = JoinConditionTestInput(buildTree3(l1, r1, true), Seq(l1), Seq(r1))
+    val (e, l, r) = input.extract
     // No extraction needed — all AST-able
     assertResult(0)(l.size)
     assertResult(0)(r.size)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastInJoinConditionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastInJoinConditionSuite.scala
@@ -1,0 +1,563 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinExec,
+  GpuBroadcastNestedLoopJoinExec}
+import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
+
+/**
+ * Test suite for issue #14283: join condition with "cast to bigint" should be pushed into
+ * the join operator rather than being placed in a post-join GpuFilter.
+ *
+ * The root cause is that GpuCast is not AST-compatible, so equi-join Meta classes
+ * (BroadcastHashJoin, ShuffledHashJoin, SortMergeJoin) use an all-or-nothing check:
+ * if any sub-expression in the join condition is not AST-able, the ENTIRE condition
+ * becomes a post-join GpuFilterExec. For inner joins this causes catastrophic row explosion.
+ *
+ * BNLJ already handles this correctly via AstUtil.extractNonAstFromJoinCond which
+ * pre-computes non-AST sub-expressions via GpuProjectExec.
+ *
+ * This suite:
+ * 1. Proves BNLJ handles cast in join conditions correctly (no post-filter)
+ * 2. Verifies BHJ/SHJ/SMJ use the same extraction pattern for equi-joins
+ * 3. Covers fallback, schema, and no-extra-project regression cases
+ */
+class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
+
+  private val BroadcastHint = "/*+ BROADCAST(b) */"
+  private val ShuffleHashHint = "/*+ SHUFFLE_HASH(b) */"
+
+  private val DefaultSelectColumns =
+    "a.category, a.range_start, a.range_end, b.b_start, b.b_end"
+
+  private val CastRangePredicate =
+    """a.range_start < CAST(b.b_end AS BIGINT)
+      |  AND a.range_end > CAST(b.b_start AS BIGINT)""".stripMargin
+
+  private val AstRangePredicate =
+    """a.range_start < b.b_end
+      |  AND a.range_end > b.b_start""".stripMargin
+
+  private def rangeJoinConf: SparkConf = new SparkConf()
+    .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
+    .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+
+  private def rangeJoinSql(
+      hint: String = BroadcastHint,
+      includeEquality: Boolean = true,
+      predicate: String = CastRangePredicate,
+      joinType: String = "INNER JOIN",
+      leftTable: String = "table_a",
+      rightTable: String = "table_b",
+      selectColumns: String = DefaultSelectColumns): String = {
+    val selectHint = if (hint.isEmpty) "" else s" $hint"
+    val joinCondition = if (includeEquality) {
+      s"b.b_category = a.category\n  AND $predicate"
+    } else {
+      predicate
+    }
+
+    s"""SELECT$selectHint
+      |  $selectColumns
+      |FROM $leftTable a
+      |$joinType $rightTable b
+      |  ON $joinCondition
+    """.stripMargin
+  }
+
+  /**
+   * Creates table_a with BIGINT range columns (range_start, range_end) and a category column.
+   */
+  private def tableADf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq(
+      ("cat1", 100L, 200L),
+      ("cat1", 150L, 250L),
+      ("cat2", 300L, 400L),
+      ("cat2", 350L, 450L),
+      ("cat3", 500L, 600L)
+    ).toDF("category", "range_start", "range_end")
+  }
+
+  /**
+   * Creates table_b with INT range columns (b_start, b_end) and a category column.
+   * The INT type triggers CAST(b_end AS BIGINT) when compared with BIGINT columns.
+   */
+  private def tableBDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq(
+      ("cat1", 120, 180),
+      ("cat1", 210, 260),
+      ("cat2", 310, 390),
+      ("cat2", 410, 460),
+      ("cat3", 510, 590)
+    ).toDF("b_category", "b_start", "b_end")
+  }
+
+  private def withDefaultTables[T](spark: SparkSession)(body: => T): T = {
+    tableADf(spark).createOrReplaceTempView("table_a")
+    tableBDf(spark).createOrReplaceTempView("table_b")
+    body
+  }
+
+  private def executedPlan(df: DataFrame): SparkPlan = {
+    df.collect()
+    df.queryExecution.executedPlan
+  }
+
+  private def withDefaultGpuQuery(
+      conf: SparkConf,
+      sqlText: String)(body: DataFrame => Unit): Unit = {
+    withGpuSparkSession(spark => {
+      withDefaultTables(spark) {
+        body(spark.sql(sqlText))
+      }
+    }, conf)
+  }
+
+  private def withDefaultGpuPlan(
+      conf: SparkConf,
+      sqlText: String)(body: SparkPlan => Unit): Unit = {
+    withDefaultGpuQuery(conf, sqlText) { df =>
+      body(executedPlan(df))
+    }
+  }
+
+  private def collectDefaultGpuResult(conf: SparkConf, sqlText: String) = {
+    withGpuSparkSession(spark => {
+      withDefaultTables(spark) {
+        spark.sql(sqlText).collect().groupBy(identity).map {
+          case (row, matchingRows) => row -> matchingRows.length
+        }
+      }
+    }, conf)
+  }
+
+  private def collectDefaultCpuResult(sqlText: String) = {
+    withCpuSparkSession(spark => {
+      withDefaultTables(spark) {
+        spark.sql(sqlText).collect().groupBy(identity).map {
+          case (row, matchingRows) => row -> matchingRows.length
+        }
+      }
+    })
+  }
+
+  private def assertDefaultGpuCpuResultsMatch(
+      conf: SparkConf,
+      sqlText: String,
+      message: String): Unit = {
+    val gpuResult = collectDefaultGpuResult(conf, sqlText)
+    val cpuResult = collectDefaultCpuResult(sqlText)
+
+    assert(gpuResult == cpuResult, s"$message\nGPU: $gpuResult\nCPU: $cpuResult")
+  }
+
+  private def assertSparkPlanHasJoin[T <: SparkPlan : ClassTag](
+      df: DataFrame,
+      joinName: String): Unit = {
+    val sparkPlan = df.queryExecution.sparkPlan
+    val joinClass = implicitly[ClassTag[T]].runtimeClass
+    val joins = PlanUtils.findOperators(sparkPlan, joinClass.isInstance)
+    assert(joins.nonEmpty, s"Expected $joinName in Spark physical plan but got:\n$sparkPlan")
+  }
+
+  private def isHashJoin(plan: SparkPlan): Boolean = plan match {
+    case _: GpuBroadcastHashJoinExec => true
+    case _: GpuShuffledSymmetricHashJoinExec => true
+    case _: GpuShuffledHashJoinExec => true
+    case _ => false
+  }
+
+  private def broadcastHashJoin(plan: SparkPlan): GpuBroadcastHashJoinExec = {
+    val bhjOps = PlanUtils.findOperators(plan, _.isInstanceOf[GpuBroadcastHashJoinExec])
+    assert(bhjOps.nonEmpty, s"Expected GpuBroadcastHashJoinExec in plan but got:\n$plan")
+    bhjOps.head.asInstanceOf[GpuBroadcastHashJoinExec]
+  }
+
+  private def broadcastNestedLoopJoin(plan: SparkPlan): GpuBroadcastNestedLoopJoinExec = {
+    val bnljOps = PlanUtils.findOperators(plan, _.isInstanceOf[GpuBroadcastNestedLoopJoinExec])
+    assert(bnljOps.nonEmpty,
+      s"Expected GpuBroadcastNestedLoopJoinExec in plan but got:\n$plan")
+    bnljOps.head.asInstanceOf[GpuBroadcastNestedLoopJoinExec]
+  }
+
+  /**
+   * Helper: checks whether a GpuFilterExec exists as a direct parent of a join operator
+   * in the executed plan. If so, the join condition was NOT pushed into the join.
+   */
+  private def hasPostJoinFilter(plan: SparkPlan): Boolean = {
+    PlanUtils.findOperators(plan, _.isInstanceOf[GpuFilterExec]).exists { filter =>
+      isHashJoin(filter.asInstanceOf[GpuFilterExec].child)
+    }
+  }
+
+  /**
+   * Helper: checks whether a GpuProjectExec wraps a child of the join (extraction pattern).
+   * This indicates that non-AST expressions were successfully extracted.
+   */
+  private def hasPreJoinProject(plan: SparkPlan): Boolean = {
+    PlanUtils.findOperators(plan, isHashJoin).exists { join =>
+      join.children.exists(_.isInstanceOf[GpuProjectExec])
+    }
+  }
+
+  // ============================================================================
+  // SECTION 1: Prove BNLJ handles CAST in join conditions correctly
+  // These tests should PASS — BNLJ already implements the extraction pattern
+  // ============================================================================
+
+  test("BNLJ handles cast-to-bigint in join condition without post-filter") {
+    val query = rangeJoinSql(includeEquality = false)
+    withDefaultGpuPlan(rangeJoinConf, query) { plan =>
+      // Verify the BNLJ has its condition inside (not in a separate filter)
+      val bnlj = broadcastNestedLoopJoin(plan)
+      assert(bnlj.condition.isDefined,
+        "BNLJ should have the join condition pushed in (not as post-filter)")
+    }
+  }
+
+  test("BNLJ with cast produces correct results") {
+    assertDefaultGpuCpuResultsMatch(
+      rangeJoinConf,
+      rangeJoinSql(includeEquality = false),
+      "GPU and CPU results should match.")
+  }
+
+  // ============================================================================
+  // SECTION 2: BroadcastHashJoin extraction behavior
+  // ============================================================================
+
+  test("BHJ with cast-to-bigint produces correct results") {
+    assertDefaultGpuCpuResultsMatch(
+      rangeJoinConf,
+      rangeJoinSql(),
+      "GPU and CPU results should match.")
+  }
+
+  test("BHJ with cast should keep condition in join (not post-filter)") {
+    withDefaultGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
+      assert(!hasPostJoinFilter(plan),
+        "BroadcastHashJoin should NOT use a post-filter for CAST in join condition. " +
+          "The extraction pattern should pre-compute CAST via GpuProjectExec on the child.")
+    }
+  }
+
+  test("BHJ with cast should have condition defined in join operator") {
+    withDefaultGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
+      val bhj = broadcastHashJoin(plan)
+      assert(bhj.condition.isDefined,
+        "BroadcastHashJoin should have the join condition defined " +
+          "(rewritten to use pre-computed CAST columns from GpuProjectExec)")
+    }
+  }
+
+  test("BHJ with cast should use extraction pattern (GpuProjectExec on child)") {
+    withDefaultGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
+      assert(hasPreJoinProject(plan),
+        "BroadcastHashJoin should have GpuProjectExec wrapping a child " +
+          "to pre-compute CAST (extraction pattern from BNLJ)")
+    }
+  }
+
+  test("BHJ with cast keeps output schema clean (no leaked attributes)") {
+    withGpuSparkSession(spark => {
+      withDefaultTables(spark) {
+        val df = spark.sql(rangeJoinSql())
+        df.collect()
+        val schema = df.schema
+
+        // The output schema should only contain the expected columns
+        // No intermediate _agpu_non_ast_* columns should leak through
+        val columnNames = schema.fieldNames.toSet
+        assert(!columnNames.exists(_.startsWith("_agpu_non_ast")),
+          "Output schema should not contain intermediate extraction attributes. " +
+            s"Got columns: ${columnNames.mkString(", ")}")
+
+        val expectedColumns = Set("category", "range_start", "range_end", "b_start", "b_end")
+        assert(columnNames == expectedColumns,
+          s"Output columns should be $expectedColumns, got $columnNames")
+      }
+    }, rangeJoinConf)
+  }
+
+  test("BHJ with cast on both sides should use extraction pattern") {
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+      // Both sides have INT columns — casting both to BIGINT
+      val dfA = Seq(
+        ("cat1", 100, 200),
+        ("cat1", 150, 250),
+        ("cat2", 300, 400)
+      ).toDF("category", "a_start", "a_end")
+      dfA.createOrReplaceTempView("int_table_a")
+
+      val dfB = Seq(
+        ("cat1", 120, 180),
+        ("cat1", 210, 260),
+        ("cat2", 310, 390)
+      ).toDF("b_category", "b_start", "b_end")
+      dfB.createOrReplaceTempView("int_table_b")
+
+      val query = rangeJoinSql(
+        hint = "/*+ BROADCAST(int_table_b) */",
+        predicate =
+          """CAST(a.a_start AS BIGINT) < CAST(b.b_end AS BIGINT)
+            |  AND CAST(a.a_end AS BIGINT) > CAST(b.b_start AS BIGINT)""".stripMargin,
+        leftTable = "int_table_a",
+        rightTable = "int_table_b",
+        selectColumns = "a.category, a.a_start, a.a_end, b.b_start, b.b_end")
+      val plan = executedPlan(spark.sql(query))
+
+      assert(!hasPostJoinFilter(plan),
+        "BroadcastHashJoin with CAST on both sides should use extraction pattern")
+    }, rangeJoinConf)
+  }
+
+  test("BHJ with non-extractable condition should still fall back to post-filter") {
+    val query = rangeJoinSql(
+      predicate =
+        // CASE WHEN itself is non-AST and this subtree references both sides of the join,
+        // so it cannot be pre-computed on either child.
+        """CASE WHEN a.range_start > CAST(b.b_end AS BIGINT)
+          |    THEN a.range_start
+          |    ELSE CAST(b.b_end AS BIGINT)
+          |  END > 100""".stripMargin)
+    withDefaultGpuPlan(rangeJoinConf, query) { plan =>
+      // Non-extractable conditions (referencing both sides in non-AST expr) should
+      // still gracefully fall back to post-filter
+      assert(hasPostJoinFilter(plan),
+        "Non-extractable conditions should still fall back to post-filter gracefully")
+    }
+  }
+
+  test("BHJ without cast should have condition in join (no regression)") {
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+      // Same types on both sides — no cast needed — already AST-able
+      val dfA = Seq(
+        ("cat1", 100L, 200L),
+        ("cat1", 150L, 250L),
+        ("cat2", 300L, 400L)
+      ).toDF("category", "range_start", "range_end")
+      dfA.createOrReplaceTempView("long_table_a")
+
+      val dfB = Seq(
+        ("cat1", 120L, 180L),
+        ("cat1", 210L, 260L),
+        ("cat2", 310L, 390L)
+      ).toDF("b_category", "b_start", "b_end")
+      dfB.createOrReplaceTempView("long_table_b")
+
+      val query = rangeJoinSql(
+        hint = "/*+ BROADCAST(long_table_b) */",
+        predicate = AstRangePredicate,
+        leftTable = "long_table_a",
+        rightTable = "long_table_b")
+      val plan = executedPlan(spark.sql(query))
+
+      // No CAST means the condition is already fully AST-able
+      // This should already work today — regression test
+      assert(!hasPostJoinFilter(plan),
+        "BroadcastHashJoin without CAST should have condition in join (already AST-able)")
+
+      val bhj = broadcastHashJoin(plan)
+      assert(bhj.condition.isDefined,
+        "BroadcastHashJoin without CAST should have condition defined")
+    }, rangeJoinConf)
+  }
+
+  test("BHJ with cast-to-bigint matches CPU results after extraction") {
+    assertDefaultGpuCpuResultsMatch(
+      rangeJoinConf,
+      rangeJoinSql(),
+      "GPU and CPU results should match after fix.")
+  }
+
+  test("Left outer BHJ with extractable cast condition plans on GPU") {
+    val query = rangeJoinSql(joinType = "LEFT OUTER JOIN")
+    withDefaultGpuPlan(rangeJoinConf, query) { plan =>
+      val bhj = broadcastHashJoin(plan)
+      assert(bhj.condition.isDefined,
+        "Left outer BroadcastHashJoin should keep extractable CAST condition in the join")
+      assert(!hasPostJoinFilter(plan),
+        "Left outer BroadcastHashJoin cannot use a post-filter for the join condition")
+    }
+    assertDefaultGpuCpuResultsMatch(
+      rangeJoinConf,
+      query,
+      "Left outer GPU and CPU results should match with extracted CAST condition.")
+  }
+
+  // ============================================================================
+  // SECTION 3: ShuffledHashJoin extraction behavior
+  // ============================================================================
+
+  private def shuffledJoinConf: SparkConf = new SparkConf()
+    .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    .set("spark.sql.join.preferSortMergeJoin", "false")
+    .set("spark.sql.shuffle.partitions", "2")
+    .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+
+  test("SHJ with cast should keep condition in join (not post-filter)") {
+    withDefaultGpuQuery(shuffledJoinConf, rangeJoinSql(hint = ShuffleHashHint)) { df =>
+      assertSparkPlanHasJoin[ShuffledHashJoinExec](df, "ShuffledHashJoinExec")
+      val plan = executedPlan(df)
+      assert(!hasPostJoinFilter(plan),
+        "ShuffledHashJoin should NOT use a post-filter for CAST in join condition")
+    }
+  }
+
+  test("SHJ with cast-to-bigint produces correct results") {
+    assertDefaultGpuCpuResultsMatch(
+      shuffledJoinConf,
+      rangeJoinSql(hint = ShuffleHashHint),
+      "ShuffledHashJoin GPU and CPU results should match.")
+  }
+
+  // ============================================================================
+  // SECTION 4: Edge cases
+  // ============================================================================
+
+  test("Multiple cast types (SHORT -> INT) in BHJ condition") {
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+      val dfA = Seq(
+        ("cat1", 100, 200),
+        ("cat2", 300, 400)
+      ).toDF("category", "range_start", "range_end")
+      dfA.createOrReplaceTempView("int_range_a")
+
+      val dfB = Seq(
+        ("cat1", 120.toShort, 180.toShort),
+        ("cat2", 310.toShort, 390.toShort)
+      ).toDF("b_category", "b_start", "b_end")
+      dfB.createOrReplaceTempView("short_range_b")
+
+      val query = rangeJoinSql(
+        hint = "/*+ BROADCAST(short_range_b) */",
+        predicate =
+          """a.range_start < CAST(b.b_end AS INT)
+            |  AND a.range_end > CAST(b.b_start AS INT)""".stripMargin,
+        leftTable = "int_range_a",
+        rightTable = "short_range_b")
+      val plan = executedPlan(spark.sql(query))
+
+      assert(!hasPostJoinFilter(plan),
+        "BHJ with SHORT->INT cast should use extraction pattern")
+    }, rangeJoinConf)
+  }
+
+  test("Multiple non-AST conditions in single join") {
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+      val dfA = Seq(
+        ("cat1", 100L, 200L, "active"),
+        ("cat2", 300L, 400L, "inactive")
+      ).toDF("category", "range_start", "range_end", "status")
+      dfA.createOrReplaceTempView("multi_a")
+
+      val dfB = Seq(
+        ("cat1", 120, 180, "active"),
+        ("cat2", 310, 390, "inactive")
+      ).toDF("b_category", "b_start", "b_end", "b_status")
+      dfB.createOrReplaceTempView("multi_b")
+
+      // Multiple CAST operations in the join condition
+      val query = rangeJoinSql(
+        hint = "/*+ BROADCAST(multi_b) */",
+        leftTable = "multi_a",
+        rightTable = "multi_b")
+      val plan = executedPlan(spark.sql(query))
+
+      assert(!hasPostJoinFilter(plan),
+        "Multiple CAST operations should all be extracted via GpuProjectExec")
+    }, rangeJoinConf)
+  }
+
+  // ============================================================================
+  // SECTION 5: SortMergeJoin extraction behavior
+  // ============================================================================
+
+  private def sortMergeJoinConf: SparkConf = new SparkConf()
+    .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    .set("spark.sql.join.preferSortMergeJoin", "true")
+    .set("spark.sql.shuffle.partitions", "2")
+    .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+
+  test("SMJ with cast should keep condition in join (not post-filter)") {
+    withDefaultGpuQuery(sortMergeJoinConf, rangeJoinSql(hint = "")) { df =>
+      assertSparkPlanHasJoin[SortMergeJoinExec](df, "SortMergeJoinExec")
+      val plan = executedPlan(df)
+      assert(!hasPostJoinFilter(plan),
+        "SortMergeJoin should NOT use a post-filter for CAST in join condition")
+    }
+  }
+
+  test("SMJ with cast-to-bigint produces correct results") {
+    assertDefaultGpuCpuResultsMatch(
+      sortMergeJoinConf,
+      rangeJoinSql(hint = ""),
+      "SortMergeJoin GPU and CPU results should match.")
+  }
+
+  // ============================================================================
+  // SECTION 6: No unnecessary projections when condition is fully AST-able
+  // ============================================================================
+
+  test("Fully AST-able condition should NOT add GpuProjectExec (no unnecessary work)") {
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+      // Same types on both sides — no cast needed — fully AST-able
+      val dfA = Seq(
+        ("cat1", 100L, 200L),
+        ("cat2", 300L, 400L)
+      ).toDF("category", "range_start", "range_end")
+      dfA.createOrReplaceTempView("long_a")
+
+      val dfB = Seq(
+        ("cat1", 120L, 180L),
+        ("cat2", 310L, 390L)
+      ).toDF("b_category", "b_start", "b_end")
+      dfB.createOrReplaceTempView("long_b")
+
+      val query = rangeJoinSql(
+        hint = "/*+ BROADCAST(long_b) */",
+        predicate = AstRangePredicate,
+        leftTable = "long_a",
+        rightTable = "long_b")
+      val plan = executedPlan(spark.sql(query))
+
+      // No CAST → fully AST-able → should NOT introduce unnecessary GpuProjectExec
+      // on join children (the extraction pattern should only activate when needed)
+      assert(!hasPreJoinProject(plan),
+        "Fully AST-able condition should NOT add GpuProjectExec on join children. " +
+          "The extraction pattern should only activate when non-AST expressions exist.")
+
+      // Also verify condition is in the join
+      assert(!hasPostJoinFilter(plan),
+        "Fully AST-able condition should be in the join (no post-filter needed)")
+    }, rangeJoinConf)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastInJoinConditionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastInJoinConditionSuite.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinExec,
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims._
 
 /**
- * Test suite for issue #14283: join condition with "cast to bigint" should be pushed into
+ * Test suite for equi-join conditions with non-AST child expressions. These expressions
+ * should be extracted into pre-join projections so the residual condition can stay inside
  * the join operator rather than being placed in a post-join GpuFilter.
  *
  * The root cause is that GpuCast is not AST-compatible, so equi-join Meta classes
@@ -51,9 +52,22 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   private val DefaultSelectColumns =
     "a.category, a.range_start, a.range_end, b.b_start, b.b_end"
 
+  private val LeftOnlySelectColumns =
+    "a.category, a.range_start, a.range_end"
+
   private val CastRangePredicate =
     """a.range_start < CAST(b.b_end AS BIGINT)
       |  AND a.range_end > CAST(b.b_start AS BIGINT)""".stripMargin
+
+  /**
+   * A right-side non-AST expression that is not a numeric cast. This keeps extraction coverage
+   * stable if simple numeric upcasts later become AST-compatible. The full subtree references
+   * only table `b`, so it should be projected on the right child and the join condition should
+   * be rewritten to read the projected attribute.
+   */
+  private val StableNonAstPredicate =
+    """a.range_start < LENGTH(TRIM(b.b_label))
+      |  AND a.range_end > LENGTH(TRIM(b.b_label))""".stripMargin
 
   private val AstRangePredicate =
     """a.range_start < b.b_end
@@ -115,9 +129,37 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
     ).toDF("b_category", "b_start", "b_end")
   }
 
-  private def withDefaultTables[T](spark: SparkSession)(body: => T): T = {
+  private def registerDefaultTables(spark: SparkSession): Unit = {
     tableADf(spark).createOrReplaceTempView("table_a")
     tableBDf(spark).createOrReplaceTempView("table_b")
+  }
+
+  private def stableNonAstTableADf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq(
+      ("cat1", 2, 20),
+      ("cat1", 6, 20),
+      ("cat2", 3, 10),
+      ("cat3", 1, 2)
+    ).toDF("category", "range_start", "range_end")
+  }
+
+  private def stableNonAstTableBDf(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq(
+      ("cat1", "  abcde  "),
+      ("cat2", "  q  "),
+      ("cat3", "  xyz  ")
+    ).toDF("b_category", "b_label")
+  }
+
+  private def registerStableNonAstTables(spark: SparkSession): Unit = {
+    stableNonAstTableADf(spark).createOrReplaceTempView("stable_non_ast_a")
+    stableNonAstTableBDf(spark).createOrReplaceTempView("stable_non_ast_b")
+  }
+
+  private def withDefaultTables[T](spark: SparkSession)(body: => T): T = {
+    registerDefaultTables(spark)
     body
   }
 
@@ -126,52 +168,70 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
     df.queryExecution.executedPlan
   }
 
-  private def withDefaultGpuQuery(
+  private def withGpuQuery(
       conf: SparkConf,
-      sqlText: String)(body: DataFrame => Unit): Unit = {
+      sqlText: String,
+      registerTables: SparkSession => Unit = registerDefaultTables)(
+      body: DataFrame => Unit): Unit = {
     withGpuSparkSession(spark => {
-      withDefaultTables(spark) {
-        body(spark.sql(sqlText))
-      }
+      registerTables(spark)
+      body(spark.sql(sqlText))
     }, conf)
   }
 
-  private def withDefaultGpuPlan(
+  private def withGpuPlan(
       conf: SparkConf,
-      sqlText: String)(body: SparkPlan => Unit): Unit = {
-    withDefaultGpuQuery(conf, sqlText) { df =>
+      sqlText: String,
+      registerTables: SparkSession => Unit = registerDefaultTables)(
+      body: SparkPlan => Unit): Unit = {
+    withGpuQuery(conf, sqlText, registerTables) { df =>
       body(executedPlan(df))
     }
   }
 
-  private def collectDefaultGpuResult(conf: SparkConf, sqlText: String) = {
+  private def collectResult(spark: SparkSession, sqlText: String) = {
+    spark.sql(sqlText).collect().groupBy(identity).map {
+      case (row, matchingRows) => row -> matchingRows.length
+    }
+  }
+
+  private def collectGpuResult(
+      conf: SparkConf,
+      sqlText: String,
+      registerTables: SparkSession => Unit) = {
     withGpuSparkSession(spark => {
-      withDefaultTables(spark) {
-        spark.sql(sqlText).collect().groupBy(identity).map {
-          case (row, matchingRows) => row -> matchingRows.length
-        }
-      }
+      registerTables(spark)
+      collectResult(spark, sqlText)
     }, conf)
   }
 
-  private def collectDefaultCpuResult(sqlText: String) = {
+  private def collectCpuResult(
+      sqlText: String,
+      registerTables: SparkSession => Unit) = {
     withCpuSparkSession(spark => {
-      withDefaultTables(spark) {
-        spark.sql(sqlText).collect().groupBy(identity).map {
-          case (row, matchingRows) => row -> matchingRows.length
-        }
-      }
+      registerTables(spark)
+      collectResult(spark, sqlText)
     })
   }
 
-  private def assertDefaultGpuCpuResultsMatch(
+  private def assertGpuCpuResultsMatch(
       conf: SparkConf,
       sqlText: String,
-      message: String): Unit = {
-    val gpuResult = collectDefaultGpuResult(conf, sqlText)
-    val cpuResult = collectDefaultCpuResult(sqlText)
+      message: String,
+      registerTables: SparkSession => Unit = registerDefaultTables): Unit = {
+    val gpuResult = collectGpuResult(conf, sqlText, registerTables)
+    val cpuResult = collectCpuResult(sqlText, registerTables)
 
     assert(gpuResult == cpuResult, s"$message\nGPU: $gpuResult\nCPU: $cpuResult")
+  }
+
+  private def stableNonAstSql: String = {
+    rangeJoinSql(
+      hint = "/*+ BROADCAST(stable_non_ast_b) */",
+      predicate = StableNonAstPredicate,
+      leftTable = "stable_non_ast_a",
+      rightTable = "stable_non_ast_b",
+      selectColumns = "a.category, a.range_start, a.range_end, b.b_label")
   }
 
   private def assertSparkPlanHasJoin[T <: SparkPlan : ClassTag](
@@ -223,6 +283,31 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
     }
   }
 
+  private def assertBroadcastHashJoinKeepsCondition(
+      plan: SparkPlan,
+      conditionDescription: String): GpuBroadcastHashJoinExec = {
+    val bhj = broadcastHashJoin(plan)
+    assert(bhj.condition.isDefined,
+      s"BroadcastHashJoin should keep $conditionDescription in the join")
+    assert(!hasPostJoinFilter(plan),
+      s"BroadcastHashJoin should not use a post-filter for $conditionDescription")
+    bhj
+  }
+
+  private def assertBroadcastHashJoinTypeWithCast(
+      joinType: String,
+      joinName: String,
+      selectColumns: String = DefaultSelectColumns): Unit = {
+    val query = rangeJoinSql(joinType = joinType, selectColumns = selectColumns)
+    withGpuPlan(rangeJoinConf, query) { plan =>
+      assertBroadcastHashJoinKeepsCondition(plan, "extractable CAST condition")
+    }
+    assertGpuCpuResultsMatch(
+      rangeJoinConf,
+      query,
+      s"$joinName GPU and CPU results should match with extracted CAST condition.")
+  }
+
   // ============================================================================
   // SECTION 1: Prove BNLJ handles CAST in join conditions correctly
   // These tests should PASS — BNLJ already implements the extraction pattern
@@ -230,7 +315,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
 
   test("BNLJ handles cast-to-bigint in join condition without post-filter") {
     val query = rangeJoinSql(includeEquality = false)
-    withDefaultGpuPlan(rangeJoinConf, query) { plan =>
+    withGpuPlan(rangeJoinConf, query) { plan =>
       // Verify the BNLJ has its condition inside (not in a separate filter)
       val bnlj = broadcastNestedLoopJoin(plan)
       assert(bnlj.condition.isDefined,
@@ -239,7 +324,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   }
 
   test("BNLJ with cast produces correct results") {
-    assertDefaultGpuCpuResultsMatch(
+    assertGpuCpuResultsMatch(
       rangeJoinConf,
       rangeJoinSql(includeEquality = false),
       "GPU and CPU results should match.")
@@ -250,14 +335,14 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   // ============================================================================
 
   test("BHJ with cast-to-bigint produces correct results") {
-    assertDefaultGpuCpuResultsMatch(
+    assertGpuCpuResultsMatch(
       rangeJoinConf,
       rangeJoinSql(),
       "GPU and CPU results should match.")
   }
 
   test("BHJ with cast should keep condition in join (not post-filter)") {
-    withDefaultGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
+    withGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
       assert(!hasPostJoinFilter(plan),
         "BroadcastHashJoin should NOT use a post-filter for CAST in join condition. " +
           "The extraction pattern should pre-compute CAST via GpuProjectExec on the child.")
@@ -265,7 +350,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   }
 
   test("BHJ with cast should have condition defined in join operator") {
-    withDefaultGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
+    withGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
       val bhj = broadcastHashJoin(plan)
       assert(bhj.condition.isDefined,
         "BroadcastHashJoin should have the join condition defined " +
@@ -274,7 +359,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   }
 
   test("BHJ with cast should use extraction pattern (GpuProjectExec on child)") {
-    withDefaultGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
+    withGpuPlan(rangeJoinConf, rangeJoinSql()) { plan =>
       assert(hasPreJoinProject(plan),
         "BroadcastHashJoin should have GpuProjectExec wrapping a child " +
           "to pre-compute CAST (extraction pattern from BNLJ)")
@@ -344,7 +429,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
           |    THEN a.range_start
           |    ELSE CAST(b.b_end AS BIGINT)
           |  END > 100""".stripMargin)
-    withDefaultGpuPlan(rangeJoinConf, query) { plan =>
+    withGpuPlan(rangeJoinConf, query) { plan =>
       // Non-extractable conditions (referencing both sides in non-AST expr) should
       // still gracefully fall back to post-filter
       assert(hasPostJoinFilter(plan),
@@ -389,25 +474,41 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   }
 
   test("BHJ with cast-to-bigint matches CPU results after extraction") {
-    assertDefaultGpuCpuResultsMatch(
+    assertGpuCpuResultsMatch(
       rangeJoinConf,
       rangeJoinSql(),
       "GPU and CPU results should match after fix.")
   }
 
   test("Left outer BHJ with extractable cast condition plans on GPU") {
-    val query = rangeJoinSql(joinType = "LEFT OUTER JOIN")
-    withDefaultGpuPlan(rangeJoinConf, query) { plan =>
-      val bhj = broadcastHashJoin(plan)
-      assert(bhj.condition.isDefined,
-        "Left outer BroadcastHashJoin should keep extractable CAST condition in the join")
-      assert(!hasPostJoinFilter(plan),
-        "Left outer BroadcastHashJoin cannot use a post-filter for the join condition")
+    assertBroadcastHashJoinTypeWithCast("LEFT OUTER JOIN", "Left outer")
+  }
+
+  test("Left semi BHJ with extractable cast condition plans on GPU") {
+    assertBroadcastHashJoinTypeWithCast("LEFT SEMI JOIN", "Left semi", LeftOnlySelectColumns)
+  }
+
+  test("Left anti BHJ with extractable cast condition plans on GPU") {
+    assertBroadcastHashJoinTypeWithCast("LEFT ANTI JOIN", "Left anti", LeftOnlySelectColumns)
+  }
+
+  /**
+   * Verifies the extraction path with a deliberately non-cast expression. The cast-based tests
+   * reproduce the original bug, while this test protects the generic extraction behavior from
+   * becoming tied to the current AST support status of numeric upcasts.
+   */
+  test("BHJ with stable right-side non-AST expression uses extraction pattern") {
+    val query = stableNonAstSql
+    withGpuPlan(rangeJoinConf, query, registerStableNonAstTables) { plan =>
+      assertBroadcastHashJoinKeepsCondition(plan, "stable non-AST expression condition")
+      assert(hasPreJoinProject(plan),
+        "BroadcastHashJoin should pre-compute stable non-AST expression with GpuProjectExec")
     }
-    assertDefaultGpuCpuResultsMatch(
+    assertGpuCpuResultsMatch(
       rangeJoinConf,
       query,
-      "Left outer GPU and CPU results should match with extracted CAST condition.")
+      "GPU and CPU results should match with extracted stable non-AST expression.",
+      registerStableNonAstTables)
   }
 
   // ============================================================================
@@ -421,7 +522,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
     .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
 
   test("SHJ with cast should keep condition in join (not post-filter)") {
-    withDefaultGpuQuery(shuffledJoinConf, rangeJoinSql(hint = ShuffleHashHint)) { df =>
+    withGpuQuery(shuffledJoinConf, rangeJoinSql(hint = ShuffleHashHint)) { df =>
       assertSparkPlanHasJoin[ShuffledHashJoinExec](df, "ShuffledHashJoinExec")
       val plan = executedPlan(df)
       assert(!hasPostJoinFilter(plan),
@@ -430,7 +531,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   }
 
   test("SHJ with cast-to-bigint produces correct results") {
-    assertDefaultGpuCpuResultsMatch(
+    assertGpuCpuResultsMatch(
       shuffledJoinConf,
       rangeJoinSql(hint = ShuffleHashHint),
       "ShuffledHashJoin GPU and CPU results should match.")
@@ -507,7 +608,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
     .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
 
   test("SMJ with cast should keep condition in join (not post-filter)") {
-    withDefaultGpuQuery(sortMergeJoinConf, rangeJoinSql(hint = "")) { df =>
+    withGpuQuery(sortMergeJoinConf, rangeJoinSql(hint = "")) { df =>
       assertSparkPlanHasJoin[SortMergeJoinExec](df, "SortMergeJoinExec")
       val plan = executedPlan(df)
       assert(!hasPostJoinFilter(plan),
@@ -516,7 +617,7 @@ class CastInJoinConditionSuite extends SparkQueryCompareTestSuite {
   }
 
   test("SMJ with cast-to-bigint produces correct results") {
-    assertDefaultGpuCpuResultsMatch(
+    assertGpuCpuResultsMatch(
       sortMergeJoinConf,
       rangeJoinSql(hint = ""),
       "SortMergeJoin GPU and CPU results should match.")


### PR DESCRIPTION
Fixes #14283

Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

### Description

**Problem:** When an equi-join condition contains a non-AST expression such as `CAST(b.b_end AS BIGINT)` in a non-equality predicate, the current equi-join conversion moves the entire condition to a post-join `GpuFilterExec`. For inner joins this causes massive intermediate row explosion (the reporter saw 82K rows explode to 32B intermediate rows — a 390,000x blowup). For non-inner joins (LEFT OUTER, LEFT SEMI, LEFT ANTI), the condition fails the AST requirement and the join silently falls back to CPU.

**Root cause:** The equi-join meta classes (`GpuBroadcastHashJoinMeta`, `GpuShuffledHashJoinMeta`, `GpuSortMergeJoinMeta`) use a binary all-or-nothing check: if any sub-expression in the condition is not AST-able, the entire condition becomes a post-join filter. `GpuBroadcastNestedLoopJoinMeta` (BNLJ) already solves this using `AstUtil.extractNonAstFromJoinCond` to pre-compute single-side non-AST sub-expressions via `GpuProjectExec`.

**Fix:** Port the BNLJ extraction pattern to all three equi-join paths:

1. Add `GpuHashJoin.extractJoinConditionIfNeeded` — a shared helper that checks if the condition is fully AST-able (fast path, no projections); if not, checks if non-AST sub-expressions can be extracted (each references only one join side); if extractable, wraps child plans with `GpuProjectExec` to pre-compute the non-AST expressions, rewrites the condition to use projected attributes, and strips temporary `_agpu_non_ast_*` columns from the final output. Falls back to post-filter for non-extractable cases.

2. Update `GpuBroadcastHashJoinMeta.convertToGpu()` (3 shim files: spark321, spark330db, spark340) to use the shared helper. BHJ handles the build-side projection at execution time via `buildSidePostProjection` to preserve the broadcast exchange.

3. Update `GpuShuffledHashJoinMeta.convertToGpu()` and `GpuSortMergeJoinMeta.convertToGpu()` to use the same helper.

4. Update `tagJoin` to skip `requireAstForGpuOn` when extraction is feasible, enabling non-inner joins to plan on GPU.

**After this change:**
- Inner joins with CAST in conditions no longer produce intermediate row explosions
- Non-inner joins with CAST in conditions now run on GPU instead of falling back to CPU
- Fully AST-able conditions retain the existing fast path with no extra projections
- Non-extractable conditions (referencing both sides in a single non-AST expression) still fall back to post-filter gracefully

**Query plan before fix (inner BHJ):**
```
GpuFilter ((range_start < cast(b_end as bigint)) AND (range_end > cast(b_start as bigint)))
  +- GpuBroadcastHashJoin [category], [b_category], Inner   ← no condition, full cross-product
```

**Query plan after fix (inner BHJ):**
```
GpuProject [strip _agpu_non_ast_* columns]
  +- GpuBroadcastHashJoin [category], [b_category], Inner,
       condition: (range_start < _agpu_non_ast_r_0) AND (range_end > _agpu_non_ast_r_1)
       +- GpuProject [cast(b_end as bigint) AS _agpu_non_ast_r_0, ...]   ← pre-computed on build side
            +- GpuBroadcastExchange
```

**Performance results (Spark 3.5.3 and 4.0.2, CPU-only node with RAPIDS plugin loaded):**

P.S: NDS-benchmark is not affected by this bug.

| Query | Before Fix | After Fix | Speedup (After vs Before) |
|-------|-----------|----------|--------------------------|
| Inner BHJ (INT→BIGINT), medium | 1.083s, post-filter=YES | 0.808s, post-filter=No | 1.3x |
| Inner BHJ (SHORT→BIGINT), medium | 0.370s, post-filter=YES | 0.216s, post-filter=No | 1.7x |
| Left Outer BHJ, medium | 2.095s (ran on CPU) | 0.204s (runs on GPU) | 10.3x |
| Left Semi BHJ, medium | 1.895s (ran on CPU) | 0.220s (runs on GPU) | 8.6x |
| Left Anti BHJ, medium | 1.697s (ran on CPU) | 0.206s (runs on GPU) | 8.2x |

Note: These measurements are on a CPU-only node (GPU operators fall back to CPU execution). On a GPU node with the before-fix code, the inner join row explosion at medium scale (~208M intermediate rows) would cause significantly worse degradation or OOM; the after-fix path produces only matching rows (~11K).


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
      - `CastInJoinConditionSuite` (19 tests): BHJ/SHJ/SMJ topology, schema cleanliness, non-extractable fallback, no-extra-project regression, duplicate-preserving CPU/GPU result checks, non-inner join GPU planning
      - `AstUtilSuite` (15 tests): extraction logic unit tests
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
      - Benchmark script with 7 query variants across join types (Inner, Left Outer, Left Semi, Left Anti), strategies (BHJ, SHJ, SMJ), and type mismatches (INT→BIGINT, SHORT→BIGINT)
      - Tested on Spark 3.5.3 and Spark 4.0.2
      - Results confirm: post-join filter eliminated for inner joins, non-inner joins now plan on GPU, consistent behavior across Spark versions
- [ ] Issue filed with a link in the PR description
- [ ] Not required