### PR TITLE
Port Delta DV predicate pruning fix to DBR 17.3 [databricks] 

### DIFF
--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
@@ -40,7 +40,7 @@ import com.nvidia.spark.rapids.delta.shims.DeltaLogShim
 import com.nvidia.spark.rapids.shims.ShimPredicateHelper
 
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, If, IsNotNull, Literal, Not}
 import org.apache.spark.sql.catalyst.plans.logical.TableSpec
 import org.apache.spark.sql.connector.write.V1Write
 import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, ProjectExec, SparkPlan}
@@ -271,16 +271,30 @@ object DeltaSpark400DB173Provider extends DatabricksDeltaProviderBase {
 private object DB173DVPredicatePushdown extends ShimPredicateHelper {
 
   def pushToScan(plan: SparkPlan): SparkPlan = {
+    def isDeletionVectorSkipRowColumnEqualToFalse(left: Expression, right: Expression): Boolean = {
+      isDeletionVectorSkipRowColumnRef(left) && isZeroOrFalseLiteral(right) ||
+        isDeletionVectorSkipRowColumnRef(right) && isZeroOrFalseLiteral(left)
+    }
+
     def isDVCondition(condition: Expression): Boolean = {
       condition match {
         case GpuEqualTo(left, right) =>
-          isDeletionVectorSkipRowColumnRef(left) && isFalseLiteral(right) ||
-            isDeletionVectorSkipRowColumnRef(right) && isFalseLiteral(left)
+          isDeletionVectorSkipRowColumnEqualToFalse(left, right)
+        case EqualTo(left, right) =>
+          isDeletionVectorSkipRowColumnEqualToFalse(left, right)
         case GpuNot(child) =>
+          isDeletionVectorSkipRowColumnRef(child)
+        case Not(child) =>
           isDeletionVectorSkipRowColumnRef(child)
         case GpuIsNotNull(child) =>
           isDeletionVectorSkipRowColumnRef(child)
+        case IsNotNull(child) =>
+          isDeletionVectorSkipRowColumnRef(child)
         case GpuIf(predicateExpr, trueExpr, falseExpr) =>
+          isDVCondition(predicateExpr) &&
+            isDVCondition(trueExpr) &&
+            !falseExpr.references.exists(ref => isDeletionVectorSkipRowColumn(ref.name))
+        case If(predicateExpr, trueExpr, falseExpr) =>
           isDVCondition(predicateExpr) &&
             isDVCondition(trueExpr) &&
             !falseExpr.references.exists(ref => isDeletionVectorSkipRowColumn(ref.name))
@@ -295,10 +309,12 @@ private object DB173DVPredicatePushdown extends ShimPredicateHelper {
       }
     }
 
-    def isFalseLiteral(expr: Expression): Boolean = {
+    def isZeroOrFalseLiteral(expr: Expression): Boolean = {
       expr match {
         case GpuLiteral(value: Number, _) if value.longValue() == 0L => true
         case GpuLiteral(value: Boolean, _) if !value => true
+        case Literal(value: Number, _) if value.longValue() == 0L => true
+        case Literal(value: Boolean, _) if !value => true
         case _ => false
       }
     }
@@ -312,7 +328,12 @@ private object DB173DVPredicatePushdown extends ShimPredicateHelper {
             originalOutput = fsse.originalOutput.filterNot(attr =>
               isDeletionVectorSkipRowColumn(attr.name)),
             requiredSchema = StructType(fsse.requiredSchema.filterNot(field =>
-              isDeletionVectorSkipRowColumn(field.name))))(fsse.rapidsConf)
+              isDeletionVectorSkipRowColumn(field.name))),
+            // AQE expects expressions in dataFilters to exist in the output of the scan.
+            // It will not reuse the stage of the scan otherwise. Since we are removing
+            // the deletion-vector skip-row column from scan's output, remove the
+            // corresponding filter from dataFilters as well.
+            dataFilters = fsse.dataFilters.filterNot(isDVCondition(_)))(fsse.rapidsConf)
       }
     }
 

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -39,7 +39,7 @@ def _assert_db173_gpu_delta_scan_if_enabled(spark, df):
     return df
 
 
-def _delta_sql_with_gpu_scan_assert(spark, sql):
+def _db_delta_sql_with_gpu_scan_assert(spark, sql):
     return _assert_db173_gpu_delta_scan_if_enabled(spark, spark.sql(sql))
 
 
@@ -62,7 +62,7 @@ def _assert_delta_dv_read_sql(test_sql, conf):
             conf=conf)
     else:
         assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: _delta_sql_with_gpu_scan_assert(spark, test_sql),
+            lambda spark: _db_delta_sql_with_gpu_scan_assert(spark, test_sql),
             conf=conf)
 
 
@@ -364,7 +364,7 @@ def do_test_scan_split(spark_tmp_path, enable_deletion_vectors, expected_num_par
             conf=read_conf)
     else:
         def get_num_partitions(spark):
-            df = _delta_sql_with_gpu_scan_assert(spark, read_sql)
+            df = _db_delta_sql_with_gpu_scan_assert(spark, read_sql)
             return df.rdd.getNumPartitions()
         num_partitions = with_gpu_session(get_num_partitions, conf=read_conf)
         assert num_partitions == expected_num_partitions, f"Expected {expected_num_partitions} partitions for split read"
@@ -712,13 +712,10 @@ def test_delta_filter_out_metadata_col(spark_tmp_path, dv_predicate_pushdown):
     data_path = spark_tmp_path + "/DELTA_DATA"
     conf = {
         "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled":
-            f"{dv_predicate_pushdown}"
+            f"{dv_predicate_pushdown}",
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true"
     }
