### PR TITLE
TimeoutSparkListener: dump executor threads in addition to driver threads

### DIFF
--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -19,7 +19,6 @@ package org.apache.spark.rapids.tests;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -37,7 +36,8 @@ import org.apache.spark.status.api.v1.ThreadStackTrace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
-import scala.collection.JavaConverters;
+import scala.collection.Iterator;
+import scala.collection.Seq;
 
 /**
  * This code helps accelerate root cause investigations for pipeline hangs
@@ -171,15 +171,19 @@ public class TimeoutSparkListener extends SparkListener {
       return;
     }
     final SparkContext sc = jsc.sc();
-    final List<String> execIds;
+    final Seq<String> execIds;
     try {
-      execIds = JavaConverters.seqAsJavaList(sc.getExecutorIds());
+      execIds = sc.getExecutorIds();
     } catch (Throwable t) {
       LOG.warn("Failed to enumerate executors for thread dump", t);
       return;
     }
     LOG.error("Executor thread dump follows ({} executor(s))", execIds.size());
-    for (String execId : execIds) {
+    // Iterate the Scala Seq directly via its Iterator to avoid the
+    // scala.collection.JavaConverters deprecation in Scala 2.13.
+    final Iterator<String> it = execIds.iterator();
+    while (it.hasNext()) {
+      final String execId = it.next();
       try {
         final Option<ThreadStackTrace[]> dumpOpt = sc.getExecutorThreadDump(execId);
         if (dumpOpt.isEmpty()) {

--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.apache.spark.rapids.tests;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -26,13 +27,17 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.scheduler.SparkListener;
 import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.status.api.v1.ThreadStackTrace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.collection.JavaConverters;
 
 /**
  * This code helps accelerate root cause investigations for pipeline hangs
@@ -108,6 +113,7 @@ public class TimeoutSparkListener extends SparkListener {
       if (taskShouldDumpThreads) {
         LOG.error(message + " Driver thread dump follows");
         dumpThreads();
+        dumpExecutorThreads();
       }
       cancelJob(jobId, message);
     }, taskTimeout, TimeUnit.SECONDS);
@@ -141,6 +147,53 @@ public class TimeoutSparkListener extends SparkListener {
     final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
     for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(true, true)) {
       LOG.warn(threadInfo.toString());
+    }
+  }
+
+  /**
+   * Best-effort dump of every live executor's JVM threads via Spark's
+   * built-in {@link SparkContext#getExecutorThreadDump} RPC. A driver-only
+   * thread dump is rarely enough to diagnose a hung Spark job because the
+   * stuck thread is almost always on an executor; this fills the gap on
+   * runtimes where the Spark UI / REST API is unreachable (e.g. Dataproc
+   * Serverless without component gateway).
+   *
+   * Failures here must not block the surrounding {@code cancelJob} /
+   * {@code System.exit} path, so every RPC is wrapped individually.
+   */
+  private static void dumpExecutorThreads() {
+    final JavaSparkContext jsc;
+    synchronized (TimeoutSparkListener.class) {
+      jsc = sparkContext;
+    }
+    if (jsc == null) {
+      LOG.warn("SparkContext not initialized; skipping executor thread dump");
+      return;
+    }
+    final SparkContext sc = jsc.sc();
+    final List<String> execIds;
+    try {
+      execIds = JavaConverters.seqAsJavaList(sc.getExecutorIds());
+    } catch (Throwable t) {
+      LOG.warn("Failed to enumerate executors for thread dump", t);
+      return;
+    }
+    LOG.error("Executor thread dump follows ({} executor(s))", execIds.size());
+    for (String execId : execIds) {
+      try {
+        final Option<ThreadStackTrace[]> dumpOpt = sc.getExecutorThreadDump(execId);
+        if (dumpOpt.isEmpty()) {
+          LOG.warn("No thread dump returned for executor {}", execId);
+          continue;
+        }
+        final ThreadStackTrace[] stacks = dumpOpt.get();
+        LOG.error("Executor {} thread dump ({} threads):", execId, stacks.length);
+        for (ThreadStackTrace stack : stacks) {
+          LOG.warn("Executor {}: {}", execId, stack);
+        }
+      } catch (Throwable t) {
+        LOG.warn("Failed to fetch thread dump for executor " + execId, t);
+      }
     }
   }
 }

--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -19,11 +19,15 @@ package org.apache.spark.rapids.tests;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.spark.SparkContext;
@@ -150,6 +154,13 @@ public class TimeoutSparkListener extends SparkListener {
     }
   }
 
