### PR TITLE
[AutoSparkUT] Fix invalid numSplits 0 in single-column explode (#11653)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -403,7 +403,13 @@ abstract class GpuExplodeBase extends GpuUnevaluableUnaryExpression with GpuGene
       val numSplitsForTargetSize =
         math.min(inputRows,
           math.ceil(estimatedOutputSizeBytes / targetSizeBytes).toInt)
-      GpuBatchUtils.generateSplitIndices(inputRows, numSplitsForTargetSize).distinct
+      if (numSplitsForTargetSize == 0) {
+        // estimatedOutputSizeBytes is 0 when every exploding row is empty/null,
+        // so no further splitting is needed. Matches the else-branch guard below.
+        Array.empty[Int]
+      } else {
+        GpuBatchUtils.generateSplitIndices(inputRows, numSplitsForTargetSize).distinct
+      }
     } else {
       NvtxRegistry.GENERATE_ESTIMATE_REPETITION {
         // get the # of repetitions per row of the input for this explode

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuGenerateSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuGenerateSuite.scala
@@ -238,6 +238,20 @@ class GpuGenerateSuite
     }
   }
 
+  test("all null inputs with single exploding column (generatorOffset == 0)") {
+    // Regression for #11653: when the batch contains only the exploding column
+    // and every row is null, estimatedOutputSizeBytes == 0 so
+    // numSplitsForTargetSize == 0. Before the fix this passed 0 to
+    // GpuBatchUtils.generateSplitIndices, which fails `require(numSplits > 0)`.
+    val (batch, _) = makeBatch(numRows = 100, includeRepeatColumn = false,
+      allNulls = true)
+    withResource(batch) { _ =>
+      val e = GpuExplode(null)
+      val splits = e.inputSplitIndices(batch, generatorOffset = 0, false, 4)
+      assertResult(0)(splits.length)
+    }
+  }
+
   test("0-row batches short-circuits to no splits") {
     val (batch, _) = makeBatch(numRows = 0)
     withResource(batch) { _ =>

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -173,7 +173,6 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-31159: rebasing dates in write", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11480"))
     .exclude("SPARK-35427: datetime rebasing in the EXCEPTION mode", ADJUST_UT("original test case inherited from Spark cannot find the needed local resources"))
   enableSuite[RapidsParquetSchemaPruningSuite]
-    .excludeBySuffix("select explode of nested field of array of struct", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/11653"))
   enableSuite[RapidsParquetSchemaSuite]
     .exclude("schema mismatch failure error message for parquet reader", WONT_FIX_ISSUE("GPU uses a unified parquet reader path; the non-vectorized CPU error variant rooted in ParquetDecodingException is not reachable by design. See https://github.com/NVIDIA/spark-rapids/issues/11434"))
   enableSuite[RapidsParquetThriftCompatibilitySuite]


### PR DESCRIPTION
Fixes #11653.

### Description

#### Problem

`RapidsParquetSchemaPruningSuite` has had four `select explode of nested field of array of struct` variants excluded since 2024 under #11653. The originally reported symptom (`IllegalArgumentException: Part of the plan is not columnar class CollectLimitExec`) no longer reproduces. Removing the `.excludeBySuffix` line now surfaces a different failure on the same code path:

```
java.lang.IllegalArgumentException: requirement failed: invalid numSplits 0
  at scala.Predef$.require(Predef.scala:281)
  at com.nvidia.spark.rapids.GpuBatchUtils$.generateSplitIndices(GpuBatchUtils.scala:148)
  at com.nvidia.spark.rapids.GpuExplodeBase.inputSplitIndices(GpuGenerateExec.scala:406)
```

#### Root cause

`GpuExplodeBase.inputSplitIndices` splits the input batch differently depending on whether other columns flow alongside the exploding column. The multi-column branch (`generatorOffset \!= 0`, line 445) already returns `Array.empty[Long]` when `numSplitsForTargetSize == 0`. The single-column branch (`generatorOffset == 0`, line 406) did not — it passed `0` straight into `GpuBatchUtils.generateSplitIndices`, which requires `numSplits > 0`. When every exploding row in a batch is empty/null, `estimatedOutputSizeBytes == 0`, so `numSplitsForTargetSize == 0` and the single-column branch crashes. The `contacts` test data triggers this because `friends` is empty or null for 3 of 4 rows.

This is a latent bug from the original 2022 commit (`b9c771f12`) that only the multi-column branch was patched for.

#### Fix

Mirror the existing else-branch guard: in the `generatorOffset == 0` branch, return `Array.empty[Int]` when `numSplitsForTargetSize == 0`. Downstream `makeSplits` (`GpuGenerateExec.scala:950`) already treats an empty split-indices array as "process the whole batch without splitting", which is the correct behavior for an empty/all-null exploding batch.

Drop the `.excludeBySuffix` line so the four previously-excluded variants in `RapidsParquetSchemaPruningSuite` are picked up by the inherited Spark `testSchemaPruning` macro. Add a `GpuGenerateSuite` regression test that exercises the exact `generatorOffset == 0` + `allNulls = true` path which previously crashed.

#### Performance impact

Cold-path-only change. The new branch only fires when `estimatedOutputSizeBytes == 0` (every exploding row in the batch is empty/null) — previously this path threw an exception, so any code reaching it was already broken. Hot path: one extra integer compare. Negligible.

#### Testing

```
mvn package -pl tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsParquetSchemaPruningSuite \
  -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0
```

Before the fix (exclusion removed):
```
Tests: succeeded 170, failed 4, canceled 0, ignored 0, pending 0
*** 4 TESTS FAILED ***
```

After the fix:
```
Tests: succeeded 174, failed 0, canceled 0, ignored 0, pending 0
```

GpuGenerateSuite regression (`-DwildcardSuites=com.nvidia.spark.rapids.GpuGenerateSuite`): `Tests: succeeded 25, failed 0` (was 24; +1 new "all null inputs with single exploding column (generatorOffset == 0)" test that fails pre-fix and passes post-fix).

#### Tests re-enabled

| RAPIDS test name | Spark macro | Spark source |
|---|---|---|
| Spark vectorized reader - without partition data column - select explode of nested field of array of struct | `testSchemaPruning("select explode of nested field of array of struct")` | `spark/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala:328-363` |
| Spark vectorized reader - with partition data column - select explode of nested field of array of struct | same | same |
| Non-vectorized reader - without partition data column - select explode of nested field of array of struct | same | same |
| Non-vectorized reader - with partition data column - select explode of nested field of array of struct | same | same |

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required