### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows [skip ci]

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -19,6 +19,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   license-header-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -19,6 +19,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -35,6 +35,9 @@ env:
     -Daether.connector.http.connectionMaxTtl=30
     -Drapids.secondaryCacheDir=$HOME/.m2/repository/.sbt/1.0/zinc/org.scala-sbt
 
+permissions:
+  contents: read
+
 jobs:
   cache-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -19,6 +19,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   shell-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes N/A (CI hardening - no associated bug issue).

### Description

Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `add-to-project.yml`, `blossom-ci.yml`.

This is supply-chain hygiene grounded in CVE-2025-30066 (March 2025 `tj-actions/changed-files` compromise) where a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token carried whatever scope was issued at the workflow level. Pinning per workflow bounds runtime authority irrespective of repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

No functional change. YAML validated locally with `yaml.safe_load` on each touched file.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required