### PR TITLE
Use fused mergeAndSetValidity kernel in mergeNulls

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable
 
-import ai.rapids.cudf.{ast, ColumnVector, ColumnView, DType, Scalar}
+import ai.rapids.cudf.{ast, BinaryOp, ColumnVector, ColumnView, DType, Scalar}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
@@ -320,20 +320,7 @@ object NullUtilities {
    * return the row from the "dataCol".
    */
   def mergeNulls(dataCol: ColumnVector, nullFlagCol: ColumnView): ColumnVector = {
-    withResource(nullFlagCol.isNull) { isNull =>
-      // if we have at least 1 null, we need to merge nulls, else
-      // it is a noop
-      val needsToChange = withResource(isNull.any) { tmp =>
-        tmp.isValid && tmp.getBoolean
-      }
-      if (needsToChange) {
-        withResource(Scalar.fromNull(dataCol.getType)) { nullScalar =>
-          isNull.ifElse(nullScalar, dataCol)
-        }
-      } else {
-        dataCol.incRefCount()
-      }
-    }
+    dataCol.mergeAndSetValidity(BinaryOp.BITWISE_AND, nullFlagCol)
   }
 
   /**
@@ -343,24 +330,6 @@ object NullUtilities {
   def mergeNulls(dataCol: ColumnVector,
                  nullFlagCol1: ColumnView,
                  nullFlagCol2: ColumnView): ColumnVector = {
-    val nullFlag = withResource(nullFlagCol1.isNull) { isNull1 =>
-      withResource(nullFlagCol2.isNull) { isNull2 =>
-        isNull1.or(isNull2)
-      }
-    }
-    withResource(nullFlag) { _ =>
-      // if we have at least 1 null, we need to merge nulls, else
-      // it is a noop
-      val needsToChange = withResource(nullFlag.any) { tmp =>
-        tmp.isValid && tmp.getBoolean
-      }
-      if (needsToChange) {
-        withResource(Scalar.fromNull(dataCol.getType)) { nullScalar =>
-          nullFlag.ifElse(nullScalar, dataCol)
-        }
-      } else {
-        dataCol.incRefCount()
-      }
-    }
+    dataCol.mergeAndSetValidity(BinaryOp.BITWISE_AND, nullFlagCol1, nullFlagCol2)
   }
 }


### PR DESCRIPTION
Contributes to #14588.

### Description

This is a small change to prefer the fused `mergeAndSetValidity` kernel in mergeNulls, avoiding what is currently 5 kernels and 3 intermediate bool columns. This utility is exercised in operators such as GpuDivide, GpuSlice. This change is covered by existing tests for said operators.

**Microbenchmark**

To measure performance, ran a granular microbenchmark isolating the utility in question.

<details>
<summary>Microbenchmark Code</summary>

Compared these two helpers in isolation.

```scala
  object Baseline {
    def mergeNulls(dataCol: ColumnVector, nullFlagCol: ColumnVector): ColumnVector = {
      withResource(nullFlagCol.isNull) { isNull =>
        val needsToChange = withResource(isNull.any) { tmp =>
          tmp.isValid && tmp.getBoolean
        }
        if (needsToChange) {
          withResource(Scalar.fromNull(dataCol.getType)) { nullScalar =>
            isNull.ifElse(nullScalar, dataCol)
          }
        } else {
          dataCol.incRefCount()
        }
      }
    }

    def mergeNulls(dataCol: ColumnVector,
        nullFlagCol1: ColumnVector,
        nullFlagCol2: ColumnVector): ColumnVector = {
      val nullFlag = withResource(nullFlagCol1.isNull) { isNull1 =>
        withResource(nullFlagCol2.isNull) { isNull2 =>
          isNull1.binaryOp(BinaryOp.LOGICAL_OR, isNull2, DType.BOOL8)
        }
      }
      withResource(nullFlag) { combinedNullFlag =>
        val needsToChange = withResource(combinedNullFlag.any) { tmp =>
          tmp.isValid && tmp.getBoolean
        }
        if (needsToChange) {
          withResource(Scalar.fromNull(dataCol.getType)) { nullScalar =>
            combinedNullFlag.ifElse(nullScalar, dataCol)
          }
        } else {
          dataCol.incRefCount()
        }
      }
    }
  }

  object Optimized {
    def mergeNulls(dataCol: ColumnVector, nullFlagCol: ColumnVector): ColumnVector = {
      dataCol.mergeAndSetValidity(BinaryOp.BITWISE_AND, nullFlagCol)
    }

    def mergeNulls(dataCol: ColumnVector,
        nullFlagCol1: ColumnVector,
        nullFlagCol2: ColumnVector): ColumnVector = {
      dataCol.mergeAndSetValidity(BinaryOp.BITWISE_AND, nullFlagCol1, nullFlagCol2)
    }
  }
```

</details>

**Results:**

  | Benchmark | Overload | Rows | Baseline med (ms) | Optimized med (ms) | Speedup |
  |---|---|---:|---:|---:|---:|
  | mergeNulls microbench | Single | 10,000,000 | 0.367 | 0.278 | 1.3214x |
  | mergeNulls microbench | Double | 10,000,000 | 0.521 | 0.276 | 1.8892x |

**E2E benchmark**

Also ran an E2E benchmark exercising mergeNulls via GpuDivide.

<details>
<summary>Spark benchmark code</summary>

Generated data:
```bash
cat << 'EOF' | "$SPARK_HOME/bin/spark-shell" \
    --jars "$DATAGEN_JAR" \
    --master "local[*]" \
    --conf spark.driver.memory=16g
import org.apache.spark.sql.tests.datagen._
import org.apache.spark.sql.functions.{col, lit, when}

val cases: Seq[(String, String)] = Seq(
  ("double", "a double, b double")
)

val numRows  = sys.env.getOrElse("BENCH_ROWS",      "10000000").toLong
val nullProb = sys.env.getOrElse("BENCH_NULL_PROB", "0.25").toDouble
val outRoot  = sys.env("BENCH_DATA_DIR")

cases.foreach { case (label, ddl) =>
  val path = s"$outRoot/$label"
  println(s"[gen_data] $label  ddl=[$ddl]  rows=$numRows  nullProb=$nullProb  -> $path")
  val dataTable = DBGen().addTable("data", ddl, numRows)
  dataTable("a").setNullProbability(nullProb)
  dataTable("b").setNullProbability(nullProb)
  val sanitized = dataTable.toDF(spark)
    .withColumn("b",
      when(col("b").isNull, lit(null).cast("double"))
        .when(col("b") === 0.0d || col("b") === -0.0d, lit(1.0d))
        .otherwise(col("b")))
  sanitized.write.mode("overwrite").parquet(path)
}

println(s"[gen_data] generated ${cases.size} dataset(s) under $outRoot/")
:quit
EOF
```

Benchmark:
```bash
cat << EOF | BENCH_LABEL="$label" "$SPARK_HOME/bin/spark-shell" \
        --jars "$jar" \
        --master "local[*]" \
        --conf spark.driver.memory=16g \
        --conf spark.plugins=com.nvidia.spark.SQLPlugin \
        --conf spark.sql.ansi.enabled=true \
        --conf spark.sql.files.maxPartitionBytes=256MB
val cases: Seq[(String, String)] = Seq(
  ("double", "SUM(a / b)")
)

val dataRoot = sys.env("BENCH_DATA_DIR")
val warmup   = sys.env.getOrElse("BENCH_WARMUP",   "2").toInt
val measured = sys.env.getOrElse("BENCH_MEASURED", "3").toInt
val tag      = sys.env.getOrElse("BENCH_LABEL",    "run")

cases.foreach { case (caseLabel, sqlFrag) =>
  val df = spark.read.parquet(s"\$dataRoot/\$caseLabel")
  df.createOrReplaceTempView("bench")
  val q = s"SELECT \$sqlFrag FROM bench"
  println(s"[\$tag] === \$caseLabel ===  \$q")
  for (_ <- 0 until warmup) spark.sql(q).collect()
  for (i <- 1 to measured) {
    print(s"[\$tag] \$caseLabel run\$i: ")
    spark.time(spark.sql(q).collect())
  }
}
:quit
EOF
done
```

</details>

| Query | Measured runs | Baseline med (ms) | Optimized med (ms) | Speedup |
|---|---:|---:|---:|---|
| SELECT SUM(a / b) FROM bench | 10 | 199.0 | 185.5 | 1.0728x |

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
