### PR TITLE
[AutoSparkUT] Fix CSV maxCharsPerColumn fallback

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -198,8 +198,9 @@ object GpuCSVScan extends Logging {
         meta.willNotWorkOnGpu(s"the positive infinity value '${parsedOptions.positiveInf}'" +
             s" is not supported'")
     }
-    // parsedOptions.maxCharsPerColumn does not impact the final output it is a performance
-    // improvement if you know the maximum size
+    if (parsedOptions.maxCharsPerColumn != -1) {
+      meta.willNotWorkOnGpu("GpuCSVScan does not support maxCharsPerColumn")
+    }
 
     // parsedOptions.maxColumns was originally a performance optimization but is not used any more
 

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -192,7 +192,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsProductAggSuite]
   enableSuite[RapidsComplexTypesSuite]
   enableSuite[RapidsCSVSuite]
-    .exclude("parse unescaped quotes with maxCharsPerColumn", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13889"))
     .exclude("DDL test parsing decimal type", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13890"))
     .exclude("nullable fields with user defined null value of \"null\"", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13893"))
     .exclude("empty fields with user defined empty values", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13894"))


### PR DESCRIPTION
Fixes #13889.

### Description

This recovers the inherited `RapidsCSVSuite` test `parse unescaped quotes with maxCharsPerColumn` by making CSV scans with a non-default `maxCharsPerColumn` fall back to CPU.

`maxCharsPerColumn` affects Spark's Univocity parsing behavior for malformed/unescaped CSV input, so treating it as only a performance option can produce GPU/CPU output divergence. The change tags `GpuCSVScan` unsupported when `parsedOptions.maxCharsPerColumn != -1`, then removes the corresponding exclusion from `RapidsTestSettings`.

| Test Name | Tier | Action | Maven Result | Status |
|---|---|---|---|---|
| `parse unescaped quotes with maxCharsPerColumn` | T3 | Unsupported CSV option now falls back to CPU; exclusion removed | `Tests: succeeded 129, failed 0, canceled 0, ignored 7, pending 0` | RECOVERED |

Traceability:
- RAPIDS suite: `org.apache.spark.sql.rapids.suites.RapidsCSVSuite`
- Original Spark test: `parse unescaped quotes with maxCharsPerColumn`
- Spark source: `spark/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala`
- Tracking issue: #13889

Performance impact analysis:
- This adds one option check in CSV scan tagging/planning.
- It does not change the GPU CSV decode hot path.
- For non-default `maxCharsPerColumn`, the scan now falls back to CPU to preserve correctness.

Validation:
```bash
mvn package -pl tests -am -Dbuildver=330 \
  -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsCSVSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0 \
  -s jenkins/settings.xml -P mirror-apache-to-urm
```

Result:
```text
Tests: succeeded 129, failed 0, canceled 0, ignored 7, pending 0
BUILD SUCCESS
```

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
