### PR TITLE
[integration tests]: pass ivy settings to spark connect smoke test [skip ci]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -505,6 +505,16 @@ else
             SERVER_JARS="${ALL_JARS//:/,}"
         fi
 
+        SPARK_SHELL_ARGS_ARR=(
+            --master local-cluster[1,2,1024]
+            --conf spark.plugins=com.nvidia.spark.SQLPlugin
+            --packages "$CONNECT_PACKAGES"
+            ${SERVER_JARS:+--jars "$SERVER_JARS"}
+        )
+        if [[ -n "$PYSP_TEST_spark_jars_ivySettings" ]]; then
+            SPARK_SHELL_ARGS_ARR+=(--conf "spark.jars.ivySettings=${PYSP_TEST_spark_jars_ivySettings}")
+        fi
+
         # Helper: check if port is listening
         check_port() {
             local port=$1
@@ -546,10 +556,7 @@ else
         trap cleanup_connect_server EXIT
 
         if ! start_output=$("${SPARK_HOME}/sbin/start-connect-server.sh" \
-            --master local-cluster[1,2,1024] \
-            --conf spark.plugins=com.nvidia.spark.SQLPlugin \
-            --packages "$CONNECT_PACKAGES" \
-            ${SERVER_JARS:+--jars "$SERVER_JARS"} 2>&1); then
+            "${SPARK_SHELL_ARGS_ARR[@]}" 2>&1); then
           echo "ERROR: Spark Connect server failed to launch"
           printf "%s\n" "$start_output" | tail -n 200
           exit 1


### PR DESCRIPTION
Fixes #14763.

### Description
Fix Spark Connect smoke test package resolution so the configured Ivy settings are actually passed to SparkSubmit. Previously, Jenkins set PYSP_TEST_spark_jars_ivySettings, but the Spark Connect branch only used that environment variable as shell state and never converted it into --conf spark.jars.ivySettings=..., so start-connect-server.sh still loaded Spark/Ivy default settings when resolving --packages.

### Changes
- Build Spark Connect server startup arguments through SPARK_SHELL_ARGS_ARR.
- Append --conf spark.jars.ivySettings=... when PYSP_TEST_spark_jars_ivySettings is provided, matching the behavior used by other package-based test paths.

### Verification
Verified in the internal pipeline
<img width="1794" height="288" alt="image" src="https://github.com/user-attachments/assets/4d52e469-7614-4dce-a529-18c337e4eb29" />
<img width="1290" height="1896" alt="image" src="https://github.com/user-attachments/assets/d69d777b-0055-4e20-8b3c-20a0a1f72c38" />
<img width="1966" height="60" alt="image" src="https://github.com/user-attachments/assets/5d4a1958-0d83-4e48-963e-7c9fdd2c677d" />

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
