### PR TITLE
Fix flaky parquet write operator time validation

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetricsEventLogValidationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetricsEventLogValidationSuite.scala
@@ -529,6 +529,7 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
           f"but was ${operatorTimeRatio * 100.0}%.1f%%")
 
       val stage5Metrics = operatorTimeMetrics.filter(_.stage.contains(5))
+      val stage5TaskTimes = taskTimes.filter(_.stage.contains(5))
       val stage5OperatorTime = stage5Metrics.map(_.value).sum
       val stage5Ratio = if (totalOperatorTime > 0) {
         stage5OperatorTime.toDouble / totalOperatorTime.toDouble
@@ -536,22 +537,26 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
         0.0
       }
       val minExpectedStage5OperatorTime =
-        TimeUnit.MILLISECONDS.toNanos(numWritePartitions * slowFsWriteDelayMs)
+        TimeUnit.MILLISECONDS.toNanos(stage5TaskTimes.length * slowFsWriteDelayMs)
 
       println(f"Parquet write job: Stage 5 operator time: " +
         f"${stage5OperatorTime / 1000000.0}%.2f ms")
       println(f"Parquet write job: Stage 5 ratio: ${stage5Ratio * 100.0}%.1f%% " +
         "of total operator time")
+      println(s"Parquet write job: Stage 5 task count: ${stage5TaskTimes.length}")
       println(f"Parquet write job: Stage 5 expected minimum operator time: " +
         f"${minExpectedStage5OperatorTime / 1000000.0}%.2f ms")
 
       assert(stage5Metrics.nonEmpty,
         "Should find operator time metrics for stage 5 (parquet write stage)")
 
+      assert(stage5TaskTimes.nonEmpty,
+        "Should find executor run times for stage 5 (parquet write stage)")
+
       assert(stage5OperatorTime >= minExpectedStage5OperatorTime,
         f"Stage 5 (parquet write stage) operator time should be at least " +
           f"${minExpectedStage5OperatorTime / 1000000.0}%.2f ms based on " +
-          f"$numWritePartitions write partitions and $slowFsWriteDelayMs ms slowfs delay, " +
+          f"${stage5TaskTimes.length} stage 5 tasks and $slowFsWriteDelayMs ms slowfs delay, " +
           f"but was ${stage5OperatorTime / 1000000.0}%.2f ms")
 
       operatorTimeMetrics.foreach { m =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetricsEventLogValidationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetricsEventLogValidationSuite.scala
@@ -16,6 +16,7 @@
 package com.nvidia.spark.rapids
 
 import java.io.{BufferedReader, File, InputStreamReader}
+import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
 import scala.io.Source
@@ -433,8 +434,11 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
       spark.conf.set("spark.rapids.sql.exec.opTimeTrackingRDD.enabled", "true")
 
       // Configure slow filesystem for testing and disable cache to prevent pollution
+      val slowFsWriteDelayMs = 100L
+      val numWritePartitions = 50
       spark.conf.set("fs.slowfs.impl.disable.cache", "true")
       spark.conf.set("fs.slowfs.impl", "com.nvidia.spark.rapids.SlowFileSystem")
+      spark.conf.set("slowfs.write.delay.ms", slowFsWriteDelayMs.toString)
 
       val numRows = 5000000L
       val numTasks = 8
@@ -459,7 +463,8 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
       // Write to slow filesystem Parquet format with repartitioning
       // and take significant time due to filesystem delays
       testDataDF
-        .repartition(50) // Repartition to 50 partitions to amplify write time
+        // Create more output tasks/files, which amplifies SlowFileSystem write delays.
+        .repartition(numWritePartitions)
         .write
         .mode("overwrite")
         .option("compression", "snappy")
@@ -523,7 +528,6 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
           f"(${totalTaskExecutionTime / 1000000.0}%.2f ms), " +
           f"but was ${operatorTimeRatio * 100.0}%.1f%%")
 
-      // Assert stage 5 (parquet write stage) operator time accounts for > 10% of total
       val stage5Metrics = operatorTimeMetrics.filter(_.stage.contains(5))
       val stage5OperatorTime = stage5Metrics.map(_.value).sum
       val stage5Ratio = if (totalOperatorTime > 0) {
@@ -531,20 +535,24 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
       } else {
         0.0
       }
+      val minExpectedStage5OperatorTime =
+        TimeUnit.MILLISECONDS.toNanos(numWritePartitions * slowFsWriteDelayMs)
 
       println(f"Parquet write job: Stage 5 operator time: " +
         f"${stage5OperatorTime / 1000000.0}%.2f ms")
       println(f"Parquet write job: Stage 5 ratio: ${stage5Ratio * 100.0}%.1f%% " +
         "of total operator time")
+      println(f"Parquet write job: Stage 5 expected minimum operator time: " +
+        f"${minExpectedStage5OperatorTime / 1000000.0}%.2f ms")
 
       assert(stage5Metrics.nonEmpty,
         "Should find operator time metrics for stage 5 (parquet write stage)")
 
