### PR TITLE
[BUG] Fix GpuRegExpUtils.backrefConversion greedy digit consumption (#14743)

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -389,6 +389,23 @@ def test_re_replace_backrefs_idx_out_of_bounds():
         conf=_regexp_conf,
         error_message='')
 
+# `${N}` (digits inside braces) is a *named-group* reference per Java's Matcher
+# spec, which requires the name to start with a letter. Java throws on this
+# syntax, so the GPU path must fall back to CPU rather than silently normalize
+# to a numeric backref. (Spark's SQL parser substitutes `${...}` itself, so we
+# disable variable substitution to make the replacement string reach the
+# expression evaluator unchanged.)
+@allow_non_gpu('ProjectExec', 'RegExpReplace')
+def test_re_replace_backrefs_braced_numeric_unsupported():
+    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
+    # Single-digit and multi-digit numeric names both exercise the consumeInt
+    # read loop and the same `Some(_)` branch in parseBackrefOrLiteralDollar.
+    assert_gpu_and_cpu_error(lambda spark: unary_op_df(spark, gen).selectExpr(
+        'REGEXP_REPLACE(a, "(T)(E)(S)(T)", "[${2}]")',
+        'REGEXP_REPLACE(a, "(T)(E)(S)(T)", "[${12}]")').collect(),
+        conf={**_regexp_conf, 'spark.sql.variable.substitute': 'false'},
+        error_message='')
+
 def test_re_replace_backrefs_escaped():
     gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -347,9 +347,15 @@ def test_re_replace_backrefs():
             'REGEXP_REPLACE(a, "(T)(E)", "$12")',
             'REGEXP_REPLACE(a, "(T)(E)", "x$12y")',
             'REGEXP_REPLACE(a, "(T)(E)", "$123$2")',
-            # Uses 12 original capture groups plus the extra capture group inserted by
-            # line-anchor rewriting; the generated $13 must not be parsed as $1 + "3".
-            'REGEXP_REPLACE(a, "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$", "$123$2")'
+            # 12 user groups plus a trailing line-anchor `$`. Two distinct boundary
+            # checks:
+            # 1. User `$123$2` -> `$12` + literal `3` + `$2`; the user count being 12
+            #    (not the transpiled 13) is enough for the greedy-with-backoff to back off.
+            # 2. User `$13` -> `$1` + literal `3` (NOT a reference to the transpiler's
+            #    internally-generated 13th group, which exists only after line-anchor
+            #    rewriting and must stay invisible to user-replacement parsing).
+            'REGEXP_REPLACE(a, "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$", "$123$2")',
+            'REGEXP_REPLACE(a, "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$", "$13")'
         ),
         conf=_regexp_conf)
 

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -330,7 +330,8 @@ def test_re_replace_escaped_chars():
 
 
 def test_re_replace_backrefs():
-    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}TEST')
+    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}TEST') \
+        .with_special_case("TESTTESTTEST")
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, gen).selectExpr(
             'REGEXP_REPLACE(a, "(TEST)", "$1")',
@@ -345,7 +346,10 @@ def test_re_replace_backrefs():
             # group 12 (which would error in cuDF).
             'REGEXP_REPLACE(a, "(T)(E)", "$12")',
             'REGEXP_REPLACE(a, "(T)(E)", "x$12y")',
-            'REGEXP_REPLACE(a, "(T)(E)", "$123$2")'
+            'REGEXP_REPLACE(a, "(T)(E)", "$123$2")',
+            # Uses 12 original capture groups plus the extra capture group inserted by
+            # line-anchor rewriting; the generated $13 must not be parsed as $1 + "3".
+            'REGEXP_REPLACE(a, "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$", "$123$2")'
         ),
         conf=_regexp_conf)
 

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -339,7 +339,13 @@ def test_re_replace_backrefs():
             'REGEXP_REPLACE(a, "(T)[a-z]+(T)", "[$2][$1][$0]")',
             'REGEXP_REPLACE(a, "([0-9]+)(T)[a-z]+(T)", "[$3][$2][$1]")',
             'REGEXP_REPLACE(a, "(.)([0-9]+TEST)", "$0 $1 $2")',
