### PR TITLE
[AutoSparkUT] CSV: support decimal grouping separator parsing (Locale.US)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -18,12 +18,14 @@ package com.nvidia.spark.rapids
 
 import java.io.IOException
 import java.nio.charset.{Charset, StandardCharsets}
+import java.util.Locale
 
 import scala.collection.JavaConverters._
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{ColumnVector, DType, Scalar, Schema, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, ShimFilePartitionReaderFactory}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -263,6 +265,10 @@ object GpuCSVScan extends Logging {
         s"To enable it please set ${RapidsConf.ENABLE_READ_CSV_DECIMALS} to true.")
     }
 
+    if (parsedOptions.locale != Locale.US && types.exists(_.isInstanceOf[DecimalType])) {
+      meta.willNotWorkOnGpu("GpuCSVScan only supports Locale.US decimal parsing")
+    }
+
     if (ColumnDefaultValuesShims.hasExistenceDefaultValues(readSchema)) {
       meta.willNotWorkOnGpu("GpuCSVScan does not support default values in schema")
     }
@@ -407,6 +413,20 @@ abstract class CSVPartitionReaderBase[BUFF <: LineBufferer, FACT <: LineBufferer
       withResource(Scalar.fromNull(DType.BOOL8)) {
         isValidBool.ifElse(isTrue, _)
       }
+    }
+  }
+
+  override def castStringToDecimal(input: ColumnVector, dt: DecimalType): ColumnVector = {
+    if (parsedOptions.locale == Locale.US) {
+      withResource(Scalar.fromString(",")) { groupingSeparator =>
+        withResource(Scalar.fromString("")) { emptyString =>
+          withResource(input.stringReplace(groupingSeparator, emptyString)) { withoutGrouping =>
+            CastStrings.toDecimal(withoutGrouping, false, dt.precision, -dt.scale)
+          }
+        }
+      }
+    } else {
+      super.castStringToDecimal(input, dt)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -104,6 +104,9 @@ object GpuCSVScan extends Logging {
 
   def isUTF8Charset(charset: Charset): Boolean = utf8Charsets.contains(charset)
 
+  def unsupportedLocaleForDecimalMessage(locale: Locale): String =
+    s"GpuCSVScan only supports Locale.US decimal parsing, got $locale"
+
   def tagSupport(scanMeta: ScanMeta[CSVScan]) : Unit = {
     val scan = scanMeta.wrapped
     tagSupport(
@@ -266,8 +269,7 @@ object GpuCSVScan extends Logging {
     }
 
     if (parsedOptions.locale != Locale.US && types.exists(_.isInstanceOf[DecimalType])) {
-      meta.willNotWorkOnGpu(
-        s"GpuCSVScan only supports Locale.US decimal parsing, got ${parsedOptions.locale}")
+      meta.willNotWorkOnGpu(GpuCSVScan.unsupportedLocaleForDecimalMessage(parsedOptions.locale))
     }
 
     if (ColumnDefaultValuesShims.hasExistenceDefaultValues(readSchema)) {
@@ -427,7 +429,8 @@ abstract class CSVPartitionReaderBase[BUFF <: LineBufferer, FACT <: LineBufferer
         }
       }
     } else {
-      super.castStringToDecimal(input, dt)
+      throw new IllegalStateException(
+        GpuCSVScan.unsupportedLocaleForDecimalMessage(parsedOptions.locale))
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -266,7 +266,8 @@ object GpuCSVScan extends Logging {
     }
 
     if (parsedOptions.locale != Locale.US && types.exists(_.isInstanceOf[DecimalType])) {
-      meta.willNotWorkOnGpu("GpuCSVScan only supports Locale.US decimal parsing")
+      meta.willNotWorkOnGpu(
+        s"GpuCSVScan only supports Locale.US decimal parsing, got ${parsedOptions.locale}")
     }
 
     if (ColumnDefaultValuesShims.hasExistenceDefaultValues(readSchema)) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@
 
 package com.nvidia.spark.rapids
 
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.functions.{col, date_add, lit}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.{DecimalType, StructField, StructType, TimestampType}
 
 class CsvScanSuite extends SparkQueryCompareTestSuite {
   testSparkResultsAreEqual("Test CSV projection with whitespace delimiter between date and time",
@@ -73,6 +77,26 @@ class CsvScanSuite extends SparkQueryCompareTestSuite {
     timestampsAsDatesCsvDf,
     conf=new SparkConf()) {
     df => df.withColumn("next_day", date_add(col("dates"), lit(1)))
+  }
+
+  testGpuReadFallback(
+    "Test CSV decimal parse with non-US locale falls back",
+    "FileSourceScanExec",
+    (file: File) => spark => {
+      spark.read
+        .format("csv")
+        .option("delimiter", ";")
+        .option("locale", "de-DE")
+        .schema(StructType(Array(StructField("amount", DecimalType(10, 2)))))
+        .load(file.getCanonicalPath)
+    },
+    (_, file) => {
+      Files.createDirectories(file.toPath)
+      Files.write(file.toPath.resolve("part-00000.csv"),
+        "1.234,56\n".getBytes(StandardCharsets.UTF_8))
+    },
+    execsAllowedNonGpu = Seq("FileSourceScanExec", "ShuffleExchangeExec")) {
+    df => df.select(col("amount"))
   }
 
   // Fails with Spark 3.2.0 and later - see https://github.com/NVIDIA/spark-rapids/issues/4940

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -191,7 +191,6 @@ class RapidsTestSettings extends BackendTestSettings {
   enableSuite[RapidsProductAggSuite]
   enableSuite[RapidsComplexTypesSuite]
   enableSuite[RapidsCSVSuite]
-    .exclude("DDL test parsing decimal type", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13890"))
     .exclude("nullable fields with user defined null value of \"null\"", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13893"))
     .exclude("empty fields with user defined empty values", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13894"))
     .exclude("save csv with empty fields with user defined empty values", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/13895"))


### PR DESCRIPTION
Fixes #13890.

### Description

The GPU CSV reader produced `null` for decimal columns whose string values contain the comma thousands separator (e.g. `"80,000.65"`), while Spark CPU parses them to the correct decimal value (`80000.65`). This caused the upstream Spark test `DDL test parsing decimal type` to fail on GPU.

**Root cause.** Spark CPU's `ExprUtils.getDecimalParser` has a special path for `Locale.US` that strips all commas before `BigDecimal` parsing: `(s: String) => new java.math.BigDecimal(s.replaceAll(",", ""))`. The GPU path in `GpuTextBasedPartitionReader.castStringToDecimal` calls `CastStrings.toDecimal` directly with no preprocessing, so values like `"80,000.65"` fail to parse and become `null`.

**Fix.** In `CSVPartitionReaderBase.castStringToDecimal`, when the parser locale is `Locale.US`, strip all commas via cudf `stringReplace` before casting to decimal. This matches Spark CPU's `Locale.US` branch byte-for-byte. For non-US locales (which use locale-aware `DecimalFormat`), tag the read as not-work-on-GPU so the query falls back to CPU rather than silently producing nulls.

**Scope**
- File changed: `sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala` (+20 lines)
- Exclusion removed: `RapidsTestSettings.scala` line for `DDL test parsing decimal type`
- No new public API, no config changes
- Non-US locale behavior changes from "silent null" to "CPU fallback" (closer to correctness)

**Tests recovered**

| Suite | Test | Spark source |
|---|---|---|
| `RapidsCSVSuite` | `DDL test parsing decimal type` | `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala:336-350` |

**Local validation**

```
mvn package -pl tests -am -Dbuildver=330 \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsCSVSuite \
  -Drapids.test.gpu.allocFraction=0.3 ...
```
Result: `Tests: succeeded 129, failed 0, canceled 0, ignored 7, pending 0`
Surefire (`RapidsCSVSuite`): `tests=136, failures=0, errors=0`; `DDL test parsing decimal type` PASSED.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required