### PR TITLE
Skip GBK decode test on Dataproc Serverless

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -18,8 +18,7 @@ import random
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, \
     assert_gpu_sql_fallback_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_error, \
     assert_cpu_and_gpu_are_equal_collect_with_capture
-from conftest import is_databricks_runtime, get_datagen_seed, is_dataproc_serverless_runtime, \
-    get_inject_oom_conf
+from conftest import is_databricks_runtime, get_datagen_seed, is_dataproc_serverless_runtime
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
@@ -39,6 +38,8 @@ _gbk_edge_cases = [
     bytearray(b'Hi\xc4\xe3\xba\xc3World'), # mixed ASCII and Chinese
 ]
 
+@pytest.mark.skipif(is_dataproc_serverless_runtime(),
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/14815")
 @pytest.mark.parametrize('data_gen', [
     # Random CJK ideographs encoded as GBK — tests normal decode path
     BinaryGen(min_length=0, max_length=50, min_val=0x4E00, max_val=0x9FA5, encoding='gbk'),
@@ -46,8 +47,6 @@ _gbk_edge_cases = [
     BinaryGen(min_length=0, max_length=50),
 ], ids=['gbk_chinese', 'random_bytes'])
 def test_string_decode_gbk(data_gen):
-    if is_dataproc_serverless_runtime() and get_inject_oom_conf():
-        pytest.skip("https://github.com/NVIDIA/spark-rapids/issues/14815")
     gen = data_gen
     for sc in _gbk_edge_cases:
         gen = gen.with_special_case(sc)

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -18,7 +18,7 @@ import random
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, \
     assert_gpu_sql_fallback_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_error, \
     assert_cpu_and_gpu_are_equal_collect_with_capture
-from conftest import is_databricks_runtime, get_datagen_seed
+from conftest import is_databricks_runtime, get_datagen_seed, is_dataproc_serverless_runtime
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
@@ -38,6 +38,8 @@ _gbk_edge_cases = [
     bytearray(b'Hi\xc4\xe3\xba\xc3World'), # mixed ASCII and Chinese
 ]
 
+@pytest.mark.skipif(is_dataproc_serverless_runtime(),
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/14815")
 @pytest.mark.parametrize('data_gen', [
     # Random CJK ideographs encoded as GBK — tests normal decode path
     BinaryGen(min_length=0, max_length=50, min_val=0x4E00, max_val=0x9FA5, encoding='gbk'),

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -18,7 +18,8 @@ import random
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, \
     assert_gpu_sql_fallback_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_error, \
     assert_cpu_and_gpu_are_equal_collect_with_capture
-from conftest import is_databricks_runtime, get_datagen_seed, is_dataproc_serverless_runtime
+from conftest import is_databricks_runtime, get_datagen_seed, is_dataproc_serverless_runtime, \
+    get_inject_oom_conf
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
@@ -38,8 +39,6 @@ _gbk_edge_cases = [
     bytearray(b'Hi\xc4\xe3\xba\xc3World'), # mixed ASCII and Chinese
 ]
 
-@pytest.mark.skipif(is_dataproc_serverless_runtime(),
-                    reason="https://github.com/NVIDIA/spark-rapids/issues/14815")
 @pytest.mark.parametrize('data_gen', [
     # Random CJK ideographs encoded as GBK — tests normal decode path
     BinaryGen(min_length=0, max_length=50, min_val=0x4E00, max_val=0x9FA5, encoding='gbk'),
@@ -47,6 +46,8 @@ _gbk_edge_cases = [
     BinaryGen(min_length=0, max_length=50),
 ], ids=['gbk_chinese', 'random_bytes'])
 def test_string_decode_gbk(data_gen):
+    if is_dataproc_serverless_runtime() and get_inject_oom_conf():
+        pytest.skip("https://github.com/NVIDIA/spark-rapids/issues/14815")
     gen = data_gen
     for sc in _gbk_edge_cases:
         gen = gen.with_special_case(sc)


### PR DESCRIPTION
related to #14815.

### Description

Dataproc Serverless 2.2 integration-test batches can intermittently time out while running the large `string_test.py` shard. In the observed failure, a Spark job exceeded the 3600 second `TimeoutSparkListener` limit after `test_string_decode_gbk` started, which killed the Driver JVM and caused the remaining tests in the xdist worker to fail as a cascade.

This change skips `test_string_decode_gbk` when the integration test runtime is `dataproc_serverless`. The test remains enabled for Apache Spark and other runtime environments, so normal local and non-Dataproc GBK string decode coverage is unchanged while the Dataproc Serverless instability is tracked separately in #14815.

Validation:

- `python -m py_compile integration_tests/src/main/python/string_test.py`
- Local targeted run: `test_string_decode_gbk and gbk_chinese --test_oom_injection_mode=always` passed
- Local targeted run: `test_string_decode_gbk --test_oom_injection_mode=always` passed with `2 passed, 2 skipped`
- Local full-file run: `string_test.py --test_oom_injection_mode=always` passed with `145 passed, 2 skipped, 1 xfailed`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
