### PR TITLE
Use fused replaceNulls for non-nested types in GpuNvl

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -28,15 +28,26 @@ import org.apache.spark.sql.types.{DataType, DoubleType, FloatType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object GpuNvl {
+  // For non-nested types, use the fused replaceNulls kernel directly.
+  // Otherwise fall back to isNotNull+ifElse (backed by copy_if_else which
+  // supports nested types).
   def apply(lhs: ColumnVector, rhs: ColumnVector): ColumnVector = {
-    withResource(lhs.isNotNull) { isLhsNotNull =>
-      isLhsNotNull.ifElse(lhs, rhs)
+    if (lhs.getType.isNestedType) {
+      withResource(lhs.isNotNull) { isLhsNotNull =>
+        isLhsNotNull.ifElse(lhs, rhs)
+      }
+    } else {
+      lhs.replaceNulls(rhs)
     }
   }
 
   def apply(lhs: ColumnVector, rhs: Scalar): ColumnVector = {
-    withResource(lhs.isNotNull) { isLhsNotNull =>
-      isLhsNotNull.ifElse(lhs, rhs)
+    if (lhs.getType.isNestedType) {
+      withResource(lhs.isNotNull) { isLhsNotNull =>
+        isLhsNotNull.ifElse(lhs, rhs)
+      }
+    } else {
+      lhs.replaceNulls(rhs)
     }
   }
 }


### PR DESCRIPTION
Contributes to #14588.

### Description

This is a small change to prefer the fused replaceNulls kernel for non-nested types in GpuNvl, avoiding the otherwise two-kernel pass and extra bool column allocation. 

Covered by existing tests in [conditional_tests.py](https://github.com/NVIDIA/spark-rapids/blob/b7b79ee1225e67a9c66deca8b582a7aabb2172d9/integration_tests/src/main/python/conditionals_test.py#L142) e.g. `test_coalesce`, `test_nvl`.

Benchmarks are below. It is a very small optimization, so in an E2E benchmark perf improvement is slight.


**Generated data:**
```bash
cat << 'EOF' | "$SPARK_HOME/bin/spark-shell" \
    --jars "$DATAGEN_JAR" \
    --master "local[*]" \
    --conf spark.driver.memory=16g
import org.apache.spark.sql.tests.datagen._

val cases: Seq[(String, String)] = Seq(
  ("long",       "a long, b long"),
  ("string",     "a string, b string"),
  ("decimal_38", "a DECIMAL(38,10), b DECIMAL(38,10)"),
  ("array_long", "a ARRAY<long>, b ARRAY<long>"),
  ("struct_2",   "a STRUCT<x:long, y:string>, b STRUCT<x:long, y:string>")
)

val numRows  = sys.env.getOrElse("BENCH_ROWS",      "10000000").toLong
val nullProb = sys.env.getOrElse("BENCH_NULL_PROB", "0.25").toDouble
val outRoot  = sys.env("BENCH_DATA_DIR")

cases.foreach { case (label, ddl) =>
  val path = s"$outRoot/$label"
  println(s"[gen_data] $label  ddl=[$ddl]  rows=$numRows  nullProb=$nullProb  -> $path")
  val dataTable = DBGen().addTable("data", ddl, numRows)
  dataTable("a").setNullProbability(nullProb)
  dataTable("b").setNullProbability(nullProb)
  dataTable.toDF(spark).write.mode("overwrite").parquet(path)
}

println(s"[gen_data] generated ${cases.size} dataset(s) under $outRoot/")
:quit
EOF
```

**Benchmark:**
```bash
cat << EOF | BENCH_LABEL="$label" "$SPARK_HOME/bin/spark-shell" \
        --jars "$jar" \
        --master "local[*]" \
        --conf spark.driver.memory=16g \
        --conf spark.plugins=com.nvidia.spark.SQLPlugin \
        --conf spark.sql.files.maxPartitionBytes=256MB
val cases: Seq[(String, String)] = Seq(
  ("long",       "SUM(a - coalesce(b, 0L)) + SUM(coalesce(a, 0L) + coalesce(b, 0L))"),
  ("decimal_38", "SUM(coalesce(a, CAST(0 AS DECIMAL(38,10))) + coalesce(b, CAST(0 AS DECIMAL(38,10))))"),
  ("string",     "COUNT(coalesce(a, 'x')) + COUNT(coalesce(b, 'y')) + COUNT(coalesce(a, b))"),
  ("array_long", "COUNT(coalesce(a, b))"),
  ("struct_2",   "COUNT(coalesce(a, b))")
)

val dataRoot = sys.env("BENCH_DATA_DIR")
val warmup   = sys.env.getOrElse("BENCH_WARMUP",   "2").toInt
val measured = sys.env.getOrElse("BENCH_MEASURED", "3").toInt
val tag      = sys.env.getOrElse("BENCH_LABEL",    "run")

cases.foreach { case (caseLabel, sqlFrag) =>
  val df = spark.read.parquet(s"\$dataRoot/\$caseLabel")
  df.createOrReplaceTempView("bench")
  val q = s"SELECT \$sqlFrag FROM bench"
  println(s"[\$tag] === \$caseLabel ===  \$q")
  for (_ <- 0 until warmup) spark.sql(q).collect()
  for (i <- 1 to measured) {
    print(s"[\$tag] \$caseLabel run\$i: ")
    spark.time(spark.sql(q).collect())
  }
}
:quit
EOF
```

**Results:**

Case | Baseline (ms) | Optimized (ms) | Δ (ms) | Speedup
-- | -- | -- | -- | --
long | 187.5 | 178.0 | −9.5 | 1.05×
decimal_38 | 262.5 | 258.5 | −4.0 | 1.02×
string | 344.0 | 335.0 | −9.0 | 1.03×
array_long | 700.5 | 699.5 | −1.0 | 1.00×
struct_2 | 492.5 | 491.0 | −1.5 | 1.00×

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
