### PR TITLE
Use scalar extractListElement index instead of column in substring where length is fixed

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -686,12 +686,8 @@ case class GpuSubstring(str: Expression, pos: Expression, len: Expression)
       lenS: GpuScalar): ColumnVector = {
     val strs = strCol.getBase
     val poses = posCol.getBase
-    val numRows =  strCol.getRowCount.toInt
     withResource(computeStarts(strs, poses)) { starts =>
-      val ends = withResource(ColumnVector.fromScalar(lenS.getBase, numRows)) { lens =>
-        computeEnds(starts, lens)
-      }
-      withResource(ends) { _ =>
+      withResource(computeEnds(starts, lenS.getBase)) { ends =>
         substringColumn(strs, starts, ends)
       }
     }


### PR DESCRIPTION
Contributes to #14588.

### Description

This is a small local change in the GPU substring overload where lenS is fixed, i.e., `doColumnar(strCol, posCol, lenS: GpuScalar)`, to pass a scalar `lenS` to computeEnds rather than replicating as a full column. computeEnds takes `lens` as a `BinaryOperable` (either scalar or column) to compute `end = start + len`. Existing substring tests (e.g. [string_test.py](https://github.com/NVIDIA/spark-rapids/blob/main/integration_tests/src/main/python/string_test.py#L629)) cover this change.

Using the scalar index API can be ~14% faster. 

<details>
<summary>Nanobenchmark comparing the two APIs</summary>

```scala
import ai.rapids.cudf.{BinaryOperable, ColumnVector, Cuda, DType, Rmm, RmmAllocationMode, Scalar}

object ComputeEndsBench {
  val NumRows = 100000
  val Warmup = 5
  val Measured = 20

  def main(args: Array[String]): Unit = {
    Rmm.initialize(RmmAllocationMode.POOL, null, Cuda.memGetInfo().free / 2 & ~255L)

    withResource(buildStarts()) { starts =>
      withResource(Scalar.fromInt(5)) { lensScalar =>
        for (_ <- 0 until Warmup) {
          broadcastFirst(starts, lensScalar).close()
          scalarDirect(starts, lensScalar).close()
        }
        val timesA = (0 until Measured).map { _ =>
          val t = System.nanoTime()
          broadcastFirst(starts, lensScalar).close()
          System.nanoTime() - t
        }
        val timesB = (0 until Measured).map { _ =>
          val t = System.nanoTime()
          scalarDirect(starts, lensScalar).close()
          System.nanoTime() - t
        }
        println(f"Col lens median: ${timesA.sorted.apply(Measured / 2) / 1e6}%.3f ms")
        println(f"Scalar lens median: ${timesB.sorted.apply(Measured / 2) / 1e6}%.3f ms")
      }
    }
  }

  def broadcastFirst(starts: ColumnVector, lensScalar: Scalar): ColumnVector =
    withResource(ColumnVector.fromScalar(lensScalar, NumRows)) { lens =>
      computeEnds(starts, lens)
    }

  def scalarDirect(starts: ColumnVector, lensScalar: Scalar): ColumnVector =
    computeEnds(starts, lensScalar)

  def computeEnds(starts: BinaryOperable, lens: BinaryOperable): ColumnVector = {
    val endLongCol = withResource(starts.add(lens, DType.INT64)) { endColAsLong =>
      withResource(Scalar.fromLong(0L)) { zero =>
        withResource(Scalar.fromLong(Int.MaxValue.toLong)) { maxInt =>
          endColAsLong.clamp(zero, maxInt)
        }
      }
    }
    withResource(endLongCol) { _ =>
      endLongCol.castTo(DType.INT32)
    }
  }

  def buildStarts(): ColumnVector =
    withResource(Scalar.fromInt(10)) { s =>
      ColumnVector.fromScalar(s, NumRows)
    }
}
```

</details>

```text
Col lens median: 0.083 ms
Scalar lens median: 0.073 ms
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required