### PR TITLE
[AutoSparkUT] Recover RapidsParquetProtobufCompatibilitySuite single-field repeated group cases

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -873,9 +873,13 @@ protected case class GpuParquetFileFilterHandler(
           }
         } else {
           val fileGroupType = fileType.asGroupType()
-          if (fileGroupType.getFieldCount > 1 &&
-              fileGroupType.isRepetition(Type.Repetition.REPEATED)) {
-            // legacy array format where struct child is directly repeated under array type group
+          if (fileGroupType.isRepetition(Type.Repetition.REPEATED)) {
+            // Unannotated 1-level legacy list: the REPEATED group itself is the element,
+            // regardless of how many fields it has. Without this branch, a single-field
+            // repeated group (e.g. `repeated group g { optional int32 someId; }`) is
+            // mis-interpreted as a 2/3-level LIST wrapper and its primitive child is
+            // treated as a group, producing ClassCastException. The cuDF reader handles
+            // the actual decoding (see rapidsai/cudf#22541 for the matching cuDF-side fix).
             checkSchemaCompat(fileGroupType, array.elementType, errorCallback, isCaseSensitive,
               useFieldId, rootFileType, rootReadType)
           } else {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -164,8 +164,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsParquetPartitionDiscoverySuite]
     .exclude("Various partition value types", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11583"))
   enableSuite[RapidsParquetProtobufCompatibilitySuite]
-    .exclude("struct with unannotated array", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11475"))
-    .exclude("unannotated array of struct with unannotated array", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11476"))
   enableSuite[RapidsParquetQuerySuite]
     .exclude("SPARK-26677: negated null-safe equality comparison should not filter matched row groups", ADJUST_UT("fetches the CPU version of Execution Plan instead of the GPU version."))
     .exclude("SPARK-34212 Parquet should read decimals correctly", ADJUST_UT("Vectorized Parquet reader throws an exception when scale is narrowed in Apache Spark where as the spark-rapids plugin does not."))


### PR DESCRIPTION
Fixes #11475
Fixes #11476

### Description

`GpuParquetFileFilterHandler::checkSchemaCompat` mirrors the Parquet LIST backward-compatibility rules. The branch that handles unannotated 1-level legacy lists of struct was gated on `fileGroupType.getFieldCount > 1`, so a `repeated group X { optional int32 f; }` (single-field) fell through to the LIST-wrapper branch and `repeatedType.asGroupType()` was called on the primitive `f`, producing the user-visible `java.lang.ClassCastException: optional int32 someId is not a group` reported in #11475 and the same crash for the nested case in #11476.

Spec reference: ["Backward-compatibility rules"](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#backward-compatibility-rules) — "A repeated field that is neither contained by a LIST- or MAP-annotated group nor annotated by LIST or MAP should be interpreted as a required list of required elements where the element type is the type of the field." For a `repeated <group>`, the element is therefore the entire group, regardless of how many fields the group has.

This PR relaxes the guard to `fileGroupType.isRepetition(REPEATED)` only — multi-field path is unchanged, and the LIST-annotated 2/3-level wrapper case is untouched (it never hits this branch because the outer group is not REPEATED).

The fix is paired with a matching libcudf change ([rapidsai/cudf#22567](https://github.com/rapidsai/cudf/pull/22567), closes [rapidsai/cudf#22541](https://github.com/rapidsai/cudf/issues/22541)). Without the cuDF change, the plugin-side schema check would now pass but cuDF's reader would still collapse the single-field group into `list<int>` and the read would fail downstream in `GpuColumnVector.typeConversionAllowed` with `ArrayType(StructType(...)) is not supported`. **Wait to merge until rapidsai/cudf#22567 is in the cuDF version this branch depends on.**

### Recovered tests (RapidsParquetProtobufCompatibilitySuite)

| RAPIDS test | Spark original | Source | Status |
|---|---|---|---|
| `struct with unannotated array` | `struct with unannotated array` | [`ParquetProtobufCompatibilitySuite.scala:61-65`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetProtobufCompatibilitySuite.scala#L61-L65) | RECOVERED |
| `unannotated array of struct with unannotated array` | `unannotated array of struct with unannotated array` | [`ParquetProtobufCompatibilitySuite.scala:67-74`](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetProtobufCompatibilitySuite.scala#L67-L74) | RECOVERED |

Both tests read `repeated group X { single_field; }` shapes (resources `proto-struct-with-array.parquet` and `nested-array-struct.parquet`).

### Local Maven validation

```
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsParquetProtobufCompatibilitySuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

```
RapidsParquetProtobufCompatibilitySuite:
- unannotated array of primitive type
- unannotated array of struct
- struct with unannotated array
- unannotated array of struct with unannotated array
- unannotated array of string
Run completed in 13 seconds, 559 milliseconds.
Total number of tests run: 5
Suites: completed 2, aborted 0
Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
[INFO] BUILD SUCCESS
```

Coverage delta: 3/5 → 5/5 passing in `RapidsParquetProtobufCompatibilitySuite`. No other tests in the suite are affected.

### Checklist

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required




