### PR TITLE
[AutoSparkUT] Fix regex complexity estimator overflow

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexComplexityEstimator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexComplexityEstimator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,54 +18,74 @@ package com.nvidia.spark.rapids
 import org.apache.spark.sql.types.DataTypes
 
 object RegexComplexityEstimator {
-  private def countStates(regex: RegexAST): Int = {
+  private def saturatedAdd(left: Long, right: Long): Long = {
+    if (Long.MaxValue - left < right) {
+      Long.MaxValue
+    } else {
+      left + right
+    }
+  }
+
+  private def saturatedMultiply(left: Long, right: Long): Long = {
+    if (left == 0L || right == 0L) {
+      0L
+    } else if (left > Long.MaxValue / right) {
+      Long.MaxValue
+    } else {
+      left * right
+    }
+  }
+
+  private def countStates(regex: RegexAST): Long = {
     regex match {
       case RegexSequence(parts) =>
-        parts.map(countStates).sum
+        parts.foldLeft(0L) { (total, part) =>
+          saturatedAdd(total, countStates(part))
+        }
       case RegexGroup(true, term, _) =>
-        1 + countStates(term)
+        saturatedAdd(1L, countStates(term))
       case RegexGroup(false, term, _) =>
         countStates(term)
       case RegexCharacterClass(_, _) =>
-        1
+        1L
       case RegexChoice(left, right) =>
-        countStates(left) + countStates(right)
+        saturatedAdd(countStates(left), countStates(right))
       case RegexRepetition(term, QuantifierFixedLength(length)) =>
-        length * countStates(term)
+        saturatedMultiply(length.toLong, countStates(term))
       case RegexRepetition(term, SimpleQuantifier(ch)) =>
         ch match {
           case '*' =>
             countStates(term)
           case '+' =>
-            1 + countStates(term)
+            saturatedAdd(1L, countStates(term))
           case '?' =>
-            1 + countStates(term)
+            saturatedAdd(1L, countStates(term))
         }
       case RegexRepetition(term, QuantifierVariableLength(minLength, maxLengthOption)) =>
         maxLengthOption match {
           case Some(maxLength) =>
-            maxLength * countStates(term)
+            saturatedMultiply(maxLength.toLong, countStates(term))
           case None =>
-            minLength.max(1) * countStates(term)
+            saturatedMultiply(minLength.max(1).toLong, countStates(term))
         }
       case RegexChar(_) | RegexEscaped(_) | RegexHexDigit(_) | RegexOctalChar(_) =>
-        1
+        1L
       case _ =>
-        0
+        0L
     }
   }
 
-  private def estimateGpuMemory(numStates: Int, desiredBatchSizeBytes: Long): Long = {
+  private def estimateGpuMemory(numStates: Long, desiredBatchSizeBytes: Long): Long = {
     val numRows = GpuBatchUtils.estimateRowCount(
       desiredBatchSizeBytes, DataTypes.StringType.defaultSize, 1)
-    
+
     // cuDF requests num_instructions * num_threads * 2 when allocating the memory on the device
     // (ignoring memory alignment). We are trying to reproduce that calculation here:
-    numStates * numRows * 2
+    saturatedMultiply(saturatedMultiply(numStates, numRows.toLong), 2L)
   }
 
   def isValid(conf: RapidsConf, regex: RegexAST): Boolean = {
-    val numStates = countStates(regex) 
+    val numStates = countStates(regex)
     estimateGpuMemory(numStates, conf.gpuTargetBatchSizeBytes) <= conf.maxRegExpStateMemory
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexComplexityEstimator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexComplexityEstimator.scala
@@ -18,7 +18,14 @@ package com.nvidia.spark.rapids
 import org.apache.spark.sql.types.DataTypes
 
 object RegexComplexityEstimator {
+  private def requireNonNegative(name: String, value: Long): Unit = {
+    require(value >= 0L, s"$name must be non-negative, got: $value")
+  }
+
+  // Saturating arithmetic for non-negative state and memory estimates.
   private def saturatedAdd(left: Long, right: Long): Long = {
+    requireNonNegative("left", left)
+    requireNonNegative("right", right)
     if (Long.MaxValue - left < right) {
       Long.MaxValue
     } else {
@@ -27,6 +34,8 @@ object RegexComplexityEstimator {
   }
 
   private def saturatedMultiply(left: Long, right: Long): Long = {
+    requireNonNegative("left", left)
+    requireNonNegative("right", right)
     if (left == 0L || right == 0L) {
       0L
     } else if (left > Long.MaxValue / right) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegexComplexityEstimatorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegexComplexityEstimatorSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class RegexComplexityEstimatorSuite extends AnyFunSuite {
+  private val conf = new RapidsConf(Map.empty[String, String])
+
+  private def isValid(pattern: String): Boolean = {
+    val ast = new RegexParser(pattern).parse()
+    RegexComplexityEstimator.isValid(conf, ast)
+  }
+
+  test("reject regex patterns whose state memory estimate overflows Int arithmetic") {
+    Seq(
+      "a{65536}{65536}",
+      "a{1073741824}",
+      "(.){65536}{32768}",
+      "a{2147483647}{2147483647}{2147483647}"
+    ).foreach { pattern =>
+      withClue(s"$pattern should exceed the default regex state memory limit") {
+        assert(!isValid(pattern))
+      }
+    }
+  }
+
+  test("accept regex patterns below the default state memory limit") {
+    assert(isValid("a{2}"))
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegexComplexityEstimatorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegexComplexityEstimatorSuite.scala
@@ -25,7 +25,7 @@ class RegexComplexityEstimatorSuite extends AnyFunSuite {
     RegexComplexityEstimator.isValid(conf, ast)
   }
 
-  test("reject regex patterns whose state memory estimate overflows Int arithmetic") {
+  test("reject regex patterns whose state memory estimate requires saturating arithmetic") {
     Seq(
       "a{65536}{65536}",
       "a{1073741824}",


### PR DESCRIPTION
Closes #14749

## Summary
- Count regex states with `Long` and saturating arithmetic so large quantifiers cannot wrap the memory estimate below the configured limit.
- Use branch-based saturation instead of exception-driven overflow handling for the pathological Long overflow path.
- Add focused unit coverage for Int overflow, Long overflow, and a valid small bounded repetition.

## Validation
- `mvn package -pl tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo -DwildcardSuites=com.nvidia.spark.rapids.RegexComplexityEstimatorSuite -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 -Drapids.test.gpu.minAllocFraction=0`
- Result: `Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0`
- Result: `BUILD SUCCESS`

## Performance Notes
Planning-time microbenchmark compared `origin/main` (`96038dbf9`) with this fix. Median ns/op:

| case | baseline parse+isValid | fix parse+isValid | baseline isValidOnly | fix isValidOnly |
|---|---:|---:|---:|---:|
| `literal_3` | 1389.3 | 814.9 | 67.5 | 31.5 |
| `bounded_small` | 937.5 | 850.3 | 38.9 | 29.4 |
| `alternation_repeat` | 1684.9 | 1443.8 | 152.3 | 88.9 |
| `issue_int_overflow` | 1171.4 | 1128.2 | 38.7 | 41.0 |
| `issue_long_overflow` | 1528.1 | 1424.8 | 44.4 | 47.6 |

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required