### PR TITLE
Fix parquet coalescing reader file grouping alignment [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
@@ -1014,7 +1014,7 @@ class GpuDeltaParquetFileFormatBase2(
   // │ BATCH ASSEMBLY PHASE  (serial)                                                    │
   // │                                                                                   │
   // │  augmentChunkMeta()                                                               │
-  // │    groups consecutive same-file blocks into Seq[PerFileDVEntry]                   │
+  // │    builds Seq[PerFileDVEntry] from file-major block groups                        │
   // │    returns meta.copy(extraInfo = DeltaBatchExtraInfo(perFileEntries))              │
   // └──────────────────────────────────┬────────────────────────────────────────────────┘
   //                                    │ CurrentChunkMeta with DeltaBatchExtraInfo
@@ -1088,46 +1088,37 @@ class GpuDeltaParquetFileFormatBase2(
       ignoreMissingFiles, ignoreCorruptFiles) {
 
     /**
-     * Groups consecutive same-file blocks from the assembled chunk into per-file DV entries,
-     * preserving file order (which matches the combined buffer layout). Also records which
-     * partition index each file belongs to for use in [[getRowsPerPartition]].
+     * Builds per-file DV entries from the assembled file-major chunk, preserving the same file
+     * order used by the combined buffer layout. Also records which partition index each file
+     * belongs to for use in [[getRowsPerPartition]].
      */
     override protected def augmentChunkMeta(meta: CurrentChunkMeta): CurrentChunkMeta = {
       if (meta.currentChunk.isEmpty) return meta
 
-      val fileEntries = ArrayBuffer[PerFileDVEntry]()
-      var fileOffsets = ArrayBuffer[Long]()
-      var fileNumRows = ArrayBuffer[Int]()
-      var fileDesc: Option[String] = None
-      var prevPath: org.apache.hadoop.fs.Path = null
-      var prevPartValues: org.apache.spark.sql.catalyst.InternalRow = null
-      var partIdx = 0
+      val fileEntries = meta.currentChunk.groupsByFile.values.zipWithIndex.map {
+        case (groupWithPartition, partitionIndex) =>
+          val group = groupWithPartition.fileBlockGroup
+          require(group.blocks.nonEmpty, s"File group must contain blocks: ${group.filePath}")
+          val firstExtra = group.blocks.head.extraInfo.asInstanceOf[DeltaParquetExtraInfo]
+          val fileDesc = firstExtra.dvDescriptor
+          val fileOffsets = ArrayBuffer[Long]()
+          val fileNumRows = ArrayBuffer[Int]()
 
-      meta.currentChunk.foreach { block =>
-        val extra = block.extraInfo.asInstanceOf[DeltaParquetExtraInfo]
-        if (prevPath != null && block.filePath != prevPath) {
-          fileEntries += PerFileDVEntry(fileDesc, fileOffsets.toArray, fileNumRows.toArray, partIdx)
-          fileOffsets = ArrayBuffer[Long]()
-          fileNumRows = ArrayBuffer[Int]()
-          if (block.partitionValues != prevPartValues) partIdx += 1
-        }
-        if (prevPath == block.filePath) {
-          require(fileDesc == extra.dvDescriptor,
-            s"Row groups within the same file must share the same DV descriptor: $prevPath")
-        }
-        prevPath = block.filePath
-        prevPartValues = block.partitionValues
-        fileDesc = extra.dvDescriptor
-        fileOffsets += extra.rowGroupOffset
-        fileNumRows += extra.rowGroupNumRows
-      }
-      if (prevPath != null) {
-        fileEntries += PerFileDVEntry(fileDesc, fileOffsets.toArray, fileNumRows.toArray, partIdx)
-      }
+          group.blocks.foreach { block =>
+            val extra = block.extraInfo.asInstanceOf[DeltaParquetExtraInfo]
+            require(fileDesc == extra.dvDescriptor,
+              s"Row groups within the same file must share the same DV descriptor: " +
+                s"${group.filePath}")
+            fileOffsets += extra.rowGroupOffset
+            fileNumRows += extra.rowGroupNumRows
+          }
+
+          PerFileDVEntry(fileDesc, fileOffsets.toArray, fileNumRows.toArray, partitionIndex)
+      }.toSeq
 
       val batchExtra = new DeltaBatchExtraInfo(
         meta.extraInfo.dateRebaseMode, meta.extraInfo.timestampRebaseMode,
-        meta.extraInfo.hasInt96Timestamps, fileEntries.toSeq)
+        meta.extraInfo.hasInt96Timestamps, fileEntries)
       meta.copy(extraInfo = batchExtra)
     }
 

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
@@ -1128,7 +1128,7 @@ case class GpuDeltaParquetFileFormatNativeDV(
   // │ BATCH ASSEMBLY PHASE  (serial)                                                    │
   // │                                                                                   │
   // │  augmentChunkMeta()                                                               │
-  // │    groups consecutive same-file blocks into Seq[PerFileDVEntry]                   │
+  // │    builds Seq[PerFileDVEntry] from file-major block groups                        │
   // │    returns meta.copy(extraInfo = DeltaBatchExtraInfo(perFileEntries))              │
   // └──────────────────────────────────┬────────────────────────────────────────────────┘
   //                                    │ CurrentChunkMeta with DeltaBatchExtraInfo

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
@@ -1201,53 +1201,38 @@ case class GpuDeltaParquetFileFormatNativeDV(
       maxGpuColumnSizeBytes, compressCfg, execMetrics, partitionSchema, poolConf,
       ignoreMissingFiles, ignoreCorruptFiles) {
 
-    /**
-     * Groups consecutive same-file blocks from the assembled chunk into per-file DV entries,
-     * preserving file order (which matches the combined buffer layout). Also records which
-     * partition index each file belongs to for use in [[getRowsPerPartition]].
-     */
     override protected def augmentChunkMeta(meta: CurrentChunkMeta): CurrentChunkMeta = {
       if (meta.currentChunk.isEmpty) return meta
 
-      val fileEntries = ArrayBuffer[PerFileDVEntry]()
-      var fileOffsets = ArrayBuffer[Long]()
-      var fileNumRows = ArrayBuffer[Int]()
-      var fileDesc: Option[String] = None
-      var fileProvider: Option[RowIndexFilterProvider] = None
-      var prevPath: org.apache.hadoop.fs.Path = null
-      var prevPartValues: org.apache.spark.sql.catalyst.InternalRow = null
-      var partIdx = 0
+      val fileEntries = meta.currentChunk.groupsByFile.values.zipWithIndex.map {
+        case (groupWithPartition, partitionIndex) =>
+          val group = groupWithPartition.fileBlockGroup
+          require(group.blocks.nonEmpty, s"File group must contain blocks: ${group.filePath}")
+          val firstExtra = group.blocks.head.extraInfo.asInstanceOf[DeltaParquetExtraInfo]
+          val fileDesc = firstExtra.dvDescriptor
+          val fileProvider = firstExtra.rowIndexFilterProvider
+          val fileOffsets = ArrayBuffer[Long]()
+          val fileNumRows = ArrayBuffer[Int]()
 
-      meta.currentChunk.foreach { block =>
-        val extra = block.extraInfo.asInstanceOf[DeltaParquetExtraInfo]
-        if (prevPath != null && block.filePath != prevPath) {
-          fileEntries += PerFileDVEntry(
-            fileDesc, fileProvider, fileOffsets.toArray, fileNumRows.toArray, partIdx)
-          fileOffsets = ArrayBuffer[Long]()
-          fileNumRows = ArrayBuffer[Int]()
-          if (block.partitionValues != prevPartValues) partIdx += 1
-        }
-        if (prevPath == block.filePath) {
-          require(fileDesc == extra.dvDescriptor,
-            s"Row groups within the same file must share the same DV descriptor: $prevPath")
-          require(fileProvider == extra.rowIndexFilterProvider,
-            s"Row groups within the same file must share the same DV filter provider: $prevPath")
-        }
-        prevPath = block.filePath
-        prevPartValues = block.partitionValues
-        fileDesc = extra.dvDescriptor
-        fileProvider = extra.rowIndexFilterProvider
-        fileOffsets += extra.rowGroupOffset
-        fileNumRows += extra.rowGroupNumRows
-      }
-      if (prevPath != null) {
-        fileEntries += PerFileDVEntry(
-          fileDesc, fileProvider, fileOffsets.toArray, fileNumRows.toArray, partIdx)
-      }
+          group.blocks.foreach { block =>
+            val extra = block.extraInfo.asInstanceOf[DeltaParquetExtraInfo]
+            require(fileDesc == extra.dvDescriptor,
+              s"Row groups within the same file must share the same DV descriptor: " +
+                s"${group.filePath}")
+            require(fileProvider == extra.rowIndexFilterProvider,
+              s"Row groups within the same file must share the same DV filter provider: " +
+                s"${group.filePath}")
+            fileOffsets += extra.rowGroupOffset
+            fileNumRows += extra.rowGroupNumRows
+          }
+
+          PerFileDVEntry(
+            fileDesc, fileProvider, fileOffsets.toArray, fileNumRows.toArray, partitionIndex)
+      }.toSeq
 
       val batchExtra = new DeltaBatchExtraInfo(
         meta.extraInfo.dateRebaseMode, meta.extraInfo.timestampRebaseMode,
-        meta.extraInfo.hasInt96Timestamps, fileEntries.toSeq)
+        meta.extraInfo.hasInt96Timestamps, fileEntries)
       meta.copy(extraInfo = batchExtra)
     }
 

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -593,7 +593,7 @@ def test_delta_deletion_vector_coalescing_partitioned_table(
                     reason="Delta Lake deletion vector support requires Spark 3.5.3+")
 @pytest.mark.skipif(is_databricks_runtime(),
                     reason="Databricks plan not GPU-convertible for this query")
-def test_delta_deletion_vector_coalescing_interleaved_file_splits(
+def test_delta_deletion_vector_interleaved_file_splits(
         spark_tmp_path, parquet_reader_type):
     """
     Tests deletion vector handling when files are interleaved in a way that causes their

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -589,10 +589,8 @@ def test_delta_deletion_vector_coalescing_partitioned_table(
 @ignore_order(local=True)
 @pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "MULTITHREADED", "COALESCING"],
                          ids=idfn)
-@pytest.mark.skipif(not supports_delta_lake_deletion_vectors() or is_before_spark_353(),
+@pytest.mark.skipif(is_before_spark_353(),
                     reason="Delta Lake deletion vector support requires Spark 3.5.3+")
-@pytest.mark.skipif(is_databricks_runtime(),
-                    reason="Databricks plan not GPU-convertible for this query")
 def test_delta_deletion_vector_interleaved_file_splits(
         spark_tmp_path, parquet_reader_type):
     """

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -587,14 +587,17 @@ def test_delta_deletion_vector_coalescing_partitioned_table(
 @allow_non_gpu("FileSourceScanExec", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
+@pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "MULTITHREADED", "COALESCING"],
+                         ids=idfn)
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors() or is_before_spark_353(),
                     reason="Delta Lake deletion vector support requires Spark 3.5.3+")
 @pytest.mark.skipif(is_databricks_runtime(),
                     reason="Databricks plan not GPU-convertible for this query")
-def test_delta_deletion_vector_coalescing_interleaved_file_splits(spark_tmp_path):
+def test_delta_deletion_vector_coalescing_interleaved_file_splits(
+        spark_tmp_path, parquet_reader_type):
     """
-    Tests the coalescing reader's handling of deletion vectors when files are interleaved
-    in a way that causes their blocks to be split non-consecutively.
+    Tests deletion vector handling when files are interleaved in a way that causes their
+    blocks to be split non-consecutively.
     
     For this test, we set up two files A (large) and B (small) such that:
       - A is split into N PartitionedFiles: [max, ..., max, tail].
@@ -624,7 +627,7 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(spark_tmp_path
     read_conf = {
         "spark.databricks.delta.delete.deletionVectors.persistent": "true",
         "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
-        "spark.rapids.sql.format.parquet.reader.type": "COALESCING",
+        "spark.rapids.sql.format.parquet.reader.type": parquet_reader_type,
         "spark.sql.files.maxPartitionBytes": str(max_split),
         "spark.sql.files.openCostInBytes": "1",
         # Pin actual maxSplitBytes == maxPartitionBytes. Without this,

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -587,24 +587,21 @@ def test_delta_deletion_vector_coalescing_partitioned_table(
 @allow_non_gpu("FileSourceScanExec", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.parametrize("use_metadata_row_index", [True, False], ids=idfn)
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors() or is_before_spark_353(),
                     reason="Delta Lake deletion vector support requires Spark 3.5.3+")
 @pytest.mark.skipif(is_databricks_runtime(),
                     reason="Databricks plan not GPU-convertible for this query")
-def test_delta_deletion_vector_coalescing_interleaved_file_splits(
-        spark_tmp_path, use_metadata_row_index):
+def test_delta_deletion_vector_coalescing_interleaved_file_splits(spark_tmp_path):
     """
-    Reproduces row-count mismatch in the coalescing reader's DV pipeline.
-
-    Setup engineers two files A (large) and B (small) such that:
+    Tests the coalescing reader's handling of deletion vectors when files are interleaved
+    in a way that causes their blocks to be split non-consecutively.
+    
+    For this test, we set up two files A (large) and B (small) such that:
       - A is split into N PartitionedFiles: [max, ..., max, tail].
       - tail(A) < len(B) < max_split.
       - maxPartitionNum=1 forces all splits + B into ONE FilePartition,
         preserving the length-desc stable sort so A's blocks are split
         non-consecutively around B's.
-    Deletes target the global min(a) (in A) and max(a) (in B) so the
-    aggregate result is directly load-bearing on per-file DV application.
     """
     import os
     import pyarrow.parquet as pq
@@ -614,7 +611,7 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(
     # Row counts tuned for ~148 B/row uncompressed (two SHA-256 hex strings +
     # two ints). File A = 3000 rows -> 4 splits ~[131K, 131K, 131K, 50K];
     # File B = 800 rows -> 1 split ~118K. Gives tail(A) ~50K < B ~118K < 131K.
-    a_lo, a_hi = 0, 3799  # global min/max of column `a`
+    col_a_lo, col_a_hi = 0, 3799  # global min/max of column `a`
     a_rows = 3000
     b_split = a_rows  # boundary between A's range and B's range
 
@@ -628,8 +625,6 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(
         "spark.databricks.delta.delete.deletionVectors.persistent": "true",
         "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
         "spark.rapids.sql.format.parquet.reader.type": "COALESCING",
-        "spark.databricks.delta.deletionVectors.useMetadataRowIndex":
-            f"{use_metadata_row_index}",
         "spark.sql.files.maxPartitionBytes": str(max_split),
         "spark.sql.files.openCostInBytes": "1",
         # Pin actual maxSplitBytes == maxPartitionBytes. Without this,
@@ -639,7 +634,7 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(
         # value and breaks the size-engineering below.
         "spark.sql.files.minPartitionNum": "1",
         # Repack initial split-per-partition layout into ONE FilePartition.
-        "spark.sql.files.maxPartitionNum": "1",
+        "spark.sql.files.maxPartitionNum": "1"
     }
 
     def setup_table(spark):
@@ -652,7 +647,7 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(
             "sha2(CAST(id + 17 AS STRING), 256)) AS payload")
         # File A: large enough to split into multiple PartitionedFiles with a
         # tail < max_split, and tuned so tail(A) < len(B) (asserted below).
-        spark.range(a_lo, b_split) \
+        spark.range(col_a_lo, b_split) \
              .selectExpr("CAST(id AS INT) AS a",
                          "CAST(id % 100 AS INT) AS b",
                          payload_expr) \
@@ -660,7 +655,7 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(
              .option("parquet.enable.dictionary", "false") \
              .format("delta").mode("append").save(data_path)
         # File B: single split. Tuned so tail(A) < len(B) < max_split.
-        spark.range(b_split, a_hi + 1) \
+        spark.range(b_split, col_a_hi + 1) \
              .selectExpr("CAST(id AS INT) AS a",
                          "CAST(id % 100 AS INT) AS b",
                          payload_expr) \
@@ -669,7 +664,7 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(
              .format("delta").mode("append").save(data_path)
         # Pin global min(a) in File A and max(a) in File B so mispaired
         # bitmaps directly perturb min(a)/max(a) on the alive set.
-        spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a IN ({a_lo}, {a_hi})")
+        spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a IN ({col_a_lo}, {col_a_hi})")
         # Noise: make per-file bitmaps dense so mispairing has many positions
         # to corrupt.
         spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a % 17 = 0")
@@ -697,9 +692,7 @@ def test_delta_deletion_vector_coalescing_interleaved_file_splits(
         n_rg = pq.read_metadata(p).num_row_groups
         assert n_rg > 1, f"{p} has {n_rg} row group(s); need > 1"
 
-    # GPU-side check: maxPartitionNum=1 actually took effect for the GPU
-    # Delta format. The CPU planner uses a different FileFormat with its own
-    # isSplitable behavior, so a CPU partition count would not prove this.
+    # GPU-side check: make sure Spark creates one partition on GPU as expected.
     num_partitions = with_gpu_session(
         lambda spark: spark.read.format("delta").load(data_path)
                            .select("a").rdd.getNumPartitions(),

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -591,6 +591,8 @@ def test_delta_deletion_vector_coalescing_partitioned_table(
                          ids=idfn)
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Delta Lake deletion vector support requires Spark 3.5.3+")
+@pytest.mark.skipif(is_databricks_runtime() and not is_databricks173_or_later(),
+                    reason="Deletion vector scan is not supported on Databricks before 17.3")
 def test_delta_deletion_vector_interleaved_file_splits(
         spark_tmp_path, parquet_reader_type):
     """

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -587,6 +587,139 @@ def test_delta_deletion_vector_coalescing_partitioned_table(
 @allow_non_gpu("FileSourceScanExec", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
+@pytest.mark.parametrize("use_metadata_row_index", [True, False], ids=idfn)
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors() or is_before_spark_353(),
+                    reason="Delta Lake deletion vector support requires Spark 3.5.3+")
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="Databricks plan not GPU-convertible for this query")
+def test_delta_deletion_vector_coalescing_interleaved_file_splits(
+        spark_tmp_path, use_metadata_row_index):
+    """
+    Reproduces row-count mismatch in the coalescing reader's DV pipeline.
+
+    Setup engineers two files A (large) and B (small) such that:
+      - A is split into N PartitionedFiles: [max, ..., max, tail].
+      - tail(A) < len(B) < max_split.
+      - maxPartitionNum=1 forces all splits + B into ONE FilePartition,
+        preserving the length-desc stable sort so A's blocks are split
+        non-consecutively around B's.
+    Deletes target the global min(a) (in A) and max(a) (in B) so the
+    aggregate result is directly load-bearing on per-file DV application.
+    """
+    import os
+    import pyarrow.parquet as pq
+
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    max_split = 128 * 1024
+    # Row counts tuned for ~148 B/row uncompressed (two SHA-256 hex strings +
+    # two ints). File A = 3000 rows -> 4 splits ~[131K, 131K, 131K, 50K];
+    # File B = 800 rows -> 1 split ~118K. Gives tail(A) ~50K < B ~118K < 131K.
+    a_lo, a_hi = 0, 3799  # global min/max of column `a`
+    a_rows = 3000
+    b_split = a_rows  # boundary between A's range and B's range
+
+    write_conf = {
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.sql.files.maxRecordsPerFile": "0",
+        "parquet.block.size": "16384",
+        "spark.sql.parquet.compression.codec": "uncompressed",
+    }
+    read_conf = {
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
+        "spark.rapids.sql.format.parquet.reader.type": "COALESCING",
+        "spark.databricks.delta.deletionVectors.useMetadataRowIndex":
+            f"{use_metadata_row_index}",
+        "spark.sql.files.maxPartitionBytes": str(max_split),
+        "spark.sql.files.openCostInBytes": "1",
+        # Pin actual maxSplitBytes == maxPartitionBytes. Without this,
+        # FilePartition.maxSplitBytes computes
+        # min(maxPartitionBytes, max(openCost, totalBytes / minPartitionNum)),
+        # which on high-parallelism CI runners collapses to a much smaller
+        # value and breaks the size-engineering below.
+        "spark.sql.files.minPartitionNum": "1",
+        # Repack initial split-per-partition layout into ONE FilePartition.
+        "spark.sql.files.maxPartitionNum": "1",
+    }
+
+    def setup_table(spark):
+        spark.sql(
+            f"CREATE TABLE delta.`{data_path}` "
+            f"(a INT, b INT, payload STRING) USING DELTA "
+            f"TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+        payload_expr = (
+            "concat(sha2(CAST(id AS STRING), 256), "
+            "sha2(CAST(id + 17 AS STRING), 256)) AS payload")
+        # File A: large enough to split into multiple PartitionedFiles with a
+        # tail < max_split, and tuned so tail(A) < len(B) (asserted below).
+        spark.range(a_lo, b_split) \
+             .selectExpr("CAST(id AS INT) AS a",
+                         "CAST(id % 100 AS INT) AS b",
+                         payload_expr) \
+             .repartition(1).write \
+             .option("parquet.enable.dictionary", "false") \
+             .format("delta").mode("append").save(data_path)
+        # File B: single split. Tuned so tail(A) < len(B) < max_split.
+        spark.range(b_split, a_hi + 1) \
+             .selectExpr("CAST(id AS INT) AS a",
+                         "CAST(id % 100 AS INT) AS b",
+                         payload_expr) \
+             .repartition(1).write \
+             .option("parquet.enable.dictionary", "false") \
+             .format("delta").mode("append").save(data_path)
+        # Pin global min(a) in File A and max(a) in File B so mispaired
+        # bitmaps directly perturb min(a)/max(a) on the alive set.
+        spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a IN ({a_lo}, {a_hi})")
+        # Noise: make per-file bitmaps dense so mispairing has many positions
+        # to corrupt.
+        spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a % 17 = 0")
+        spark.sql(f"DELETE FROM delta.`{data_path}` WHERE a % 23 = 5")
+
+    with_cpu_session(setup_table, conf=write_conf)
+
+    # ---- Preconditions on the engineered layout ----------------------------
+    parquet_files = sorted(
+        os.path.join(data_path, f) for f in os.listdir(data_path)
+        if f.endswith(".parquet"))
+    assert len(parquet_files) == 2, \
+        f"Expected exactly 2 data files, got {parquet_files}"
+
+    sizes = sorted((os.path.getsize(p) for p in parquet_files), reverse=True)
+    a_size, b_size = sizes[0], sizes[1]
+    a_tail = a_size % max_split
+    assert a_size > max_split, \
+        f"File A ({a_size}) must exceed max_split ({max_split}) to split"
+    assert 0 < a_tail < b_size < max_split, (
+        f"Sort order won't interleave: a_tail={a_tail}, "
+        f"b={b_size}, max_split={max_split}")
+
+    for p in parquet_files:
+        n_rg = pq.read_metadata(p).num_row_groups
+        assert n_rg > 1, f"{p} has {n_rg} row group(s); need > 1"
+
+    # GPU-side check: maxPartitionNum=1 actually took effect for the GPU
+    # Delta format. The CPU planner uses a different FileFormat with its own
+    # isSplitable behavior, so a CPU partition count would not prove this.
+    num_partitions = with_gpu_session(
+        lambda spark: spark.read.format("delta").load(data_path)
+                           .select("a").rdd.getNumPartitions(),
+        conf=read_conf)
+    assert num_partitions == 1, \
+        f"Expected 1 FilePartition after rescale, got {num_partitions}"
+
+    # ---- Bug surface -------------------------------------------------------
+    # min(a): fails if File A's DV doesn't actually delete a=a_lo.
+    # max(a): fails if File B's DV doesn't actually delete a=a_hi.
+    # sum(a), count(a): backstop wrong-row deletion not touching the extremes.
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.sql(
+            f"SELECT count(a), sum(a), min(a), max(a) FROM delta.`{data_path}`"),
+        conf=read_conf)
+
+
+@allow_non_gpu("FileSourceScanExec", "ColumnarToRowExec", *delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
 @pytest.mark.parametrize("reader_type", ["PERFILE", "MULTITHREADED", "COALESCING"], ids=idfn)
 @pytest.mark.parametrize("dv_predicate_pushdown", [True, False], ids=idfn)
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -20,6 +20,7 @@ from data_gen import *
 from delta_lake_utils import delta_meta_allow, setup_delta_dest_table, deletion_vector_values_with_350DB143_xfail_reasons
 from marks import allow_non_gpu, delta_lake, ignore_order
 from parquet_test import reader_opt_confs_no_native
+from parquet_test_utils import parquet_row_group_midpoints
 from spark_session import with_cpu_session, with_gpu_session, is_databricks_runtime, \
     is_spark_320_or_later, is_spark_340_or_later, supports_delta_lake_deletion_vectors, is_spark_401_or_later, \
     is_before_spark_353, is_databricks173_or_later
@@ -607,7 +608,6 @@ def test_delta_deletion_vector_interleaved_file_splits(
         non-consecutively around B's.
     """
     import os
-    import pyarrow.parquet as pq
 
     data_path = spark_tmp_path + "/DELTA_DATA"
     max_split = 128 * 1024
@@ -682,8 +682,9 @@ def test_delta_deletion_vector_interleaved_file_splits(
     assert len(parquet_files) == 2, \
         f"Expected exactly 2 data files, got {parquet_files}"
 
-    sizes = sorted((os.path.getsize(p) for p in parquet_files), reverse=True)
-    a_size, b_size = sizes[0], sizes[1]
+    files_by_size = sorted(
+        ((os.path.getsize(p), p) for p in parquet_files), reverse=True)
+    (a_size, a_path), (b_size, b_path) = files_by_size
     a_tail = a_size % max_split
     assert a_size > max_split, \
         f"File A ({a_size}) must exceed max_split ({max_split}) to split"
@@ -691,9 +692,13 @@ def test_delta_deletion_vector_interleaved_file_splits(
         f"Sort order won't interleave: a_tail={a_tail}, "
         f"b={b_size}, max_split={max_split}")
 
-    for p in parquet_files:
-        n_rg = pq.read_metadata(p).num_row_groups
-        assert n_rg > 1, f"{p} has {n_rg} row group(s); need > 1"
+    a_tail_start = a_size - a_tail
+    a_midpoints = parquet_row_group_midpoints(a_path)
+    b_midpoints = parquet_row_group_midpoints(b_path)
+    assert any(a_tail_start <= midpoint < a_size for midpoint in a_midpoints), (
+        f"A tail split [{a_tail_start}, {a_size}) has no row-group midpoint; "
+        f"midpoints={a_midpoints}")
+    assert b_midpoints, f"File B has no row groups: {b_path}"
 
     # GPU-side check: make sure Spark creates one partition on GPU as expected.
     num_partitions = with_gpu_session(

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -22,7 +22,7 @@ from data_gen import *
 from parquet_write_test import parquet_datetime_gen_simple, parquet_nested_datetime_gen, parquet_ts_write_options
 from marks import *
 import pyarrow as pa
-import pyarrow.parquet as pa_pq
+from parquet_test_utils import parquet_row_group_midpoints
 from pyspark.sql.types import *
 from pyspark.sql.functions import *
 from spark_init_internal import spark_version
@@ -979,22 +979,6 @@ def test_parquet_interleaved_file_splits_partition_value_alignment(
              .option("parquet.enable.dictionary", "false") \
              .parquet(f"{data_path}/p=2")
 
-    def row_group_midpoints(path):
-        meta = pa_pq.read_metadata(path)
-        midpoints = []
-        for rg_index in range(meta.num_row_groups):
-            row_group = meta.row_group(rg_index)
-            first_col = row_group.column(0)
-            start = first_col.data_page_offset
-            dict_offset = first_col.dictionary_page_offset
-            if dict_offset is not None and dict_offset > 0:
-                start = min(start, dict_offset)
-            total_size = 0
-            for col_index in range(row_group.num_columns):
-                total_size += row_group.column(col_index).total_compressed_size
-            midpoints.append(start + total_size // 2)
-        return midpoints
-
     with_cpu_session(setup_table, conf=write_conf)
 
     parquet_files_by_part = {}
@@ -1020,8 +1004,8 @@ def test_parquet_interleaved_file_splits_partition_value_alignment(
         f"b={b_size}, max_split={max_split}")
 
     a_tail_start = a_size - a_tail
-    a_midpoints = row_group_midpoints(a_path)
-    b_midpoints = row_group_midpoints(b_path)
+    a_midpoints = parquet_row_group_midpoints(a_path)
+    b_midpoints = parquet_row_group_midpoints(b_path)
     assert any(a_tail_start <= midpoint < a_size for midpoint in a_midpoints), (
         f"A tail split [{a_tail_start}, {a_size}) has no row-group midpoint; "
         f"midpoints={a_midpoints}")

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -925,8 +925,6 @@ def test_small_file_memory(spark_tmp_path, v1_enabled_list):
 @ignore_order(local=True)
 @pytest.mark.skipif(is_before_spark_350(),
                     reason="spark.sql.files.maxPartitionNum requires Spark 3.5.0+")
-@pytest.mark.skipif(is_databricks_runtime(),
-                    reason="Databricks planner may differ for this layout")
 @pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "MULTITHREADED", "COALESCING"],
                          ids=idfn)
 def test_parquet_interleaved_file_splits_partition_value_alignment(

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -929,7 +929,7 @@ def test_small_file_memory(spark_tmp_path, v1_enabled_list):
                     reason="Databricks planner may differ for this layout")
 @pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "MULTITHREADED", "COALESCING"],
                          ids=idfn)
-def test_parquet_coalescing_interleaved_file_splits_partition_value_alignment(
+def test_parquet_interleaved_file_splits_partition_value_alignment(
         spark_tmp_path, parquet_reader_type):
     """
     Verifies partition values remain aligned when reading split Parquet files from different

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -919,6 +919,122 @@ def test_small_file_memory(spark_tmp_path, v1_enabled_list):
             conf={'spark.rapids.sql.format.parquet.reader.type': 'COALESCING',
                   'spark.sql.sources.useV1SourceList': v1_enabled_list,
                   'spark.sql.files.maxPartitionBytes': "1g"})
+
+
+@allow_non_gpu("FileSourceScanExec", "ColumnarToRowExec")
+@ignore_order(local=True)
+@pytest.mark.skipif(is_before_spark_350(),
+                    reason="spark.sql.files.maxPartitionNum requires Spark 3.5.0+")
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="Databricks planner may differ for this layout")
+def test_parquet_coalescing_interleaved_file_splits_partition_value_alignment(
+        spark_tmp_path):
+    """
+    Verifies partition values remain aligned when coalescing split Parquet files
+    from different partition directories.
+
+    The setup creates file A under p=1 and file B under p=2 such that Spark's
+    length-desc split sort produces [A..., B, A-tail] in a single FilePartition.
+    The row-group midpoint precondition below proves A-tail contributes at least
+    one Parquet block to the coalescing reader; otherwise the split interleaving
+    would not reach populateCurrentBlockChunk.
+    """
+    data_path = spark_tmp_path + "/PARQUET_DATA"
+    max_split = 128 * 1024
+    a_rows = 3000
+    b_rows = 800
+    b_split = a_rows
+
+    write_conf = {
+        "spark.sql.files.maxRecordsPerFile": "0",
+        "parquet.block.size": "16384",
+        "spark.sql.parquet.compression.codec": "uncompressed",
+    }
+    read_conf = {
+        "spark.rapids.sql.format.parquet.reader.type": "COALESCING",
+        "spark.rapids.sql.format.parquet.reader.footer.type": "JAVA",
+        "spark.sql.sources.useV1SourceList": "parquet",
+        "spark.sql.files.maxPartitionBytes": str(max_split),
+        "spark.sql.files.openCostInBytes": "1",
+        "spark.sql.files.minPartitionNum": "1",
+        "spark.sql.files.maxPartitionNum": "1",
+    }
+
+    def setup_table(spark):
+        payload_expr = (
+            "concat(sha2(CAST(id AS STRING), 256), "
+            "sha2(CAST(id + 17 AS STRING), 256)) AS payload")
+        spark.range(0, a_rows) \
+             .selectExpr("CAST(id AS INT) AS a", payload_expr) \
+             .repartition(1).write \
+             .option("parquet.enable.dictionary", "false") \
+             .parquet(f"{data_path}/p=1")
+        spark.range(b_split, b_split + b_rows) \
+             .selectExpr("CAST(id AS INT) AS a", payload_expr) \
+             .repartition(1).write \
+             .option("parquet.enable.dictionary", "false") \
+             .parquet(f"{data_path}/p=2")
+
+    def row_group_midpoints(path):
+        meta = pa_pq.read_metadata(path)
+        midpoints = []
+        for rg_index in range(meta.num_row_groups):
+            row_group = meta.row_group(rg_index)
+            first_col = row_group.column(0)
+            start = first_col.data_page_offset
+            dict_offset = first_col.dictionary_page_offset
+            if dict_offset is not None and dict_offset > 0:
+                start = min(start, dict_offset)
+            total_size = 0
+            for col_index in range(row_group.num_columns):
+                total_size += row_group.column(col_index).total_compressed_size
+            midpoints.append(start + total_size // 2)
+        return midpoints
+
+    with_cpu_session(setup_table, conf=write_conf)
+
+    parquet_files_by_part = {}
+    for root, _, files in os.walk(data_path):
+        parquet_files = [os.path.join(root, f) for f in files if f.endswith(".parquet")]
+        if parquet_files:
+            parquet_files_by_part[os.path.basename(root)] = parquet_files
+
+    assert sorted(parquet_files_by_part.keys()) == ["p=1", "p=2"], \
+        f"Expected parquet files under p=1 and p=2, got {parquet_files_by_part}"
+    assert len(parquet_files_by_part["p=1"]) == 1, parquet_files_by_part["p=1"]
+    assert len(parquet_files_by_part["p=2"]) == 1, parquet_files_by_part["p=2"]
+
+    a_path = parquet_files_by_part["p=1"][0]
+    b_path = parquet_files_by_part["p=2"][0]
+    a_size = os.path.getsize(a_path)
+    b_size = os.path.getsize(b_path)
+    a_tail = a_size % max_split
+    assert a_size > max_split, \
+        f"File A ({a_size}) must exceed max_split ({max_split}) to split"
+    assert 0 < a_tail < b_size < max_split, (
+        f"Sort order will not interleave: a_tail={a_tail}, "
+        f"b={b_size}, max_split={max_split}")
+
+    a_tail_start = a_size - a_tail
+    a_midpoints = row_group_midpoints(a_path)
+    b_midpoints = row_group_midpoints(b_path)
+    assert any(a_tail_start <= midpoint < a_size for midpoint in a_midpoints), (
+        f"A tail split [{a_tail_start}, {a_size}) has no row-group midpoint; "
+        f"midpoints={a_midpoints}")
+    assert b_midpoints, f"File B has no row groups: {b_path}"
+
+    num_partitions = with_gpu_session(
+        lambda spark: spark.read.parquet(data_path).select("a").rdd.getNumPartitions(),
+        conf=read_conf)
+    assert num_partitions == 1, \
+        f"Expected 1 FilePartition after rescale, got {num_partitions}"
+
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.parquet(data_path).selectExpr(
+            f"SUM(CASE WHEN a < {b_split} AND p != 1 THEN 1 "
+            f"WHEN a >= {b_split} AND p != 2 THEN 1 "
+            "ELSE 0 END) AS bad_partition_rows"),
+        conf=read_conf)
 
 
 _nested_pruning_schemas = [

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -952,12 +952,16 @@ def test_parquet_coalescing_interleaved_file_splits_partition_value_alignment(
     }
     read_conf = {
         "spark.rapids.sql.format.parquet.reader.type": "COALESCING",
-        "spark.rapids.sql.format.parquet.reader.footer.type": "JAVA",
-        "spark.sql.sources.useV1SourceList": "parquet",
         "spark.sql.files.maxPartitionBytes": str(max_split),
         "spark.sql.files.openCostInBytes": "1",
+        # Pin actual maxSplitBytes == maxPartitionBytes. Without this,
+        # FilePartition.maxSplitBytes computes
+        # min(maxPartitionBytes, max(openCost, totalBytes / minPartitionNum)),
+        # which on high-parallelism CI runners collapses to a much smaller
+        # value and breaks the size-engineering below.
         "spark.sql.files.minPartitionNum": "1",
-        "spark.sql.files.maxPartitionNum": "1",
+        # Repack initial split-per-partition layout into ONE FilePartition.
+        "spark.sql.files.maxPartitionNum": "1"
     }
 
     def setup_table(spark):

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -927,11 +927,13 @@ def test_small_file_memory(spark_tmp_path, v1_enabled_list):
                     reason="spark.sql.files.maxPartitionNum requires Spark 3.5.0+")
 @pytest.mark.skipif(is_databricks_runtime(),
                     reason="Databricks planner may differ for this layout")
+@pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "MULTITHREADED", "COALESCING"],
+                         ids=idfn)
 def test_parquet_coalescing_interleaved_file_splits_partition_value_alignment(
-        spark_tmp_path):
+        spark_tmp_path, parquet_reader_type):
     """
-    Verifies partition values remain aligned when coalescing split Parquet files
-    from different partition directories.
+    Verifies partition values remain aligned when reading split Parquet files from different
+    partition directories.
 
     The setup creates file A under p=1 and file B under p=2 such that Spark's
     length-desc split sort produces [A..., B, A-tail] in a single FilePartition.
@@ -951,7 +953,7 @@ def test_parquet_coalescing_interleaved_file_splits_partition_value_alignment(
         "spark.sql.parquet.compression.codec": "uncompressed",
     }
     read_conf = {
-        "spark.rapids.sql.format.parquet.reader.type": "COALESCING",
+        "spark.rapids.sql.format.parquet.reader.type": parquet_reader_type,
         "spark.sql.files.maxPartitionBytes": str(max_split),
         "spark.sql.files.openCostInBytes": "1",
         # Pin actual maxSplitBytes == maxPartitionBytes. Without this,

--- a/integration_tests/src/main/python/parquet_test_utils.py
+++ b/integration_tests/src/main/python/parquet_test_utils.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyarrow.parquet as pa_pq
+
+
+def parquet_row_group_midpoints(path):
+    """Returns an approximate byte midpoint for each Parquet row group."""
+    meta = pa_pq.read_metadata(path)
+    midpoints = []
+    for rg_index in range(meta.num_row_groups):
+        row_group = meta.row_group(rg_index)
+        first_col = row_group.column(0)
+        start = first_col.data_page_offset
+        dict_offset = first_col.dictionary_page_offset
+        if dict_offset is not None and dict_offset > 0:
+            start = min(start, dict_offset)
+        total_size = 0
+        for col_index in range(row_group.num_columns):
+            total_size += row_group.column(col_index).total_compressed_size
+        midpoints.append(start + total_size // 2)
+    return midpoints

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -1086,14 +1086,70 @@ abstract class MultiFileCoalescingPartitionReaderBase(
     clippedBlocks.iterator.buffered
   private[this] val inputMetrics = TaskContext.get.taskMetrics().inputMetrics
 
+  /**
+   * A group of blocks in one coalesced read that have the same file path.
+   * This may be a subset of all blocks in that file.
+   */
+  protected final class FileBlockGroup(
+      val filePath: Path,
+      val blocks: Seq[SingleDataBlockInfo]) {
+    val numRows: Long = blocks.foldLeft(0L)(_ + _.dataBlock.getRowCount)
+  }
+
+  /**
+   * A file block group and the partition value for that group.
+   */
+  protected final class FileBlockGroupWithPartition(
+      val fileBlockGroup: FileBlockGroup,
+      val partitionValue: InternalRow)
+
+  /**
+   * Blocks for one coalesced read, grouped by file path.
+   * rowsPerPartition and allPartValues are derived from groupsByFile values.
+   */
+  protected final class FileMajorBlockChunk private(
+      val groupsByFile: LinkedHashMap[Path, FileBlockGroupWithPartition]) {
+    val rowsPerPartition: Array[Long] =
+      groupsByFile.values.map(_.fileBlockGroup.numRows).toArray
+    val allPartValues: Array[InternalRow] =
+      groupsByFile.values.map(_.partitionValue).toArray
+    def isEmpty: Boolean = groupsByFile.isEmpty
+  }
+
+  protected object FileMajorBlockChunk {
+    /**
+     * Builds a chunk by grouping the given blocks by file path.
+     * rowsPerPartition and allPartValues are computed from the groups.
+     */
+    def fromBlocks(blocks: Seq[SingleDataBlockInfo]): FileMajorBlockChunk = {
+      val blocksByFile = LinkedHashMap[Path, ArrayBuffer[SingleDataBlockInfo]]()
+      blocks.foreach { block =>
+        blocksByFile.getOrElseUpdate(block.filePath, new ArrayBuffer[SingleDataBlockInfo]) += block
+      }
+
+      val groupsByFile = LinkedHashMap[Path, FileBlockGroupWithPartition]()
+
+      blocksByFile.foreach { case (filePath, fileBlocks) =>
+        val groupedBlocks = fileBlocks.toSeq
+        val partitionValue = groupedBlocks.head.partitionValues
+        require(groupedBlocks.forall(_.partitionValues == partitionValue),
+          s"Blocks from the same file must share partition values: $filePath")
+        val group = new FileBlockGroup(filePath, groupedBlocks)
+        groupsByFile += filePath -> new FileBlockGroupWithPartition(group, partitionValue)
+      }
+
+      new FileMajorBlockChunk(groupsByFile)
+    }
+  }
+
   protected case class CurrentChunkMeta(
     clippedSchema: SchemaBase,
     readSchema: StructType,
-    currentChunk: Seq[SingleDataBlockInfo],
-    numTotalRows: Long,
-    rowsPerPartition: Array[Long],
-    allPartValues: Array[InternalRow],
-    extraInfo: ExtraInfo)
+    currentChunk: FileMajorBlockChunk,
+    extraInfo: ExtraInfo) {
+    def rowsPerPartition: Array[Long] = currentChunk.rowsPerPartition
+    def allPartValues: Array[InternalRow] = currentChunk.allPartValues
+  }
 
   /**
    * To check if the next block will be split into another ColumnarBatch
@@ -1376,19 +1432,23 @@ abstract class MultiFileCoalescingPartitionReaderBase(
 
   /**
    * Read all data blocks into HostMemoryBuffer
-   * @param blocks a sequence of data blocks to be read
+   * @param chunk the file-major data blocks to be read
    * @param clippedSchema the clipped schema is used to calculate the estimated output size
    * @return the HostMemoryBuffer
    */
   private def readPartFiles(
-      blocks: Seq[SingleDataBlockInfo],
+      chunk: FileMajorBlockChunk,
       clippedSchema: SchemaBase): SpillableHostBuffer = {
 
     NvtxIdWithMetrics(NvtxRegistry.BUFFER_FILE_SPLIT, metrics("bufferTime")) {
-      // ugly but we want to keep the order
       val filesAndBlocks = LinkedHashMap[Path, ArrayBuffer[DataBlockBase]]()
-      blocks.foreach { b =>
-        filesAndBlocks.getOrElseUpdate(b.filePath, new ArrayBuffer[DataBlockBase]) += b.dataBlock
+      chunk.groupsByFile.foreach { case (file, groupWithPartition) =>
+        val group = groupWithPartition.fileBlockGroup
+        val dataBlocks = new ArrayBuffer[DataBlockBase](group.blocks.size)
+        group.blocks.foreach { block =>
+          dataBlocks += block.dataBlock
+        }
+        filesAndBlocks += file -> dataBlocks
       }
       val tasks = new java.util.ArrayList[Future[AsyncResult[(Seq[DataBlockBase], Long)]]]()
 
@@ -1496,12 +1556,8 @@ abstract class MultiFileCoalescingPartitionReaderBase(
     var numBytes: Long = 0
     var numChunkBytes: Long = 0
     var currentFile: Path = null
-    var currentPartitionValues: InternalRow = null
     var currentClippedSchema: SchemaBase = null
     var currentReadSchema: StructType = null
-    val rowsPerPartition = new ArrayBuffer[Long]()
-    var lastPartRows: Long = 0
-    val allPartValues = new ArrayBuffer[InternalRow]()
     var currentDataBlock: SingleDataBlockInfo = null
     var extraInfo: ExtraInfo = null
 
@@ -1512,8 +1568,6 @@ abstract class MultiFileCoalescingPartitionReaderBase(
           // first time of readNextBatch
           currentDataBlock = blockIterator.head
           currentFile = blockIterator.head.filePath
-          currentPartitionValues = blockIterator.head.partitionValues
-          allPartValues += currentPartitionValues
           currentClippedSchema = blockIterator.head.schema
           currentReadSchema = blockIterator.head.readSchema
           extraInfo = blockIterator.head.extraInfo
@@ -1534,19 +1588,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
                 logInfo(s"splitting ${blockIterator.head.filePath} into another batch!")
                 return
               }
-              // If the partition values are different we have to track the number of rows that get
-              // each partition value and the partition values themselves so that we can build
-              // the full columns with different partition values later.
-              if (blockIterator.head.partitionValues != currentPartitionValues) {
-                rowsPerPartition += (numRows - lastPartRows)
-                lastPartRows = numRows
-                // we add the actual partition values here but then
-                // the number of rows in that partition at the end or
-                // when the partition changes
-                allPartValues += blockIterator.head.partitionValues
-              }
               currentFile = blockIterator.head.filePath
-              currentPartitionValues = blockIterator.head.partitionValues
               currentClippedSchema = blockIterator.head.schema
               currentReadSchema = blockIterator.head.readSchema
               currentDataBlock = blockIterator.head
@@ -1563,11 +1605,10 @@ abstract class MultiFileCoalescingPartitionReaderBase(
       }
     }
     readNextBatch()
-    rowsPerPartition += (numRows - lastPartRows)
+    val fileMajorChunk = FileMajorBlockChunk.fromBlocks(currentChunk.toSeq)
     logDebug(s"Loaded $numRows rows from ${getFileFormatShortName}. " +
       s"${getFileFormatShortName} bytes read: $numChunkBytes. Estimated GPU bytes: $numBytes. " +
-      s"Number of different partitions: ${allPartValues.size}")
-    CurrentChunkMeta(currentClippedSchema, currentReadSchema, currentChunk.toSeq,
-      numRows, rowsPerPartition.toArray, allPartValues.toArray, extraInfo)
+      s"Number of partition entries: ${fileMajorChunk.allPartValues.length}")
+    CurrentChunkMeta(currentClippedSchema, currentReadSchema, fileMajorChunk, extraInfo)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14760.
Fixes https://github.com/NVIDIA/spark-rapids/issues/14831.

### Description

  The coalescing reader builds its combined input buffer in file-major order, but some metadata was still derived from the incoming split order. When Spark creates `FilePartition`s with interleaved splits from different files, this can misalign metadata with the rows in the combined buffer.

  This affects two paths:
  - Delta deletion vectors can be paired with the wrong file/row-group ranges.
  - Partition values can be attached to the wrong row ranges for Parquet-based readers (plain Parquet, Delta, and Delta with DVs).

  This PR makes the parent coalescing reader build an explicit file-major chunk structure. Each chunk groups blocks by file path, stores the partition value for that file group, and derives `rowsPerPartition` / `allPartValues` from that same structure. The Delta DV path now builds `PerFileDVEntry` from those file-major groups instead of inferring file boundaries from split order.

  Tests added:
  - `test_delta_deletion_vector_coalescing_interleaved_file_splits`
  - `test_parquet_coalescing_interleaved_file_splits_partition_value_alignment`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
