### PR TITLE
Revert "Skip GBK decode test on Dataproc Serverless (#14816)"

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -18,7 +18,7 @@ import random
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, \
     assert_gpu_sql_fallback_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_error, \
     assert_cpu_and_gpu_are_equal_collect_with_capture
-from conftest import is_databricks_runtime, get_datagen_seed, is_dataproc_serverless_runtime
+from conftest import is_databricks_runtime, get_datagen_seed
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
@@ -38,8 +38,6 @@ _gbk_edge_cases = [
     bytearray(b'Hi\xc4\xe3\xba\xc3World'), # mixed ASCII and Chinese
 ]
 
-@pytest.mark.skipif(is_dataproc_serverless_runtime(),
-                    reason="https://github.com/NVIDIA/spark-rapids/issues/14815")
 @pytest.mark.parametrize('data_gen', [
     # Random CJK ideographs encoded as GBK — tests normal decode path
     BinaryGen(min_length=0, max_length=50, min_val=0x4E00, max_val=0x9FA5, encoding='gbk'),


### PR DESCRIPTION
This reverts commit 20f4632a87cbb26f56f8ec4f641606dc7caa050e after https://github.com/NVIDIA/spark-rapids-jni/pull/4585 merged in.

Fixes https://github.com/NVIDIA/spark-rapids/issues/14815.

### Description

Add `test_string_decode_gbk` integration test back on dataproc serverless after a bug fix in jni.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