-            'REGEXP_REPLACE(a, "(TESTT)", "\\0 \\1")'  # no match
+            'REGEXP_REPLACE(a, "(TESTT)", "\\0 \\1")',  # no match
+            # issue-14743: greedy-with-backoff per Java's `Matcher.appendReplacement`.
+            # "$12" on a 2-group pattern must be parsed as "$1" + literal "2", not as
+            # group 12 (which would error in cuDF).
+            'REGEXP_REPLACE(a, "(T)(E)", "$12")',
+            'REGEXP_REPLACE(a, "(T)(E)", "x$12y")',
+            'REGEXP_REPLACE(a, "(T)(E)", "$123$2")'
         ),
         conf=_regexp_conf)
 

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -389,17 +389,11 @@ def test_re_replace_backrefs_idx_out_of_bounds():
         conf=_regexp_conf,
         error_message='')
 
-# `${N}` (digits inside braces) is a *named-group* reference per Java's Matcher
-# spec, which requires the name to start with a letter. Java throws on this
-# syntax, so the GPU path must fall back to CPU rather than silently normalize
-# to a numeric backref. (Spark's SQL parser substitutes `${...}` itself, so we
-# disable variable substitution to make the replacement string reach the
-# expression evaluator unchanged.)
 @allow_non_gpu('ProjectExec', 'RegExpReplace')
 def test_re_replace_backrefs_braced_numeric_unsupported():
     gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
