### PR TITLE
Fix async output write with pipe-backed cloud streams

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStream.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStream.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,13 @@ object AsyncOutputStream {
       openFn: Callable[OutputStream],
       trafficController: TrafficController,
       statsTrackers: Seq[ColumnarWriteTaskStatsTracker]): AsyncOutputStream = {
+    // Use a single writer thread that stays alive until close. Some cloud output streams, such as
+    // the GCS connector, can bridge OutputStream writes to an async uploader through a
+    // PipedOutputStream/PipedInputStream pair, where the reader can report a broken pipe if the
+    // writer thread exits while the stream is still open.
     val executor = new ThrottlingExecutor(
-      TrampolineUtil.newDaemonCachedThreadPool("AsyncOutputStream for "
-        + Thread.currentThread().getName, 1, 1), trafficController,
+      TrampolineUtil.newDaemonSingleThreadExecutor("AsyncOutputStream for "
+        + Thread.currentThread().getName), trafficController,
       new StatsUpdaterForWriteFunc(statsTrackers).func)
     new AsyncOutputStream(openFn, executor)
   }
@@ -191,15 +195,23 @@ class AsyncOutputStream(openFn: Callable[OutputStream], executor: ThrottlingExec
     if (!closed) {
       Seq[AutoCloseable](
         () => {
-          // Wait for all pending writes to complete
-          // This will throw an exception if one of the writes fails
-          flush()
+          // Close on the async executor after all pending writes, before shutting the executor
+          // down. Some cloud streams use a pipe tied to the writing thread and can report a
+          // broken pipe if that thread exits before the stream is closed.
+          executor.submit(() => {
+            try {
+              throwIfError()
+              ensureOpen()
+              delegate.flush()
+            } catch {
+              case t: Throwable =>
+                delegate.safeClose(t)
+                throw t
+            }
+            delegate.close()
+          }, 0).get()
         },
-        () => {
-          // Give the executor a chance to shutdown gracefully.
-          executor.shutdownNow(10, TimeUnit.SECONDS)
-        },
-        delegate,
+        () => executor.shutdownNow(10, TimeUnit.SECONDS),
         () => closed = true).safeClose()
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStream.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStream.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.io.async
 
 import java.io.{IOException, OutputStream}
-import java.util.concurrent.{Callable, TimeUnit}
+import java.util.concurrent.{Callable, ExecutionException, TimeUnit}
 import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -99,6 +99,15 @@ class AsyncOutputStream(openFn: Callable[OutputStream], executor: ThrottlingExec
   }
 
   @throws[IOException]
+  private def throwExecutionExceptionAsIOException(e: ExecutionException): Nothing = {
+    e.getCause match {
+      case t: IOException => throw t
+      case t if t != null => throw new IOException(t)
+      case _ => throw new IOException(e)
+    }
+  }
+
+  @throws[IOException]
   private def ensureOpen(): Unit = {
     if (closed) {
       throw new IOException("Stream closed")
@@ -176,7 +185,11 @@ class AsyncOutputStream(openFn: Callable[OutputStream], executor: ThrottlingExec
       delegate.flush()
     }, 0)
 
-    f.get()
+    try {
+      f.get()
+    } catch {
+      case e: ExecutionException => throwExecutionExceptionAsIOException(e)
+    }
   }
 
   /**
@@ -198,18 +211,22 @@ class AsyncOutputStream(openFn: Callable[OutputStream], executor: ThrottlingExec
           // Close on the async executor after all pending writes, before shutting the executor
           // down. Some cloud streams use a pipe tied to the writing thread and can report a
           // broken pipe if that thread exits before the stream is closed.
-          executor.submit(() => {
-            try {
-              throwIfError()
-              ensureOpen()
-              delegate.flush()
-            } catch {
-              case t: Throwable =>
-                delegate.safeClose(t)
-                throw t
-            }
-            delegate.close()
-          }, 0).get()
+          try {
+            executor.submit(() => {
+              try {
+                throwIfError()
+                ensureOpen()
+                delegate.flush()
+              } catch {
+                case t: Throwable =>
+                  delegate.safeClose(t)
+                  throw t
+              }
+              delegate.close()
+            }, 0).get()
+          } catch {
+            case e: ExecutionException => throwExecutionExceptionAsIOException(e)
+          }
         },
         () => executor.shutdownNow(10, TimeUnit.SECONDS),
         () => closed = true).safeClose()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.execution
 
-import java.util.concurrent.{ScheduledExecutorService, ThreadPoolExecutor}
+import java.util.concurrent.{ExecutorService, ScheduledExecutorService, ThreadPoolExecutor}
 
 import org.apache.hadoop.conf.Configuration
 import org.json4s.JsonAST
@@ -238,6 +238,10 @@ object TrampolineUtil {
     // which gives us important Hadoop config variables that are needed for the
     // Unity Catalog authentication
     ThreadUtils.newDaemonCachedThreadPool(prefix, maxThreadNumber, keepAliveSeconds)
+  }
+
+  def newDaemonSingleThreadExecutor(threadName: String): ExecutorService = {
+    ThreadUtils.newDaemonSingleThreadExecutor(threadName)
   }
 
   def newDaemonSingleThreadScheduledExecutor(threadName: String): ScheduledExecutorService = {

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
@@ -147,7 +147,7 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
           assert(secondReadStarted.await(5, TimeUnit.SECONDS),
             "timed out waiting for second pipe read")
 
-          Thread.sleep(4500)
+          Thread.sleep(2500)
           assert(pipeConsumerFailure.get() == null,
             s"pipe consumer failed while waiting for more data: ${pipeConsumerFailure.get()}")
 

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/io/async/AsyncOutputStreamSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 package com.nvidia.spark.rapids.io.async
 
-import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, File, FileInputStream, FileOutputStream, IOException, OutputStream}
+import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, File, FileInputStream}
+import java.io.{FileOutputStream, IOException, OutputStream, PipedInputStream, PipedOutputStream}
 import java.nio.ByteBuffer
-import java.util.concurrent.{Callable, ExecutorService, Future}
+import java.util.concurrent.{Callable, CountDownLatch, ExecutorService, Future, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
 
 import com.google.common.util.concurrent.ForwardingExecutorService
 import com.nvidia.spark.rapids.Arm.withResource
@@ -93,6 +95,67 @@ class AsyncOutputStreamSuite extends AnyFunSuite with BeforeAndAfterEach {
     }
     assertResult(bufLen * numBufs)(stream.metrics.numBytesScheduled)
     assertResult(bufLen * numBufs)(stream.metrics.numBytesWritten.get())
+  }
+
+  test("pipe-backed delegate does not see async writer thread as dead between writes") {
+    val pipeSource = new PipedInputStream(bufLen * maxBufCount)
+    val pipeSink = new PipedOutputStream(pipeSource)
+    val firstBufferRead = new CountDownLatch(1)
+    val secondReadStarted = new CountDownLatch(1)
+    val pipeConsumerFailure = new AtomicReference[Throwable]()
+    val pipeConsumerExecutor =
+      TrampolineUtil.newDaemonCachedThreadPool("AsyncOutputStreamPipeConsumer", 1, 1)
+    withResource(new AutoCloseable {
+      override def close(): Unit = pipeConsumerExecutor.shutdownNow()
+    }) { _ =>
+      withResource(pipeSource) { _ =>
+        val pipeConsumerFuture = pipeConsumerExecutor.submit(new Callable[Unit] {
+          override def call(): Unit = {
+            val readBuffer = new Array[Byte](bufLen)
+            var totalBytesRead = 0
+            var readCount = 0
+            var done = false
+
+            try {
+              while (!done) {
+                readCount += 1
+                if (readCount == 2) {
+                  secondReadStarted.countDown()
+                }
+                val bytesRead = pipeSource.read(readBuffer)
+                if (bytesRead == -1) {
+                  done = true
+                } else {
+                  totalBytesRead += bytesRead
+                  if (totalBytesRead >= bufLen) {
+                    firstBufferRead.countDown()
+                  }
+                }
+            }
+          } catch {
+            case t: Throwable =>
+                pipeConsumerFailure.set(t)
+                throw t
+            }
+          }
+        })
+
+        withResource(AsyncOutputStream(() => pipeSink, trafficController, Seq.empty)) { os =>
+          os.write(buf)
+          assert(firstBufferRead.await(5, TimeUnit.SECONDS),
+            "timed out waiting for first pipe read")
+          assert(secondReadStarted.await(5, TimeUnit.SECONDS),
+            "timed out waiting for second pipe read")
+
+          Thread.sleep(4500)
+          assert(pipeConsumerFailure.get() == null,
+            s"pipe consumer failed while waiting for more data: ${pipeConsumerFailure.get()}")
+
+          os.write(buf)
+        }
+        pipeConsumerFuture.get(5, TimeUnit.SECONDS)
+      }
+    }
   }
 
   def testWrite(writeCall: (AsyncOutputStream, Int) => Unit,


### PR DESCRIPTION
### Description

  This PR fixes a failure in RAPIDS async query output writes when the underlying output stream is backed by a pipe-based async uploader, such as the GCS connector. In that case, the pipe consumer can report `java.io.IOException: Pipe broken` if the writer thread exits while the stream is still open and the consumer is waiting for more data.

  The change updates `AsyncOutputStream` to use a daemon single-thread executor so the async writer thread stays alive for the lifetime of the stream. This prevents pipe-backed output streams from observing a dead writer thread while the stream is still open. It also moves delegate flush/close onto that same writer thread before executor shutdown, so close follows the same ordering as writes and the delegate is not closed after the writer thread has exited.

  This PR also adds a regression test using a `PipedOutputStream`/`PipedInputStream` pair to model pipe-backed output streams and verify the pipe consumer does not see the async writer thread as dead between writes.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
