### PR TITLE
Optimize null-restore sequence in cast struct to json

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1125,15 +1125,10 @@ object GpuCast {
                   attrColumns += attrValue.incRefCount()
             }
             // now concatenate
-            val jsonAttr = withResource(Scalar.fromString("")) { emptyString =>
-              ColumnVector.stringConcatenate(emptyString, emptyString, attrColumns.toArray)
-            }
             // add an empty string or the attribute
-            withResource(jsonAttr) { _ =>
-              withResource(cv.isNull) { isNull =>
-                withResource(Scalar.fromNull(DType.STRING)) { nullScalar =>
-                  isNull.ifElse(nullScalar, jsonAttr)
-                }
+            withResource(Scalar.fromString("")) { emptyString =>
+              withResource(Scalar.fromNull(DType.STRING)) { nullScalar =>
+                ColumnVector.stringConcatenate(emptyString, nullScalar, attrColumns.toArray)
               }
             }
           } else {


### PR DESCRIPTION
Contributes to #14588.

### Description

The JSON path in `castStructToJsonString` originally concatenates an attribute with an empty null replacement, then restores child nulls with `isNull` / `ifElse`. This change instead passes a null `narep` into `stringConcatenate`, so that cuDF will propagate nulls directly without the extra kernels. This is covered by existing `test_structs_to_json` tests.

#### Benchmark

##### Nanobenchmark

Isolating the rewritten block in a nanobenchmark shows 2.5x speedup.

<details>
<summary>json attribute nanobenchmark</summary>

```scala
import ai.rapids.cudf.{ColumnVector, Cuda, DType, Rmm, RmmAllocationMode, Scalar}

object GpuCastJsonNullConcatBench {
  val NumRows = 100000
  val Warmup = 5
  val Measured = 20

  def main(args: Array[String]): Unit = {
    Rmm.initialize(RmmAllocationMode.POOL, null, Cuda.memGetInfo().free / 2 & ~255L)

    withResource(buildStringCol(NumRows)) { jsonValue =>
      withResource(Scalar.fromString("\"a\"")) { name =>
        withResource(Scalar.fromString(":")) { colon =>
          withResource(Scalar.fromString("")) { empty =>
            withResource(ColumnVector.fromScalar(name, NumRows)) { nameCol =>
              withResource(ColumnVector.fromScalar(colon, NumRows)) { colonCol =>
                for (_ <- 0 until Warmup) {
                  jsonAttributeBase(jsonValue, nameCol, colonCol, empty).close()
                  jsonAttributeNew(jsonValue, nameCol, colonCol, empty).close()
                }
                val timesBase = (0 until Measured).map { _ =>
                  val t = System.nanoTime()
                  jsonAttributeBase(jsonValue, nameCol, colonCol, empty).close()
                  System.nanoTime() - t
                }
                val timesNew = (0 until Measured).map { _ =>
                  val t = System.nanoTime()
                  jsonAttributeNew(jsonValue, nameCol, colonCol, empty).close()
                  System.nanoTime() - t
                }
                println(f"BASE median: ${timesBase.sorted.apply(Measured / 2) / 1e6}%.3f ms")
                println(f"NEW  median: ${timesNew.sorted.apply(Measured / 2) / 1e6}%.3f ms")
              }
            }
          }
        }
      }
    }
  }

  // Pre-change castStructToJsonString attribute pipeline for ignoreNullFieldsInStructs=true:
  // concatenate with empty null replacement, then restore child nulls with isNull + ifElse.
  def jsonAttributeBase(
      jsonValue: ColumnVector,
      nameCol: ColumnVector,
      colonCol: ColumnVector,
      empty: Scalar): ColumnVector = {
    val jsonAttr = ColumnVector.stringConcatenate(empty, empty, Array(nameCol, colonCol, jsonValue))
    withResource(jsonAttr) { _ =>
      withResource(jsonValue.isNull) { isNull =>
        withResource(Scalar.fromNull(DType.STRING)) { nullString =>
          isNull.ifElse(nullString, jsonAttr)
        }
      }
    }
  }

  // Let stringConcatenate propagate nulls from jsonValue instead of restoring them afterward.
  def jsonAttributeNew(
      jsonValue: ColumnVector,
      nameCol: ColumnVector,
      colonCol: ColumnVector,
      empty: Scalar): ColumnVector = {
    withResource(Scalar.fromNull(DType.STRING)) { nullString =>
      ColumnVector.stringConcatenate(empty, nullString, Array(nameCol, colonCol, jsonValue))
    }
  }

  // ~25% nulls, rest JSON-ready string values.
  def buildStringCol(n: Int): ColumnVector = {
    val arr = Array.tabulate(n)(i => if (i % 4 == 0) null else f"v$i%05d")
    ColumnVector.fromStrings(arr: _*)
  }

  def withResource[T <: AutoCloseable, R](r: T)(f: T => R): R =
    try f(r) finally if (r != null) r.close()
}
```

</details>

```
BASE median: 0.177 ms
NEW  median: 0.070 ms
```

##### Spark benchmark

An end-to-end benchmark of `to_json` shows 1.12-1.13x speedup.

```bash
spark-shell \
  --master local[*] \
  --conf spark.driver.memory=16g \
  --conf spark.sql.shuffle.partitions=8 <<'EOF'
import org.apache.spark.sql.functions._

val rows = sys.env.getOrElse("BENCH_ROWS", "5000000").toLong
val fields = sys.env.getOrElse("BENCH_FIELDS", "16").toInt
val out = "/tmp/spark-rapids-json-bench/json_data"
val cols = (0 until fields).map { i =>
  when(((col("id") + lit(i)) % 4) === 0, lit(null).cast("long"))
    .otherwise(col("id") + lit(i))
    .alias(s"f$i")
}
val df = spark.range(rows).select(struct(cols: _*).alias("s"))
df.write.mode("overwrite").parquet(out)
println(s"generated rows=$rows fields=$fields path=$out")
:quit
EOF
```

```bash
cat <<'EOF' | spark-shell \
  --master local[*] \
  --jars "$JAR" \
  --conf spark.driver.memory=16g \
  --conf spark.plugins=com.nvidia.spark.SQLPlugin \
  --conf spark.rapids.sql.expression.StructsToJson=true \
  --conf spark.rapids.sql.explain=NONE \
  --conf spark.sql.files.maxPartitionBytes=256MB \
  --conf spark.sql.shuffle.partitions=8
import org.apache.spark.sql.functions._

val path = "/tmp/spark-rapids-json-bench/json_data"
val warmup = 2
val measured = 5
val df = spark.read.parquet(path)
def benchQuery = {
  val projected = df.select(to_json(col("s"), Map("ignoreNullFields" -> "true")).alias("j"))
  projected.agg(sum(length(col("j"))).alias("total"))
}
for (_ <- 0 until warmup) benchQuery.collect()
val times = (1 to measured).map { i =>
  val t = System.nanoTime()
  val res = benchQuery.collect().head.getLong(0)
  val ms = (System.nanoTime() - t) / 1e6
  println(f"run$i: $ms%.1f ms result=$res")
  ms
}
println(f"median: ${times.sorted.apply(measured / 2)}%.1f ms")
:quit
EOF
```

| Build | Runs (ms) | Median |
| --- | --- | ---: |
| Baseline | 1029.9, 877.0, 748.1, 911.4, 1034.0 | 911.4 ms |
| Optimized | 817.2, 818.7, 660.8, 937.9, 743.6 | 817.2 ms |

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [X] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [X] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
