### PR TITLE
Fall back to CPU for Iceberg partition transforms sourcing nested fields

### DIFF
--- a/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/package.scala
+++ b/iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,17 @@ import scala.collection.JavaConverters._
 import org.apache.iceberg.Schema
 
 package object iceberg {
-  def fieldIndex(schema: Schema, fieldId: Int): Int = {
+  def findFieldIndex(schema: Schema, fieldId: Int): Option[Int] = {
     val idx = schema
       .columns()
       .asScala
       .indexWhere(_.fieldId() == fieldId)
-    if (idx == -1) {
+    if (idx == -1) None else Some(idx)
+  }
+
+  def fieldIndex(schema: Schema, fieldId: Int): Int = {
+    findFieldIndex(schema, fieldId).getOrElse {
       throw new IllegalArgumentException(s"Field id $fieldId not found in schema")
-    } else {
-      idx
     }
   }
 }

--- a/iceberg/common/src/main/scala/org/apache/iceberg/spark/functions/transforms.scala
+++ b/iceberg/common/src/main/scala/org/apache/iceberg/spark/functions/transforms.scala
@@ -18,7 +18,7 @@ package org.apache.iceberg.spark.functions
 
 import scala.util.Try
 
-import com.nvidia.spark.rapids.iceberg.fieldIndex
+import com.nvidia.spark.rapids.iceberg.findFieldIndex
 import org.apache.iceberg.Schema
 import org.apache.iceberg.transforms.Transform
 
@@ -100,9 +100,16 @@ object GpuTransform {
 
 case class GpuFieldTransform(sourceFieldId: Int, transform: GpuTransform) {
   def supports(inputType: StructType, inputSchema: Schema): Boolean = {
-    val fieldIdx = fieldIndex(inputSchema, sourceFieldId)
-    val sparkField = inputType.fields(fieldIdx)
-    transform.support(sparkField.dataType, sparkField.nullable)
+    // Iceberg allows partition source fields to reference nested-leaf field ids
+    // (e.g. `bucket(4, contact.email)`). Those ids do not appear in
+    // `schema.columns()` (top level only), so an Option-returning lookup lets
+    // us refuse GPU and fall back to CPU instead of throwing.
+    findFieldIndex(inputSchema, sourceFieldId) match {
+      case Some(idx) =>
+        val sparkField = inputType.fields(idx)
+        transform.support(sparkField.dataType, sparkField.nullable)
+      case None => false
+    }
   }
 }
 

--- a/integration_tests/src/main/python/iceberg/iceberg_append_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_append_test.py
@@ -274,6 +274,42 @@ def test_insert_into_table_unsupported_file_format_fallback(
 @ignore_order(local=True)
 @allow_non_gpu('AppendDataExec', 'ShuffleExchangeExec', 'ProjectExec')
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
+@pytest.mark.parametrize("partition_col_sql", [
+    pytest.param("bucket(4, contact.email)", id="bucket_nested_struct_field"),
+    pytest.param("truncate(3, contact.email)", id="truncate_nested_struct_field"),
+    pytest.param("contact.email", id="identity_nested_struct_field"),
+], )
+def test_insert_into_table_nested_partition_source_fallback(
+        spark_tmp_table_factory, partition_col_sql):
+    table_name = get_full_table_name(spark_tmp_table_factory)
+    table_prop = _build_tblprops({"format-version": "2"})
+    props_sql = ", ".join(f"'{k}' = '{v}'" for k, v in table_prop.items())
+
+    def create_table(spark):
+        spark.sql(
+            f"CREATE TABLE {table_name} "
+            f"(id BIGINT, contact STRUCT<email: STRING, phone: STRING>) "
+            f"USING ICEBERG "
+            f"PARTITIONED BY ({partition_col_sql}) "
+            f"TBLPROPERTIES ({props_sql})")
+
+    with_cpu_session(create_table)
+
+    def insert_data(spark):
+        return spark.sql(
+            f"INSERT INTO {table_name} VALUES "
+            f"(1, named_struct('email', 'a@x.test', 'phone', '111')), "
+            f"(2, named_struct('email', 'b@y.test', 'phone', '222'))")
+
+    assert_gpu_fallback_collect(lambda spark: insert_data(spark),
+                                "AppendDataExec",
+                                conf=iceberg_write_enabled_conf)
+
+
+@iceberg
+@ignore_order(local=True)
+@allow_non_gpu('AppendDataExec', 'ShuffleExchangeExec', 'ProjectExec')
+@pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
 @pytest.mark.parametrize("conf_key", ["spark.rapids.sql.format.iceberg.enabled",
                                       "spark.rapids.sql.format.iceberg.write.enabled"],
                          ids=lambda x: f"{x}=False")


### PR DESCRIPTION
Fixes #14858.

### Description

When an Iceberg partition spec sources a nested struct field (e.g. `bucket(4, contact.email)` where `contact` is `STRUCT<email STRING, phone STRING>`), the spark-rapids plugin threw `IllegalArgumentException: Field id <N> not found in schema` during plan tagging instead of marking the operator `willNotWorkOnGpu(...)` and falling back to CPU. The exception propagated through `GpuOverrideUtil.tryOverride` → `QueryExecution.executedPlan$lzycompute` and surfaced as a Python-side query failure.

**User-facing change:** queries that write to an Iceberg table partitioned by a transform over a nested field now run on CPU (silent fallback) instead of failing. No new configuration. Adding native GPU support for nested partition source fields is a separate feature, not in this PR.

**Technical change:**
- `iceberg/common/src/main/scala/com/nvidia/spark/rapids/iceberg/package.scala` — added a non-throwing `findFieldIndex(schema, fieldId): Option[Int]`. The existing throwing `fieldIndex` now delegates to it, preserving its contract for callers that have already validated the field exists in the schema (`GpuIcebergPartitioner`, `GpuDeleteFilter`).
- `iceberg/common/src/main/scala/org/apache/iceberg/spark/functions/transforms.scala` — `GpuFieldTransform.supports` switched to `findFieldIndex`. When the source field id is not in `schema.columns()` (e.g. a nested-leaf field id), it returns `false`, letting `GpuSparkWrite.tagForGpuWrite` call `willNotWorkOnGpu(...)`.

**Why a fallback, not full support:** The Iceberg `Schema.findField(id)` lookup *can* locate the nested field, but applying a bucket/truncate/identity transform over a nested column on the GPU requires extracting the value at write time, which isn't wired up in `GpuIcebergPartitioner`. Falling back to CPU is the correct minimum-viable fix that matches user expectations of "GPU plugin should never fail a query because of an unsupported pattern."

**Tests:**
- Added `test_insert_into_table_nested_partition_source_fallback` in `integration_tests/src/main/python/iceberg/iceberg_append_test.py`, parametrized over `bucket(4, contact.email)`, `truncate(3, contact.email)`, and identity `contact.email`. Asserts CPU fallback via `assert_gpu_fallback_collect("AppendDataExec", ...)`.
- Verified locally: 3/3 cases pass against `iceberg-spark-runtime-3.5_2.12:1.10.1` on Spark 3.5.6 (buildver 356).

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required