### PR TITLE
Use fused mergeAndSetValidity kernel in hypot

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -515,15 +515,6 @@ object GpuHypot {
     }
   }
 
-  def eitherNull(x: ColumnVector,
-                 y: ColumnVector): ColumnVector = {
-    withResource(x.isNull) { xIsNull =>
-      withResource(y.isNull) { yIsNull =>
-        xIsNull.or(yIsNull)
-      }
-    }
-  }
-
   def computeHypot(x: ColumnVector, y: ColumnVector): ColumnVector = {
     val yOverXSquared = withResource(y.div(x)) { yOverX =>
       yOverX.mul(yOverX)
@@ -590,11 +581,7 @@ case class GpuHypot(left: Expression, right: Expression) extends CudfBinaryMathE
       }
 
       withResource(infOrRest) { _ =>
-        withResource(Scalar.fromNull(x.getType)) { nullS =>
-          withResource(GpuHypot.eitherNull(x, y)) { eitherNull =>
-            eitherNull.ifElse(nullS, infOrRest)
-          }
-        }
+        infOrRest.mergeAndSetValidity(BinaryOp.BITWISE_AND, x, y)
       }
     }
   }


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/14588.

### Description

This is a small change to replace eitherNull with the fused `mergeAndSetValidity` kernel, replacing what is currently 5 kernels and 3 intermediate bool columns. This change is covered by existing tests for GPU Hypot. 

Isolating `computeHypot` in a nanobenchmark, this change can yield 20% speedups.

<details>
<summary>computeHypot nanobenchmark</summary>

```scala
import ai.rapids.cudf.{BinaryOp, ColumnVector, Cuda, Rmm, RmmAllocationMode, Scalar}

object GpuHypotBench {
  val NumRows = 100000
  val Warmup = 5
  val Measured = 20

  def main(args: Array[String]): Unit = {
    Rmm.initialize(RmmAllocationMode.POOL, null, Cuda.memGetInfo().free / 2 & ~255L)

    withResource(broadcastDouble(3.0)) { lhs =>
      withResource(broadcastDouble(4.0)) { rhs =>
        for (_ <- 0 until Warmup) {
          hypotBase(lhs, rhs).close()
          hypotMerge(lhs, rhs).close()
        }
        val timesBase = (0 until Measured).map { _ =>
          val t = System.nanoTime()
          hypotBase(lhs, rhs).close()
          System.nanoTime() - t
        }
        val timesMerge = (0 until Measured).map { _ =>
          val t = System.nanoTime()
          hypotMerge(lhs, rhs).close()
          System.nanoTime() - t
        }
        println(f"BASE  median: ${timesBase.sorted.apply(Measured / 2) / 1e6}%.3f ms")
        println(f"MERGE median: ${timesMerge.sorted.apply(Measured / 2) / 1e6}%.3f ms")
      }
    }
  }

  // Pre-change pipeline: trailing null propagation via eitherNull + ifElse.
  def hypotBase(lhs: ColumnVector, rhs: ColumnVector): ColumnVector =
    withChooseXandY(lhs, rhs) { (x, y) =>
      val zeroOrBase = withResource(Scalar.fromDouble(0)) { zero =>
        withResource(both(zero, x, y)) { bothZero =>
          withResource(computeHypot(x, y)) { hyp => bothZero.ifElse(zero, hyp) }
        }
      }
      val nanOrRest = withResource(zeroOrBase) { _ =>
        withResource(Scalar.fromDouble(Double.NaN)) { nan =>
          withResource(eitherNan(x, y)) { en => en.ifElse(nan, zeroOrBase) }
        }
      }
      val infOrRest = withResource(nanOrRest) { _ =>
        withResource(Scalar.fromDouble(Double.PositiveInfinity)) { inf =>
          withResource(either(inf, x, y)) { ei => ei.ifElse(inf, nanOrRest) }
        }
      }
      withResource(infOrRest) { _ =>
        withResource(Scalar.fromNull(x.getType)) { nullS =>
          withResource(eitherNull(x, y)) { en => en.ifElse(nullS, infOrRest) }
        }
      }
    }

  // mergeAndSetValidity replaces the trailing eitherNull + ifElse + null-scalar pipeline.
  def hypotMerge(lhs: ColumnVector, rhs: ColumnVector): ColumnVector =
    withChooseXandY(lhs, rhs) { (x, y) =>
      val zeroOrBase = withResource(Scalar.fromDouble(0)) { zero =>
        withResource(both(zero, x, y)) { bothZero =>
          withResource(computeHypot(x, y)) { hyp => bothZero.ifElse(zero, hyp) }
        }
      }
      val nanOrRest = withResource(zeroOrBase) { _ =>
        withResource(Scalar.fromDouble(Double.NaN)) { nan =>
          withResource(eitherNan(x, y)) { en => en.ifElse(nan, zeroOrBase) }
        }
      }
      val infOrRest = withResource(nanOrRest) { _ =>
        withResource(Scalar.fromDouble(Double.PositiveInfinity)) { inf =>
          withResource(either(inf, x, y)) { ei => ei.ifElse(inf, nanOrRest) }
        }
      }
      withResource(infOrRest) { _ =>
        infOrRest.mergeAndSetValidity(BinaryOp.BITWISE_AND, lhs, rhs)
      }
    }

  // ===== Shared helpers =====

  def withChooseXandY[R](lhs: ColumnVector, rhs: ColumnVector)
      (f: (ColumnVector, ColumnVector) => R): R =
    withResource(lhs.abs) { lhsAbs =>
      withResource(rhs.abs) { rhsAbs =>
        withResource(lhsAbs.greaterThan(rhsAbs)) { lhsGreater =>
          withResource(lhsGreater.ifElse(lhsAbs, rhsAbs)) { x =>
            withResource(lhsGreater.ifElse(rhsAbs, lhsAbs)) { y => f(x, y) }
          }
        }
      }
    }

  def either(v: Scalar, x: ColumnVector, y: ColumnVector): ColumnVector =
    withResource(x.equalTo(v)) { xv => withResource(y.equalTo(v)) { yv => xv.or(yv) } }

  def both(v: Scalar, x: ColumnVector, y: ColumnVector): ColumnVector =
    withResource(x.equalTo(v)) { xv => withResource(y.equalTo(v)) { yv => xv.and(yv) } }

  def eitherNan(x: ColumnVector, y: ColumnVector): ColumnVector =
    withResource(x.isNan) { xIsNan =>
      withResource(y.isNan) { yIsNan => xIsNan.or(yIsNan) }
    }

  def eitherNull(x: ColumnVector, y: ColumnVector): ColumnVector =
    withResource(x.isNull) { xIsNull =>
      withResource(y.isNull) { yIsNull => xIsNull.or(yIsNull) }
    }

  def computeHypot(x: ColumnVector, y: ColumnVector): ColumnVector = {
    val yOverXSquared = withResource(y.div(x)) { yOverX => yOverX.mul(yOverX) }
    val onePlusTerm = withResource(yOverXSquared) { _ =>
      withResource(Scalar.fromDouble(1)) { one => one.add(yOverXSquared) }
    }
    val onePlusTermSqrt = withResource(onePlusTerm) { _ => onePlusTerm.sqrt }
    withResource(onePlusTermSqrt) { _ => x.mul(onePlusTermSqrt) }
  }

  def broadcastDouble(v: Double): ColumnVector =
    withResource(Scalar.fromDouble(v)) { s => ColumnVector.fromScalar(s, NumRows) }
}
```

</details

```
BASE  median: 0.325 ms
MERGE median: 0.270 ms
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
