### PR TITLE
Fix concurrent writer fallback with empty caches

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -839,8 +839,9 @@ class GpuDynamicPartitionDataConcurrentWriter(
     // Write the cached batches
     val writeFunc: (WriterIndex, WriterStatusWithBatches) => Unit =
       if (pendingBatches.nonEmpty) {
-        // Flush all the caches before going into sorted sequential write
-        writeOneCacheAndClose
+        // Flush all non-empty caches before going into sorted sequential write. Some writers may
+        // have been flushed previously, but are kept open for possible reuse during fallback.
+        writeOneCacheIfNeededAndClose
       } else {
         // Still the concurrent write, so write out only partitions that size > threshold.
         (wi, ws) =>
@@ -850,6 +851,13 @@ class GpuDynamicPartitionDataConcurrentWriter(
       }
     concurrentWriters.foreach { case (writerIdx, writerStatus) =>
       writeFunc(writerIdx, writerStatus)
+    }
+  }
+
+  private def writeOneCacheIfNeededAndClose(writerId: WriterIndex,
+      status: WriterStatusWithBatches): Unit = {
+    if (status.tableCaches.nonEmpty) {
+      writeOneCacheAndClose(writerId, status)
     }
   }
 

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -521,6 +521,27 @@ class GpuFileFormatDataWriterSuite extends AnyFunSuite with BeforeAndAfterEach {
         verify(dynamicConcurrentWriter, times(5)).newWriter(any(), any(), any())
         // 5 files written because this is the single writer mode
         verify(mockOutputWriter, times(5)).close()
+      }
+    }
+  }
+
+  test("dynamic partition concurrent data writer fallback after cache flush") {
+    resetMocksWithAndWithoutRetry {
+      val cb = buildBatchWithPartitionedCol(1, 2)
+      val cb2 = buildBatchWithPartitionedCol(1, 2, 3)
+      val cbs = Seq(spy(cb), spy(cb2))
+      withColumnarBatchesVerifyClosed(cbs) {
+        // Force the first batch to flush the two open writer caches. The second batch then hits
+        // the writer limit and falls back, so previously flushed empty caches must be skipped.
+        when(mockJobDescription.concurrentWriterPartitionFlushSize).thenReturn(1)
+        when(mockJobDescription.maxRecordsPerFile).thenReturn(0)
+        val dynamicConcurrentWriter =
+          prepareDynamicPartitionConcurrentWriter(maxWriters = 2, batchSize = 1)
+        dynamicConcurrentWriter.writeWithIterator(cbs.iterator)
+        dynamicConcurrentWriter.commit()
+
+        verify(mockOutputWriter, times(5))
+            .writeSpillableAndClose(any())
       }
     }
   }


### PR DESCRIPTION
Fixes N/A (no public issue).

### Description

This fixes a concurrent dynamic partition writer fallback path where a writer can already have had its cached batches flushed by the partition flush threshold, while the writer remains registered for possible fallback reuse and cleanup.

When fallback begins, the previous code attempted to flush every registered writer through `writeOneCacheAndClose`, which asserts that `tableCaches` is non-empty. That assertion is valid for actual cache writes, but it is too strict for already-flushed writers that have no remaining cached batches.

The change adds a small guard in the fallback flush path so only writers with non-empty caches are flushed. Empty-cache writers stay registered for fallback reuse and cleanup, but no longer trip the assertion.

The PR also adds a regression test that forces the sequence:

1. first batch opens two partition writers and flushes their caches with a very small concurrent writer partition flush threshold
2. second batch hits the writer limit and enters fallback
3. fallback skips the already-flushed empty caches and completes the write

Validation:

Validated with a minimized dynamic partition ORC write on an EMR GPU cluster using Spark `3.5.6-amzn-1`. The run exercised the GPU write path with `spark.sql.maxConcurrentOutputFileWriters=2` and a small concurrent writer partition flush threshold, completed successfully, and produced partitioned ORC output without the assertion.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