+  // Total wall-clock budget for collecting all executor thread dumps. A stuck
+  // executor's RPC blocks for spark.rpc.askTimeout (default 120s); without a
+  // shared deadline, N stuck executors would extend the driver's lifetime by
+  // 120s * N past the original job timeout. 30s is enough for healthy
+  // executors to reply while bounding the worst case.
+  private static final long EXECUTOR_DUMP_BUDGET_SECONDS = 30;
+
   /**
    * Best-effort dump of every live executor's JVM threads via Spark's
    * built-in {@link SparkContext#getExecutorThreadDump} RPC. A driver-only
@@ -158,8 +169,10 @@ public class TimeoutSparkListener extends SparkListener {
    * runtimes where the Spark UI / REST API is unreachable (e.g. Dataproc
    * Serverless without component gateway).
    *
-   * Failures here must not block the surrounding {@code cancelJob} /
-   * {@code System.exit} path, so every RPC is wrapped individually.
+   * RPCs are issued concurrently and share a single overall deadline
+   * ({@link #EXECUTOR_DUMP_BUDGET_SECONDS}) so an unresponsive executor
+   * cannot block the surrounding {@code cancelJob} / {@code System.exit}
+   * path for more than that budget regardless of executor count.
    */
   private static void dumpExecutorThreads() {
     final JavaSparkContext jsc;
@@ -171,33 +184,73 @@ public class TimeoutSparkListener extends SparkListener {
       return;
     }
     final SparkContext sc = jsc.sc();
-    final Seq<String> execIds;
+    final Seq<String> execIdsSeq;
     try {
-      execIds = sc.getExecutorIds();
+      execIdsSeq = sc.getExecutorIds();
     } catch (Throwable t) {
       LOG.warn("Failed to enumerate executors for thread dump", t);
       return;
     }
-    LOG.error("Executor thread dump follows ({} executor(s))", execIds.size());
-    // Iterate the Scala Seq directly via its Iterator to avoid the
-    // scala.collection.JavaConverters deprecation in Scala 2.13.
-    final Iterator<String> it = execIds.iterator();
-    while (it.hasNext()) {
-      final String execId = it.next();
-      try {
-        final Option<ThreadStackTrace[]> dumpOpt = sc.getExecutorThreadDump(execId);
-        if (dumpOpt.isEmpty()) {
-          LOG.warn("No thread dump returned for executor {}", execId);
+    final int numExecs = execIdsSeq.size();
+    LOG.error("Executor thread dump follows ({} executor(s), {}s shared budget)",
+      numExecs, EXECUTOR_DUMP_BUDGET_SECONDS);
+    if (numExecs == 0) {
+      return;
+    }
+
+    // Submit all RPCs in parallel. A dedicated daemon pool is used so that
+    // an in-flight RPC blocked on a stuck executor cannot delay shutdown.
+    final ExecutorService rpcPool = Executors.newFixedThreadPool(
+      Math.min(numExecs, 16),
+      runnable -> {
+        final Thread t = new Thread(runnable);
+        t.setDaemon(true);
+        t.setName("timeout-listener-executor-dump-" + t.hashCode());
+        return t;
+      });
+    try {
+      final Map<String, Future<Option<ThreadStackTrace[]>>> futures = new LinkedHashMap<>();
+      // Iterate the Scala Seq directly via its Iterator to avoid the
+      // scala.collection.JavaConverters deprecation in Scala 2.13.
+      final Iterator<String> it = execIdsSeq.iterator();
+      while (it.hasNext()) {
+        final String execId = it.next();
+        futures.put(execId, rpcPool.submit(() -> sc.getExecutorThreadDump(execId)));
+      }
+
+      final long deadlineNanos = System.nanoTime()
+        + TimeUnit.SECONDS.toNanos(EXECUTOR_DUMP_BUDGET_SECONDS);
+      for (Map.Entry<String, Future<Option<ThreadStackTrace[]>>> e : futures.entrySet()) {
+        final String execId = e.getKey();
+        final long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          LOG.warn("Executor dump budget exhausted before reaching executor {}", execId);
+          e.getValue().cancel(true);
           continue;
         }
-        final ThreadStackTrace[] stacks = dumpOpt.get();
-        LOG.error("Executor {} thread dump ({} threads):", execId, stacks.length);
-        for (ThreadStackTrace stack : stacks) {
-          LOG.warn("Executor {}: {}", execId, stack);
+        try {
+          final Option<ThreadStackTrace[]> dumpOpt =
+            e.getValue().get(remainingNanos, TimeUnit.NANOSECONDS);
+          if (dumpOpt.isEmpty()) {
+            LOG.warn("No thread dump returned for executor {}", execId);
+            continue;
+          }
+          final ThreadStackTrace[] stacks = dumpOpt.get();
+          LOG.error("Executor {} thread dump ({} threads):", execId, stacks.length);
+          for (ThreadStackTrace stack : stacks) {
+            LOG.warn("Executor {}: {}", execId, stack);
+          }
+        } catch (TimeoutException te) {
+          LOG.warn("Timed out fetching thread dump for executor {}", execId);
+          e.getValue().cancel(true);
+        } catch (Throwable t) {
+          LOG.warn("Failed to fetch thread dump for executor " + execId, t);
         }
-      } catch (Throwable t) {
-        LOG.warn("Failed to fetch thread dump for executor " + execId, t);
       }
+    } finally {
+      // shutdownNow interrupts the RPC threads so any still-blocking dumps
+      // are abandoned rather than holding the driver JVM alive.
+      rpcPool.shutdownNow();
     }
   }
 }

--- a/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
+++ b/integration_tests/src/main/java/org/apache/spark/rapids/tests/TimeoutSparkListener.java
@@ -19,15 +19,18 @@ package org.apache.spark.rapids.tests;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.spark.SparkContext;
@@ -161,6 +164,21 @@ public class TimeoutSparkListener extends SparkListener {
   // executors to reply while bounding the worst case.
   private static final long EXECUTOR_DUMP_BUDGET_SECONDS = 30;
 
+  private static final class ExecutorDumpResult {
+    private final String execId;
+    private final Option<ThreadStackTrace[]> dumpOpt;
+    private final Throwable error;
+
+    private ExecutorDumpResult(
+        String execId,
+        Option<ThreadStackTrace[]> dumpOpt,
+        Throwable error) {
+      this.execId = execId;
+      this.dumpOpt = dumpOpt;
+      this.error = error;
+    }
+  }
+
   /**
    * Best-effort dump of every live executor's JVM threads via Spark's
    * built-in {@link SparkContext#getExecutorThreadDump} RPC. A driver-only
@@ -209,42 +227,68 @@ public class TimeoutSparkListener extends SparkListener {
         return t;
       });
     try {
-      final Map<String, Future<Option<ThreadStackTrace[]>>> futures = new LinkedHashMap<>();
+      final CompletionService<ExecutorDumpResult> completionService =
+        new ExecutorCompletionService<>(rpcPool);
+      final List<Future<ExecutorDumpResult>> futures = new ArrayList<>(numExecs);
       // Iterate the Scala Seq directly via its Iterator to avoid the
       // scala.collection.JavaConverters deprecation in Scala 2.13.
       final Iterator<String> it = execIdsSeq.iterator();
       while (it.hasNext()) {
         final String execId = it.next();
-        futures.put(execId, rpcPool.submit(() -> sc.getExecutorThreadDump(execId)));
+        futures.add(completionService.submit(() -> {
+          try {
+            return new ExecutorDumpResult(execId, sc.getExecutorThreadDump(execId), null);
+          } catch (Throwable t) {
+            return new ExecutorDumpResult(execId, null, t);
+          }
+        }));
       }
 
       final long deadlineNanos = System.nanoTime()
         + TimeUnit.SECONDS.toNanos(EXECUTOR_DUMP_BUDGET_SECONDS);
-      for (Map.Entry<String, Future<Option<ThreadStackTrace[]>>> e : futures.entrySet()) {
-        final String execId = e.getKey();
+      int remaining = numExecs;
+      while (remaining > 0) {
         final long remainingNanos = deadlineNanos - System.nanoTime();
         if (remainingNanos <= 0) {
-          LOG.warn("Executor dump budget exhausted before reaching executor {}", execId);
-          e.getValue().cancel(true);
-          continue;
+          LOG.warn("Executor dump budget exhausted before receiving {} executor dump(s)",
+            remaining);
+          break;
         }
         try {
-          final Option<ThreadStackTrace[]> dumpOpt =
-            e.getValue().get(remainingNanos, TimeUnit.NANOSECONDS);
-          if (dumpOpt.isEmpty()) {
-            LOG.warn("No thread dump returned for executor {}", execId);
+          final Future<ExecutorDumpResult> future =
+            completionService.poll(remainingNanos, TimeUnit.NANOSECONDS);
+          if (future == null) {
+            LOG.warn("Timed out fetching thread dumps from {} executor(s)", remaining);
+            break;
+          }
+          remaining--;
+          final ExecutorDumpResult result = future.get();
+          if (result.error != null) {
+            LOG.warn("Failed to fetch thread dump for executor " + result.execId, result.error);
             continue;
           }
-          final ThreadStackTrace[] stacks = dumpOpt.get();
-          LOG.error("Executor {} thread dump ({} threads):", execId, stacks.length);
-          for (ThreadStackTrace stack : stacks) {
-            LOG.warn("Executor {}: {}", execId, stack);
+          if (result.dumpOpt.isEmpty()) {
+            LOG.warn("No thread dump returned for executor {}", result.execId);
+            continue;
           }
-        } catch (TimeoutException te) {
-          LOG.warn("Timed out fetching thread dump for executor {}", execId);
-          e.getValue().cancel(true);
+          final ThreadStackTrace[] stacks = result.dumpOpt.get();
+          LOG.error("Executor {} thread dump ({} threads):", result.execId, stacks.length);
+          for (ThreadStackTrace stack : stacks) {
+            LOG.warn("Executor {}: {}", result.execId, stack);
+          }
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          LOG.warn("Interrupted fetching executor thread dumps", ie);
+          break;
+        } catch (ExecutionException ee) {
+          LOG.warn("Failed to fetch an executor thread dump", ee.getCause());
         } catch (Throwable t) {
-          LOG.warn("Failed to fetch thread dump for executor " + execId, t);
+          LOG.warn("Failed to fetch an executor thread dump", t);
+        }
+      }
+      for (Future<ExecutorDumpResult> future : futures) {
+        if (!future.isDone()) {
+          future.cancel(true);
         }
       }
     } finally {
@@ -254,4 +298,3 @@ public class TimeoutSparkListener extends SparkListener {
     }
   }
 }
-


### PR DESCRIPTION
Fixes #14822.

### Description

When a Spark job hangs and `TimeoutSparkListener` fires with `dump_threads=true`, the previous implementation only dumped the *driver* JVM via `ThreadMXBean.dumpAllThreads`. That dump is rarely sufficient to diagnose a hang because the responsible thread is almost always on an executor, not the driver — in practice the driver shows `main` blocked on `PythonRunner.waitFor` and `Thread-7` on `ThreadUtils.awaitReady` while every other thread is idle, which gives the investigator nothing to act on.

This PR adds a `dumpExecutorThreads()` step that runs right after the existing driver dump. It enumerates live executors via `SparkContext.getExecutorIds()` and pulls each executor's JVM thread dump through `SparkContext.getExecutorThreadDump(executorId)` — the same RPC path the Spark UI and the v1 REST API use. The output goes to the same SLF4J channel as the driver dump, so it lands in whichever log stream is already being captured by CI (e.g. GCP Cloud Logging on Dataproc Serverless). This is important on runtimes where the Spark UI / REST API is not reachable: until now there was no way to obtain executor-side thread stacks at all on Dataproc Serverless without the component gateway.

The new step is **best-effort**: every RPC is wrapped in its own `try`/`catch` and logged individually so a single unreachable executor cannot block the `cancelJob` / `System.exit` path that immediately follows. If the executor list itself cannot be fetched, we log the failure and skip the executor dump rather than throw. There is **no behaviour change** when `dump_threads=false` (the default) — nothing new runs in that case.

No new dependencies: `SparkContext.getExecutorIds` and `getExecutorThreadDump` have been public Spark API since 1.6 / 2.x, and `ThreadStackTrace` is in `spark-core`'s `status.api.v1` package.

This was prompted by the investigation of #14815 (GBK decode hang on Dataproc Serverless under `--test_oom_injection_mode=always`). The hang was unreproducible locally and the only diagnostic surface available was the driver log captured by Cloud Logging, which contained the existing driver-only dump that pointed nowhere useful. Future intermittent / environment-specific CI hangs will hit the same blind spot until executor dumps land alongside the driver dump.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

This is best-effort diagnostic instrumentation invoked only when `TimeoutSparkListener` fires. Exercising it under unit test would require mocking the Spark RPC path, which is more code than the change itself; the value of this PR is realized at the next real CI hang. Smoke tested locally with `mvn compile -Dbuildver=352` on `integration_tests`.

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required