### PR TITLE
[AutoSparkUT] Recover JSON floating point exclusions (#10773)

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsJsonSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/suites/RapidsJsonSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.suites
 
+import com.nvidia.spark.rapids.RapidsConf
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.datasources.{InMemoryFileIndex, NoopCache}
 import org.apache.spark.sql.execution.datasources.json.JsonSuite
@@ -31,6 +35,29 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class RapidsJsonSuite
   extends JsonSuite with RapidsSQLTestsBaseTrait with RapidsJsonConfTrait {
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
+      (implicit pos: Position): Unit = {
+    val wrappedTestFun = if (RapidsJsonSuite.jsonFloatFallbackTests.contains(testName)) {
+      () => withSQLConf(
+        RapidsConf.ENABLE_READ_JSON_FLOATS.key -> "false",
+        RapidsConf.ENABLE_READ_JSON_DOUBLES.key -> "false") {
+        testFun
+      }
+    } else {
+      () => testFun
+    }
+    super.test(testName, testTags: _*)(wrappedTestFun())(pos)
+  }
+}
+
+object RapidsJsonSuite {
+  private val jsonFloatFallbackTests: Set[String] = Set(
+    "SPARK-18352: Parse normal multi-line JSON files (uncompressed)",
+    "SPARK-18352: Parse normal multi-line JSON files (compressed)",
+    "Applying schemas",
+    "Loading a JSON dataset from a text file with SQL",
+    "Loading a JSON dataset from a text file")
 }
 
 class RapidsJsonV1Suite extends RapidsJsonSuite with RapidsSQLTestsBaseTrait {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -132,11 +132,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-33134: return partial results only for root JSON objects", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14088"))
   enableSuite[RapidsJsonSuite]
     .exclude("SPARK-32810: JSON data source should be able to read files with escaped glob metacharacter in the paths", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
-    .exclude("SPARK-18352: Parse normal multi-line JSON files (uncompressed)", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
-    .exclude("SPARK-18352: Parse normal multi-line JSON files (compressed)", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
-    .exclude("Applying schemas", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
-    .exclude("Loading a JSON dataset from a text file with SQL", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
-    .exclude("Loading a JSON dataset from a text file", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10773"))
   enableSuite[RapidsMathExpressionsSuite]
     .exclude("round/bround/floor/ceil", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13747"))
   enableSuite[RapidsMathFunctionsSuite]


### PR DESCRIPTION
Contributes to #10773.

### Description

This recovers five `RapidsJsonSuite` exclusions tied to the documented JSON floating-point parsing compatibility gap. Directly removing the exclusions still runs the JSON double scan on GPU and fails with the known `1.7976931348623157` vs `1.7976931348623155` mismatch. Instead, this change wraps only the affected inherited Spark tests with the existing compatibility fallback configs:

- `spark.rapids.sql.json.read.float.enabled=false`
- `spark.rapids.sql.json.read.double.enabled=false`

That keeps the original Spark assertions intact and avoids pretending the GPU JSON floating-point parser is bit-compatible for these cases. Other `RapidsJsonSuite` tests continue to use the existing suite configuration.

`SPARK-32810` remains ignored here because open PR #14778 already owns that recovery.

### Per-test traceability

| RAPIDS test | Spark original | Spark source |
|---|---|---|
| Loading a JSON dataset from a text file | identical | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala:595` |
| Loading a JSON dataset from a text file with SQL | identical | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala:861` |
| Applying schemas | identical | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala:888` |
| SPARK-18352: Parse normal multi-line JSON files (compressed) | identical | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala:1889` |
| SPARK-18352: Parse normal multi-line JSON files (uncompressed) | identical | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala:1914` |

### Maven evidence

```bash
mvn package -s jenkins/settings.xml -P mirror-apache-to-urm -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsJsonSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

```text
Tests: succeeded 127, failed 0, canceled 0, ignored 1, pending 0
All tests passed.
```

Remaining ignored: `SPARK-32810`, handled by #14778.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
