### PR TITLE
Use fused replaceNulls to compute per row repetition in explode

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -334,10 +334,7 @@ abstract class GpuExplodeBase extends GpuUnevaluableUnaryExpression with GpuGene
       if (outer) {
         // for outer, empty arrays and null arrays will produce a row
         withResource(GpuScalar.from(1, IntegerType)) { one =>
-          val noNulls = withResource(arrayLengths.isNotNull) { isLhsNotNull =>
-            isLhsNotNull.ifElse(arrayLengths, one)
-          }
-          withResource(noNulls) { _ =>
+          withResource(arrayLengths.replaceNulls(one)) { noNulls =>
             withResource(noNulls.greaterOrEqualTo(one)) { isGeOne =>
               isGeOne.ifElse(noNulls, one)
             }


### PR DESCRIPTION
Contributes to #14588, follow-up on https://github.com/NVIDIA/spark-rapids/pull/14817#pullrequestreview-4313348710. 

### Description

A small change to use the fused replaceNulls rather than the two-kernel pass and extra bool column allocation. Covered by existing tests in `test_explode_*`.

This API can be ~2.4x faster than the two-kernel approach.

<details>
<summary>replaceNulls nanobenchmark</summary>

```scala
import ai.rapids.cudf.{ColumnVector, Cuda, Rmm, RmmAllocationMode, Scalar}

object ReplaceNullsBench {
  val NumRows = 100000
  val Warmup = 5
  val Measured = 20

  def main(args: Array[String]): Unit = {
    Rmm.initialize(RmmAllocationMode.POOL, null, Cuda.memGetInfo().free / 2 & ~255L)

    withResource(buildIntColWithNulls(NumRows)) { cv =>
      withResource(Scalar.fromInt(1)) { default =>
        for (_ <- 0 until Warmup) {
          replaceWithIfElse(cv, default).close()
          replaceWithReplaceNulls(cv, default).close()
        }
        val timesOld = (0 until Measured).map { _ =>
          val t = System.nanoTime()
          replaceWithIfElse(cv, default).close()
          System.nanoTime() - t
        }
        val timesNew = (0 until Measured).map { _ =>
          val t = System.nanoTime()
          replaceWithReplaceNulls(cv, default).close()
          System.nanoTime() - t
        }
        println(f"OLD median: ${timesOld.sorted.apply(Measured / 2) / 1e6}%.3f ms")
        println(f"NEW median: ${timesNew.sorted.apply(Measured / 2) / 1e6}%.3f ms")
      }
    }
  }

  // Old pattern: isNotNull mask + ifElse to substitute scalar for null rows.
  def replaceWithIfElse(cv: ColumnVector, default: Scalar): ColumnVector =
    withResource(cv.isNotNull) { mask =>
      mask.ifElse(cv, default)
    }

  // New pattern: single fused replaceNulls kernel.
  def replaceWithReplaceNulls(cv: ColumnVector, default: Scalar): ColumnVector =
    cv.replaceNulls(default)

  // ~25% nulls, rest sequential ints
  def buildIntColWithNulls(n: Int): ColumnVector = {
    val arr: Array[Integer] =
      Array.tabulate(n)(i => if (i % 4 == 0) null else Integer.valueOf(i))
    ColumnVector.fromBoxedInts(arr: _*)
  }

  def withResource[T <: AutoCloseable, R](r: T)(f: T => R): R =
    try f(r) finally if (r != null) r.close()
}
```

</details> 

```
OLD median: 0.027 ms
NEW median: 0.008 ms
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