-      assert(stage5Ratio > 0.1,
-        f"Stage 5 (parquet write stage) operator time should account for more than 10%% " +
-          f"of total operator time, but was only ${stage5Ratio * 100.0}%.1f%% " +
-          f"(${stage5OperatorTime / 1000000.0}%.2f ms out of " +
-          f"${totalOperatorTime / 1000000.0}%.2f ms)")
+      assert(stage5OperatorTime >= minExpectedStage5OperatorTime,
+        f"Stage 5 (parquet write stage) operator time should be at least " +
+          f"${minExpectedStage5OperatorTime / 1000000.0}%.2f ms based on " +
+          f"$numWritePartitions write partitions and $slowFsWriteDelayMs ms slowfs delay, " +
+          f"but was ${stage5OperatorTime / 1000000.0}%.2f ms")
 
       operatorTimeMetrics.foreach { m =>
         println(f"  ${m.name}: ${m.value / 1000000.0}%.2f ms " +

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetricsEventLogValidationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetricsEventLogValidationSuite.scala
@@ -436,6 +436,8 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
       // Configure slow filesystem for testing and disable cache to prevent pollution
       val slowFsWriteDelayMs = 100L
       val numWritePartitions = 50
+      // Keep AQE from coalescing the write shuffle partitions used by the slowfs lower bound.
+      spark.conf.set("spark.sql.adaptive.coalescePartitions.enabled", "false")
       spark.conf.set("fs.slowfs.impl.disable.cache", "true")
       spark.conf.set("fs.slowfs.impl", "com.nvidia.spark.rapids.SlowFileSystem")
       spark.conf.set("slowfs.write.delay.ms", slowFsWriteDelayMs.toString)
@@ -460,10 +462,8 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
         )
         .filter($"total_count" > 5)
 
-      // Write to slow filesystem Parquet format with repartitioning
-      // and take significant time due to filesystem delays
+      // Use many small output tasks so SlowFileSystem delays are visible in write-stage op time.
       testDataDF
-        // Create more output tasks/files, which amplifies SlowFileSystem write delays.
         .repartition(numWritePartitions)
         .write
         .mode("overwrite")
@@ -529,34 +529,30 @@ class MetricsEventLogValidationSuite extends AnyFunSuite with BeforeAndAfterEach
           f"but was ${operatorTimeRatio * 100.0}%.1f%%")
 
       val stage5Metrics = operatorTimeMetrics.filter(_.stage.contains(5))
-      val stage5TaskTimes = taskTimes.filter(_.stage.contains(5))
       val stage5OperatorTime = stage5Metrics.map(_.value).sum
       val stage5Ratio = if (totalOperatorTime > 0) {
         stage5OperatorTime.toDouble / totalOperatorTime.toDouble
       } else {
         0.0
       }
+      // Expect at least one slowfs-delayed write per configured output partition.
       val minExpectedStage5OperatorTime =
-        TimeUnit.MILLISECONDS.toNanos(stage5TaskTimes.length * slowFsWriteDelayMs)
+        TimeUnit.MILLISECONDS.toNanos(numWritePartitions * slowFsWriteDelayMs)
 
       println(f"Parquet write job: Stage 5 operator time: " +
         f"${stage5OperatorTime / 1000000.0}%.2f ms")
       println(f"Parquet write job: Stage 5 ratio: ${stage5Ratio * 100.0}%.1f%% " +
         "of total operator time")
-      println(s"Parquet write job: Stage 5 task count: ${stage5TaskTimes.length}")
       println(f"Parquet write job: Stage 5 expected minimum operator time: " +
         f"${minExpectedStage5OperatorTime / 1000000.0}%.2f ms")
 
       assert(stage5Metrics.nonEmpty,
         "Should find operator time metrics for stage 5 (parquet write stage)")
 
-      assert(stage5TaskTimes.nonEmpty,
-        "Should find executor run times for stage 5 (parquet write stage)")
-
       assert(stage5OperatorTime >= minExpectedStage5OperatorTime,
         f"Stage 5 (parquet write stage) operator time should be at least " +
           f"${minExpectedStage5OperatorTime / 1000000.0}%.2f ms based on " +
-          f"${stage5TaskTimes.length} stage 5 tasks and $slowFsWriteDelayMs ms slowfs delay, " +
+          f"$numWritePartitions write partitions and $slowFsWriteDelayMs ms slowfs delay, " +
           f"but was ${stage5OperatorTime / 1000000.0}%.2f ms")
 
       operatorTimeMetrics.foreach { m =>


### PR DESCRIPTION
Fixes #14790.

### Description

This PR updates `MetricsEventLogValidationSuite` to validate the parquet write stage operator time against the slow filesystem delay injected by the test instead of asserting that stage 5 accounts for more than 10% of total job operator time.

The previous ratio check could fail when upstream stages contributed more operator time, even though the parquet write stage still recorded a meaningful amount of time. The new assertion uses the configured slowfs write delay and write partition count as an absolute lower bound while keeping the ratio in the logs for diagnostics.

Tested with:

```
mvn test -pl tests -Dbuildver=330 -DwildcardSuites=com.nvidia.spark.rapids.MetricsEventLogValidationSuite
```

Result: 4 tests succeeded, 0 failed.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required