### PR TITLE
Use null-propagating stringConcatenate in cast complex-type-to-string

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -855,19 +855,15 @@ object GpuCast {
           _.replaceNulls(nullRep)
         }
       } else {
-        // add a space string to each non-null element
-        val (strChild, childNotNull, numElements) =
-          withResource(input.getChildColumnView(0)) { childCol =>
-            closeOnExcept(childCol.replaceNulls(nullRep)) {
-              (_, childCol.isNotNull(), childCol.getRowCount.toInt)
-            }
+        // Prepend a space to each non-null element, letting the concat propagate nulls
+        // from the child column, then fill those nulls with nullRep.
+        withResource(input.getChildColumnView(0)) { childCol =>
+          val numElements = childCol.getRowCount.toInt
+          val withSpaces = withResource(ColumnVector.fromScalar(space, numElements)) { spaceCol =>
+            ColumnVector.stringConcatenate(Array(spaceCol, childCol))
           }
-        withResource(Seq(strChild, childNotNull)) { _ =>
-          val hasSpaces = withResource(ColumnVector.fromScalar(space, numElements)) { spaceCol =>
-            ColumnVector.stringConcatenate(Array(spaceCol, strChild))
-          }
-          withResource(hasSpaces) {
-            childNotNull.ifElse(_, strChild)
+          withResource(withSpaces) { _ =>
+            withSpaces.replaceNulls(nullRep)
           }
         }
       }


### PR DESCRIPTION
Contributes to #14588.

### Description

This is a small change to the non-JSON branch of `concatenateStringArrayElements` (used by cast-array-to-string and cast-map-to-string when prepending a space to each element). Replaces the per-row `isNotNull.ifElse` null restore with `stringConcatenate`'s null propagation plus a single trailing `replaceNulls(nullRep)`. Covered by existing tests in `integration_tests/src/main/python/cast_test.py`.

Isolating the rewritten block in a nanobenchmark, this change can yield ~58% speedups on 100k rows.

<details>
<summary>cast nanobenchmark</summary>

```scala
import ai.rapids.cudf.{ColumnVector, Cuda, Rmm, RmmAllocationMode, Scalar}

object GpuCastSpacePrependBench {
  val NumRows = 100000
  val Warmup = 5
  val Measured = 20

  def main(args: Array[String]): Unit = {
    Rmm.initialize(RmmAllocationMode.POOL, null, Cuda.memGetInfo().free / 2 & ~255L)

    withResource(buildStringCol(NumRows)) { childCol =>
      withResource(Scalar.fromString(" ")) { space =>
        withResource(Scalar.fromString("null")) { nullRep =>
          for (_ <- 0 until Warmup) {
            castOld(childCol, space, nullRep).close()
            castNew(childCol, space, nullRep).close()
          }
          val timesOld = (0 until Measured).map { _ =>
            val t = System.nanoTime()
            castOld(childCol, space, nullRep).close()
            System.nanoTime() - t
          }
          val timesNew = (0 until Measured).map { _ =>
            val t = System.nanoTime()
            castNew(childCol, space, nullRep).close()
            System.nanoTime() - t
          }
          println(f"OLD median: ${timesOld.sorted.apply(Measured / 2) / 1e6}%.3f ms")
          println(f"NEW median: ${timesNew.sorted.apply(Measured / 2) / 1e6}%.3f ms")
        }
      }
    }
  }

  // Original pipeline: replaceNulls -> isNotNull -> concat -> ifElse
  def castOld(childCol: ColumnVector, space: Scalar, nullRep: Scalar): ColumnVector = {
    val numElements = childCol.getRowCount.toInt
    withResource(childCol.replaceNulls(nullRep)) { strChild =>
      withResource(childCol.isNotNull) { childNotNull =>
        val hasSpaces = withResource(ColumnVector.fromScalar(space, numElements)) { spaceCol =>
          ColumnVector.stringConcatenate(Array(spaceCol, strChild))
        }
        withResource(hasSpaces) { _ =>
          childNotNull.ifElse(hasSpaces, strChild)
        }
      }
    }
  }

  // Rewritten pipeline: concat-with-null-propagation -> replaceNulls
  def castNew(childCol: ColumnVector, space: Scalar, nullRep: Scalar): ColumnVector = {
    val numElements = childCol.getRowCount.toInt
    val withSpaces = withResource(ColumnVector.fromScalar(space, numElements)) { spaceCol =>
      ColumnVector.stringConcatenate(Array(spaceCol, childCol))
    }
    withResource(withSpaces) { _ =>
      withSpaces.replaceNulls(nullRep)
    }
  }

  // ~25% nulls, rest "abc"
  def buildStringCol(n: Int): ColumnVector = {
    val arr = Array.tabulate(n)(i => if (i % 4 == 0) null else "abc")
    ColumnVector.fromStrings(arr: _*)
  }

  def withResource[T <: AutoCloseable, R](r: T)(f: T => R): R =
    try f(r) finally if (r != null) r.close()
}
```

</details>

```
OLD median: 0.287 ms
NEW median: 0.183 ms
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