-    if is_databricks173_or_later():
-        conf.update({
-            "spark.databricks.delta.delete.deletionVectors.persistent": "true",
-            "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true"
-        })
 
     col_a_gen = IntegerGen(min_val=0, max_val=100, nullable=False, special_cases=[])
     col_b_gen = IntegerGen(min_val=0, max_val=1, nullable=False, special_cases=[0, 1])
@@ -734,7 +731,7 @@ def test_delta_filter_out_metadata_col(spark_tmp_path, dv_predicate_pushdown):
     def read_table(spark):
         sql = f"SELECT * FROM delta.`{data_path}`"
         if is_databricks173_or_later() and dv_predicate_pushdown:
-            df = _delta_sql_with_gpu_scan_assert(spark, sql)
+            df = _db_delta_sql_with_gpu_scan_assert(spark, sql)
         else:
             df = spark.sql(sql)
         is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
@@ -815,7 +812,7 @@ def test_delta_deletion_vector_native_footer_multi_row_group(spark_tmp_path, par
     with_cpu_session(setup_tables, conf=write_conf)
 
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: _delta_sql_with_gpu_scan_assert(spark, query.format(path=data_path)),
+        lambda spark: _db_delta_sql_with_gpu_scan_assert(spark, query.format(path=data_path)),
         conf=read_conf)
 
 

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -703,13 +703,22 @@ def test_delta_deletion_vector_ignore_corrupt_files(spark_tmp_path, reader_type)
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.skipif(is_databricks_runtime(),
-                    reason="Deletion vector scan is not supported on Databricks")
+@pytest.mark.skipif(is_databricks_runtime() and not is_databricks173_or_later(),
+                    reason="Deletion vector scan is not supported on Databricks before 17.3")
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
 @pytest.mark.parametrize("dv_predicate_pushdown", [True, False], ids=idfn)
 def test_delta_filter_out_metadata_col(spark_tmp_path, dv_predicate_pushdown):
     data_path = spark_tmp_path + "/DELTA_DATA"
+    conf = {
+        "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled":
+            f"{dv_predicate_pushdown}"
+    }
+    if is_databricks173_or_later():
+        conf.update({
+            "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+            "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true"
+        })
 
     col_a_gen = IntegerGen(min_val=0, max_val=100, nullable=False, special_cases=[])
     col_b_gen = IntegerGen(min_val=0, max_val=1, nullable=False, special_cases=[0, 1])
@@ -723,17 +732,29 @@ def test_delta_filter_out_metadata_col(spark_tmp_path, dv_predicate_pushdown):
         assert count > 100, "Expected enough rows to be deleted to create deletion vectors"
 
     def read_table(spark):
-        df = spark.sql(f"SELECT * FROM delta.`{data_path}`")
-        is_gpu = spark.conf.get("spark.rapids.sql.enabled").lower() == "true"
+        sql = f"SELECT * FROM delta.`{data_path}`"
+        if is_databricks173_or_later() and dv_predicate_pushdown:
+            df = _delta_sql_with_gpu_scan_assert(spark, sql)
+        else:
+            df = spark.sql(sql)
+        is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
         if is_gpu:
-            # The `is_row_deleted` column is removed from the plan when the pushdown is enabled.
             explain_str = str(df._jdf.queryExecution().executedPlan())
-            is_row_deleted_in_plan = "__delta_internal_is_row_deleted" in explain_str
-            assert dv_predicate_pushdown != is_row_deleted_in_plan
+            if is_databricks173_or_later():
+                if dv_predicate_pushdown:
+                    assert "__delta_internal_is_row_deleted" not in explain_str
+                    assert "_databricks_internal_edge_computed_column_skip_row" not in explain_str
+            else:
+                # The `is_row_deleted` column is removed from the plan when the pushdown is enabled.
+                is_row_deleted_in_plan = "__delta_internal_is_row_deleted" in explain_str
+                assert dv_predicate_pushdown != is_row_deleted_in_plan
         return df
 
-    with_cpu_session(create_delta)
-    assert_gpu_and_cpu_are_equal_collect(read_table, conf={'spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled': dv_predicate_pushdown})
+    with_cpu_session(create_delta, conf=conf)
+    if is_databricks173_or_later() and not dv_predicate_pushdown:
+        assert_gpu_fallback_collect(read_table, "FileSourceScanExec", conf=conf)
+    else:
+        assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
 
 
 @allow_non_gpu(*delta_meta_allow)


### PR DESCRIPTION

Contributes to  https://github.com/NVIDIA/spark-rapids/issues/14696

### Description

Port of NVIDIA/spark-rapids#14761 for the DBR 17.3 Delta shim.

This updates the DBR 17.3 Delta DV predicate pushdown handling to:
- remove deletion-vector skip-row predicates from `dataFilters` when the hidden skip-row column is pruned from scan output
- recognize both GPU and CPU predicate forms produced in DBR 17.3
- handle DBR 17.3 skip-row comparisons against both zero and false literals

The Delta metadata-column integration test was also updated to cover DBR 17.3 in the existing test - `test_delta_filter_out_metadata_col`

The above test passed on DB-17.3:
```
========= 2 passed, 39927 deselected, 124 warnings in 93.88s (0:01:33) =========

```

Performance benchmarks will be done later - https://github.com/NVIDIA/spark-rapids/issues/14715

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required
