### PR TITLE
[integration tests]: extend spark connect startup wait [skip ci]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -547,6 +547,16 @@ else
         CONNECT_SERVER_URL="sc://${CONNECT_HOST}:${CONNECT_PORT}"
 
         cleanup_connect_server() {
+            # dump connect server logs for troubleshooting
+            local connect_server_logs=("$SPARK_HOME"/logs/*SparkConnectServer*.out)
+            if [[ -f "${connect_server_logs[0]}" ]]; then
+                for f in "${connect_server_logs[@]}"; do
+                    echo "=== $f ==="
+                    cat "$f" || true
+                done
+            else
+                echo "No Spark Connect server .out log found in $SPARK_HOME/logs"
+            fi
             if [[ -f "${SPARK_HOME}/sbin/stop-connect-server.sh" ]]; then
                 timeout 20 "${SPARK_HOME}/sbin/stop-connect-server.sh" || true
             fi
@@ -569,7 +579,7 @@ else
                 service_ready=1
                 break
             fi
-            sleep 1
+            sleep 10
         done
         if (( service_ready != 1 )); then
             echo "ERROR: Connect server failed to start on ${CONNECT_HOST}:${CONNECT_PORT}"


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14763

### Description
Improve Spark Connect smoke test diagnostics and give the server more time to become ready. This helps preserve the Connect server log in Jenkins output when startup fails or hangs before the readiness check succeeds.

### Changes
- Print Spark Connect server .out logs during cleanup, with a clear message when no server log exists.
- Increase the timeout from 1min to 10mins.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