-    # Single-digit and multi-digit numeric names both exercise the consumeInt
-    # read loop and the same `Some(_)` branch in parseBackrefOrLiteralDollar.
+    # variable.substitute=false keeps `${N}` literal so it reaches RegExpReplace
+    # instead of being expanded by Spark's SQL parser.
     assert_gpu_and_cpu_error(lambda spark: unary_op_df(spark, gen).selectExpr(
         'REGEXP_REPLACE(a, "(T)(E)(S)(T)", "[${2}]")',
         'REGEXP_REPLACE(a, "(T)(E)(S)(T)", "[${12}]")').collect(),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -55,10 +55,16 @@ class GpuRegExpReplaceMeta(
           val (pat, repl) =
               new CudfRegexTranspiler(RegexReplaceMode).getTranspiledAST(s.toString, None,
                   replacement)
+          // Use the user's Java pattern group count for the greedy-with-backoff parse so that
+          // user-authored backref tokens (e.g. `$13` on a 12-group pattern) follow Java's
+          // `Matcher.appendReplacement` spec. The transpiler emits internally-generated
+          // backrefs (e.g. the line-anchor rewrite's captured terminator) in braced
+          // `${N}` form, which `backrefConversion` passes through verbatim and which the
+          // user count therefore does not need to cover.
+          val userNumCaptureGroups =
+            java.util.regex.Pattern.compile(s.toString).matcher("").groupCount()
           repl.map { r =>
-            // Use the rewritten replacement's group count because replace-mode rewrites can add
-            // capture groups and corresponding backrefs, such as line-anchor handling.
-            GpuRegExpUtils.backrefConversion(r.toRegexString, r.numCaptureGroups)
+            GpuRegExpUtils.backrefConversion(r.toRegexString, userNumCaptureGroups)
           }.foreach {
               case (hasBackref, convertedRep) =>
                 containsBackref = hasBackref

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -55,15 +55,10 @@ class GpuRegExpReplaceMeta(
           val (pat, repl) =
               new CudfRegexTranspiler(RegexReplaceMode).getTranspiledAST(s.toString, None,
                   replacement)
-          // Compute the actual capture-group count of the Java pattern so that
-          // `backrefConversion` can follow Java's greedy-with-backoff rule:
-          // `$N` where N's running value would exceed the group count is interpreted as
-          // `$<longest valid prefix>` followed by the remaining digits as literals
-          // (see issue #14743).
-          val numCaptureGroups =
-            java.util.regex.Pattern.compile(s.toString).matcher("").groupCount()
           repl.map { r =>
-            GpuRegExpUtils.backrefConversion(r.toRegexString, numCaptureGroups)
+            // Use the rewritten replacement's group count because replace-mode rewrites can add
+            // capture groups and corresponding backrefs, such as line-anchor handling.
+            GpuRegExpUtils.backrefConversion(r.toRegexString, r.numCaptureGroups)
           }.foreach {
               case (hasBackref, convertedRep) =>
                 containsBackref = hasBackref

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,16 @@ class GpuRegExpReplaceMeta(
           val (pat, repl) =
               new CudfRegexTranspiler(RegexReplaceMode).getTranspiledAST(s.toString, None,
                   replacement)
-          repl.map { r => GpuRegExpUtils.backrefConversion(r.toRegexString) }.foreach {
+          // Compute the actual capture-group count of the Java pattern so that
+          // `backrefConversion` can follow Java's greedy-with-backoff rule:
+          // `$N` where N's running value would exceed the group count is interpreted as
+          // `$<longest valid prefix>` followed by the remaining digits as literals
+          // (see issue #14743).
+          val numCaptureGroups =
+            java.util.regex.Pattern.compile(s.toString).matcher("").groupCount()
+          repl.map { r =>
+            GpuRegExpUtils.backrefConversion(r.toRegexString, numCaptureGroups)
+          }.foreach {
               case (hasBackref, convertedRep) =>
                 containsBackref = hasBackref
                 replacement = Some(GpuRegExpUtils.unescapeReplaceString(convertedRep))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -390,8 +390,19 @@ class RegexParser(pattern: String) {
         if (peek().contains('}')) {
           consumeExpected('}')
           num match {
-            case Some(n) =>
-              RegexBackref(n)
+            case Some(_) =>
+              // Java's Matcher.appendReplacement treats `${...}` as a *named*-group
+              // reference. Its parser accepts ASCII letters and digits in the name
+              // body but rejects names whose first character is a digit
+              // (`if (ASCII.isDigit(gname.charAt(0))) throw IllegalArgumentException`).
+              // All-digit names like `${12}` therefore throw on CPU. We must not
+              // silently normalize the user-authored `${N}` to `$N`, which would let
+              // cuDF resolve it as a numeric backref and diverge from CPU. Fall back
+              // to CPU so Java's spec applies unchanged.
+              throw new RegexUnsupportedException(
+                "Numeric `${N}` backref in replacement string is not supported on GPU " +
+                  "(Java's Matcher.appendReplacement rejects this syntax)",
+                Some(start))
             case _ =>
               treatAsLiteralDollar()
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -1949,7 +1949,11 @@ sealed case class RegexBackref(num: Int, isNew: Boolean = false) extends RegexAS
     this.position = Some(position)
   }
   override def children(): Seq[RegexAST] = Seq.empty
-  override def toRegexString: String = s"$$$num"
+  // Internally-generated backrefs (e.g. from line-anchor rewriting) are emitted in braced
+  // `${N}` form so `backrefConversion` can tell them apart from user-authored `$N` tokens
+  // and pass them through verbatim. User-authored backrefs keep the raw `$N` form so the
+  // greedy-with-backoff parser in `backrefConversion` honors the user's pattern group count.
+  override def toRegexString: String = if (isNew) s"$${$num}" else s"$$$num"
 }
 
 sealed case class RegexReplacement(parts: ListBuffer[RegexAST],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -391,14 +391,6 @@ class RegexParser(pattern: String) {
           consumeExpected('}')
           num match {
             case Some(_) =>
-              // Java's Matcher.appendReplacement treats `${...}` as a *named*-group
-              // reference. Its parser accepts ASCII letters and digits in the name
-              // body but rejects names whose first character is a digit
-              // (`if (ASCII.isDigit(gname.charAt(0))) throw IllegalArgumentException`).
-              // All-digit names like `${12}` therefore throw on CPU. We must not
-              // silently normalize the user-authored `${N}` to `$N`, which would let
-              // cuDF resolve it as a numeric backref and diverge from CPU. Fall back
-              // to CPU so Java's spec applies unchanged.
               throw new RegexUnsupportedException(
                 "Numeric `${N}` backref in replacement string is not supported on GPU " +
                   "(Java's Matcher.appendReplacement rejects this syntax)",

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1095,9 +1095,26 @@ object GpuRegExpUtils {
   def backrefConversion(rep: String, numCaptureGroups: Int): (Boolean, String) = {
     val b = new StringBuilder
     var i = 0
+    var hasBracedBackref = false
     while (i < rep.length) {
-      // match $group_index or \group_index
-      if (Seq('$', '\\').contains(rep.charAt(i))
+      // Pass through already-braced `${N}` tokens unchanged. These are emitted by the
+      // transpiler for internally-generated backrefs (e.g. the line-anchor rewrite's
+      // captured line terminator) and must not be re-parsed against the user pattern's
+      // group count, which would mis-resolve them when the user count is less than the
+      // generated index.
+      if (rep.charAt(i) == '$' && i + 2 < rep.length && rep.charAt(i + 1) == '{') {
+        val close = rep.indexOf('}', i + 2)
+        val allDigits = close > i + 2 &&
+          (i + 2 until close).forall(k => rep.charAt(k).isDigit)
+        if (allDigits) {
+          b.append(rep.substring(i, close + 1))
+          hasBracedBackref = true
+          i = close + 1
+        } else {
+          b.append(rep.charAt(i))
+          i += 1
+        }
+      } else if (Seq('$', '\\').contains(rep.charAt(i))
         && i + 1 < rep.length && rep.charAt(i + 1).isDigit) {
 
         // Consume digits one at a time. If the running group index would exceed the actual
@@ -1136,7 +1153,8 @@ object GpuRegExpUtils {
           i = k
         }
       } else if (rep.charAt(i) == '\\' && i + 1 < rep.length) {
-        // skip potential \$group_index or \\group_index
+        // skip potential escape sequences like `\$` or `\\`; `\digit` is handled by the
+        // greedy-with-backoff branch above.
         b.append('\\').append(rep.charAt(i + 1))
         i += 2
       } else {
@@ -1146,7 +1164,9 @@ object GpuRegExpUtils {
     }
 
     val converted = b.toString
-    !rep.equals(converted) -> converted
+    // A pass-through `${N}` token does not modify the string, so equality alone would miss
+    // it; treat it as a backref so the caller routes through `stringReplaceWithBackrefs`.
+    (hasBracedBackref || !rep.equals(converted)) -> converted
   }
 
   /**

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1079,11 +1079,20 @@ object GpuRegExpUtils {
    * This method transforms above two patterns into cuDF pattern \${group_index}, except they are
    * preceded by escape character.
    *
+   * Java's `Matcher.appendReplacement` reads the digits after `$` or `\` one at a time and
+   * stops as soon as adding the next digit would make the running group index exceed the
+   * actual capture-group count; any further digits are treated as literal characters
+   * (greedy-with-backoff). When `numCaptureGroups` is negative the caller is opting out of the
+   * Java-spec check (used by tests and legacy callers), in which case we keep the original
+   * eagerly-greedy behavior so cuDF still raises on out-of-range indices.
+   *
    * @param rep replacement string
+   * @param numCaptureGroups number of capturing groups in the corresponding pattern; pass a
+   *                         negative value to disable greedy-with-backoff
    * @return A pair consists of a boolean indicating whether containing any backref and the
    *         converted replacement.
    */
-  def backrefConversion(rep: String): (Boolean, String) = {
+  def backrefConversion(rep: String, numCaptureGroups: Int): (Boolean, String) = {
     val b = new StringBuilder
     var i = 0
     while (i < rep.length) {
@@ -1091,14 +1100,41 @@ object GpuRegExpUtils {
       if (Seq('$', '\\').contains(rep.charAt(i))
         && i + 1 < rep.length && rep.charAt(i + 1).isDigit) {
 
-        b.append("${")
+        // Consume digits one at a time. If the running group index would exceed the actual
+        // capture-group count, stop and leave the remaining digits as literals. When no digit
+        // can be consumed without exceeding the count (e.g. `$5` against a 4-group pattern),
+        // fall through to the legacy eagerly-greedy path so cuDF surfaces the out-of-range
+        // error.
         var j = i + 1
-        do {
-          b.append(rep.charAt(j))
-          j += 1
-        } while (j < rep.length && rep.charAt(j).isDigit)
-        b.append("}")
-        i = j
+        var n = 0
+        val consumed = new StringBuilder
+        var stopped = false
+        while (j < rep.length && rep.charAt(j).isDigit && !stopped) {
+          val nextN = n * 10 + (rep.charAt(j) - '0')
+          if (numCaptureGroups >= 0 && nextN > numCaptureGroups) {
+            stopped = true
+          } else {
+            n = nextN
+            consumed.append(rep.charAt(j))
+            j += 1
+          }
+        }
+        if (consumed.nonEmpty) {
+          b.append("${").append(consumed).append("}")
+          i = j
+        } else {
+          // Legacy path: greedily swallow every digit so cuDF errors on the out-of-range
+          // index (preserves existing behavior covered by
+          // `test_re_replace_backrefs_idx_out_of_bounds`).
+          b.append("${")
+          var k = i + 1
+          do {
+            b.append(rep.charAt(k))
+            k += 1
+          } while (k < rep.length && rep.charAt(k).isDigit)
+          b.append("}")
+          i = k
+        }
       } else if (rep.charAt(i) == '\\' && i + 1 < rep.length) {
         // skip potential \$group_index or \\group_index
         b.append('\\').append(rep.charAt(i + 1))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -283,6 +283,22 @@ class RegularExpressionParserSuite extends AnyFunSuite {
     RegexChar('$'))))
   }
   
+  test("replacement: numeric braced backref rejected (Java spec)") {
+    // Java's Matcher.appendReplacement rejects `${name}` when name starts with a
+    // digit (`if (ASCII.isDigit(gname.charAt(0))) throw IllegalArgumentException`),
+    // so we must not silently parse a user-authored braced numeric backref.
+    val brace = "$" + "{"
+    val cases = Seq(s"[${brace}2}]", s"${brace}1}", s"${brace}12}",
+        s"a${brace}3}b", s"${brace}0}")
+    for (rep <- cases) {
+      val e = intercept[RegexUnsupportedException] {
+        new RegexParser(rep).parseReplacement(4)
+      }
+      assert(e.getMessage.contains("backref in replacement string is not supported"),
+        s"unexpected message for replacement '$rep': ${e.getMessage}")
+    }
+  }
+
   private def parse(pattern: String): RegexAST = {
     new RegexParser(pattern).parse()
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -284,9 +284,6 @@ class RegularExpressionParserSuite extends AnyFunSuite {
   }
   
   test("replacement: numeric braced backref rejected (Java spec)") {
-    // Java's Matcher.appendReplacement rejects `${name}` when name starts with a
-    // digit (`if (ASCII.isDigit(gname.charAt(0))) throw IllegalArgumentException`),
-    // so we must not silently parse a user-authored braced numeric backref.
     val brace = "$" + "{"
     val cases = Seq(s"[${brace}2}]", s"${brace}1}", s"${brace}12}",
         s"a${brace}3}b", s"${brace}0}")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -1021,7 +1021,9 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
       input: Seq[String]): Array[String] = {
     val result = new Array[String](input.length)
     val replace = GpuRegExpUtils.unescapeReplaceString(replaceString)
-    val (hasBackrefs, converted) = GpuRegExpUtils.backrefConversion(replace)
+    // Pass -1 to opt out of Java-spec greedy-with-backoff; the REPLACE_STRING used by this
+    // helper contains no `$N` backrefs, so the legacy behavior is sufficient here.
+    val (hasBackrefs, converted) = GpuRegExpUtils.backrefConversion(replace, -1)
     withResource(ColumnVector.fromStrings(input: _*)) { cv =>
       val c = if (hasBackrefs) {
         cv.stringReplaceWithBackrefs(new RegexProgram(cudfPattern,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -220,6 +220,49 @@ class RegExpUtilsSuite extends AnyFunSuite {
     }
 
   }
+
+  test("issue-14743: backrefConversion greedy-with-backoff per Java spec") {
+    // (numCaptureGroups, replacement, expectedHasBackref, expectedConverted).
+    // Java's `Matcher.appendReplacement` reads digits one at a time and stops as
+    // soon as the running group index would exceed the capture-group count.
+    // Note: literal "${...}" tokens are spelled with concatenation so scalastyle
+    // doesn't flag them as missing string interpolation.
+    val open = "$" + "{"
+    val cases: Seq[(Int, String, Boolean, String)] = Seq(
+      // 2 groups, "$12": stop after "1" (because 12 > 2); remaining "2" is literal.
+      (2, "$12", true, open + "1}2"),
+      // 20 groups, "$12": both digits consumed (12 <= 20).
+      (20, "$12", true, open + "12}"),
+      // 2 groups, "$123": stop after "1"; "23" trail as literals.
+      (2, "$123", true, open + "1}23"),
+      // 2 groups, "$2": one digit consumed.
+      (2, "$2", true, open + "2}"),
+      // 0 groups, "$1": legacy path -- emit ${1} so cuDF surfaces the error.
+      (0, "$1", true, open + "1}"),
+      // Same shape with backslash backref.
+      (2, "\\12", true, open + "1}2"),
+      // No digits after `$` -- literal `$`.
+      (2, "$a", false, "$a"),
+      // `$0` is the whole-match backref and is always valid (cuDF supports group 0).
+      (2, "$0", true, open + "0}"),
+      // Numbers in the middle: "x$12y" with 2 groups -> "x${1}2y".
+      (2, "x$12y", true, "x" + open + "1}2y"),
+      // First digit alone would already exceed the count: fall back to the legacy
+      // eagerly-greedy path so cuDF errors out as before (covered by
+      // test_re_replace_backrefs_idx_out_of_bounds in regexp_test.py).
+      (4, "[$5]", true, "[" + open + "5}]"),
+      // Negative numCaptureGroups disables the greedy-with-backoff check (legacy
+      // behavior preserved for callers that don't know the group count).
+      (-1, "$12", true, open + "12}")
+    )
+    cases.foreach { case (numGroups, rep, expectedHas, expectedConv) =>
+      val (hasBackref, converted) = GpuRegExpUtils.backrefConversion(rep, numGroups)
+      assert(hasBackref == expectedHas,
+        s"hasBackref mismatch for ($numGroups, $rep): got $hasBackref, want $expectedHas")
+      assert(converted == expectedConv,
+        s"converted mismatch for ($numGroups, $rep): got '$converted', want '$expectedConv'")
+    }
+  }
 }
 
 /*

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -264,20 +264,37 @@ class RegExpUtilsSuite extends AnyFunSuite {
     }
   }
 
-  test("issue-14743: backrefConversion uses rewritten capture group count") {
+  test("issue-14743: line-anchor rewrite preserves user-vs-generated backref boundary") {
+    // A 12-group user pattern ending in line-anchor `$` causes the transpiler to append an
+    // internally-generated 13th capture group (for the captured line terminator) plus a
+    // matching backref in the replacement. The user-authored replacement tokens must be
+    // parsed against the user's 12-group count (Java spec), while the generated `$13`
+    // must round-trip to cuDF as `${13}`. The transpiler emits the generated backref in
+    // braced form so `backrefConversion` can tell the two apart from a single string.
     val open = "$" + "{"
-    val pattern = "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$"
-    val (_, replacement) = new CudfRegexTranspiler(RegexReplaceMode)
-      .getTranspiledAST(pattern, None, Some("$123$2"))
-    val rewrittenReplacement = replacement.get
+    val userPattern = "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$"
+    val userNumCaptureGroups =
+      java.util.regex.Pattern.compile(userPattern).matcher("").groupCount()
+    assert(userNumCaptureGroups == 12)
 
-    assert(rewrittenReplacement.numCaptureGroups == 13)
-    val (hasBackref, converted) =
-      GpuRegExpUtils.backrefConversion(rewrittenReplacement.toRegexString,
-        rewrittenReplacement.numCaptureGroups)
+    // Case 1: user replacement `$123$2` -> `$12` + literal `3` + `$2`, plus generated `${13}`.
+    val (_, repl1) = new CudfRegexTranspiler(RegexReplaceMode)
+      .getTranspiledAST(userPattern, None, Some("$123$2"))
+    val (has1, conv1) =
+      GpuRegExpUtils.backrefConversion(repl1.get.toRegexString, userNumCaptureGroups)
+    assert(has1)
+    assert(conv1 == open + "12}3" + open + "2}" + open + "13}")
 
-    assert(hasBackref)
-    assert(converted == open + "12}3" + open + "2}" + open + "13}")
+    // Case 2: user replacement `$13` with only 12 user groups MUST parse as `$1` + literal
+    // `3`, NOT as a reference to the internally-generated 13th group. The generated
+    // `${13}` still rides along after the user portion.
+    val (_, repl2) = new CudfRegexTranspiler(RegexReplaceMode)
+      .getTranspiledAST(userPattern, None, Some("$13"))
+    val (has2, conv2) =
+      GpuRegExpUtils.backrefConversion(repl2.get.toRegexString, userNumCaptureGroups)
+    assert(has2)
+    assert(conv2 == open + "1}3" + open + "13}",
+      s"expected user `$$13` to back off to `$${1}3`, got `$conv2`")
   }
 }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -263,6 +263,22 @@ class RegExpUtilsSuite extends AnyFunSuite {
         s"converted mismatch for ($numGroups, $rep): got '$converted', want '$expectedConv'")
     }
   }
+
+  test("issue-14743: backrefConversion uses rewritten capture group count") {
+    val open = "$" + "{"
+    val pattern = "(T)(E)(S)(T)(T)(E)(S)(T)(T)(E)(S)(T)$"
+    val (_, replacement) = new CudfRegexTranspiler(RegexReplaceMode)
+      .getTranspiledAST(pattern, None, Some("$123$2"))
+    val rewrittenReplacement = replacement.get
+
+    assert(rewrittenReplacement.numCaptureGroups == 13)
+    val (hasBackref, converted) =
+      GpuRegExpUtils.backrefConversion(rewrittenReplacement.toRegexString,
+        rewrittenReplacement.numCaptureGroups)
+
+    assert(hasBackref)
+    assert(converted == open + "12}3" + open + "2}" + open + "13}")
+  }
 }
 
 /*


### PR DESCRIPTION
Closes #14743
Contributes to #14733

## What this fixes

`GpuRegExpUtils.backrefConversion` greedily consumed every digit after a
`$` or `\` backref into the group index. So `regexp_replace(a, '([a-z]+)
([a-z]+)', '$12')` on the 2-capture-group pattern was emitted as
`${12}` to cuDF, which threw `CudfException: Group index numbers must
be in the range 0 to group count`. Java's `Matcher.appendReplacement`
reads digits one at a time and stops as soon as the running group
index would exceed the actual capture-group count, treating any
trailing digits as literal characters. The expected output is `$1`
followed by literal `"2"` -> `"foo2"`, `"hello2"`.

## Approach

Make `backrefConversion` take `numCaptureGroups` and follow Java's
greedy-with-backoff rule. The caller (`GpuRegExpReplaceMeta`) computes
the count via `java.util.regex.Pattern.compile(...).matcher("").groupCount()`,
which mirrors Java's `Matcher` semantics that the issue cites. Internal-only
signature change; the only other caller (a test helper in
`RegularExpressionTranspilerSuite`) is updated to pass `-1` (a sentinel
that disables the check, preserving its legacy behavior).

When no digit can be consumed without exceeding the count (e.g. `$5`
on a 4-group pattern), the implementation falls back to the legacy
eagerly-greedy emit so cuDF still surfaces the out-of-range error.
This preserves the existing
`test_re_replace_backrefs_idx_out_of_bounds` expectation (GPU and CPU
both error).

None - applied the suggested fix from the issue with one adjustment:
the suggested snippet was pseudocode (`return ...`); the implementation
fully spells out the digit-walking + legacy fallback while keeping the
two-channel emit (`${...}` for backrefs, literals via the outer loop).

## Tests added

- Scala unit: `com.nvidia.spark.rapids.RegExpUtilsSuite` ->
  `issue-14743: backrefConversion greedy-with-backoff per Java spec`
  (11 cases: 2/`$12`->`${1}2`, 20/`$12`->`${12}`, 2/`$123`->`${1}23`,
  2/`$2`->`${2}`, 0/`$1`->`${1}` (legacy), 2/`\12`->`${1}2`, 2/`$a`->`$a`,
  2/`$0`->`${0}`, 2/`x$12y`->`x${1}2y`, 4/`[$5]`->`[${5}]` (legacy),
  -1/`$12`->`${12}` (sentinel)).
- Python IT: `regexp_test.py::test_re_replace_backrefs` extended inline
  with three new `selectExpr` entries (`(T)(E)` with `$12`, `x$12y`,
  `$123$2`) per repo convention (no new test function).

## Local validation

Spark 3.3.0, GPU (NVIDIA, 48.5 GB free), `-Dbuildver=330`.

Scala suite (`RegExpUtilsSuite` + `RegularExpressionTranspilerSuite`):

```
Tests: succeeded 96, failed 0, canceled 6, ignored 0, pending 0
```

Python IT (`test_re_replace_backrefs`, `test_re_replace_backrefs_idx_out_of_bounds`,
`test_re_replace_backrefs_escaped`):

```
3 passed, 39865 deselected, 17 warnings in 11.62s
```

End-to-end repro re-run on the patched dist JAR (`SparkSession` with
`spark.rapids.sql.enabled=true`, `regexp_replace(a, '([a-z]+) ([a-z]+)',
'$12')` on `[("foo bar",), ("hello world",)]`): GPU output
`['foo2', 'hello2']` equals CPU `['foo2', 'hello2']`. Baseline run on
the same code without the fix throws `CudfException: Group index
numbers must be in the range 0 to group count`.

## CI checklist

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
