### PR TITLE
[AutoSparkUT] Propagate SQL query context for decimal-overflow exceptions (SPARK-39190)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/decimalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/decimalExpressions.scala
@@ -20,6 +20,7 @@ import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.{Arithmetic, RoundMode}
 
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.types.{DataType, DecimalType, LongType}
 
 /**
@@ -43,23 +44,38 @@ case class GpuCheckOverflow(child: Expression,
     DType.create(DType.DTypeEnum.DECIMAL32, expectedCudfScale)
   }
 
-  override protected def doColumnar(input: GpuColumnVector): ColumnVector = {
-    val base = input.getBase
-    val rounded = if (resultDType.equals(base.getType)) {
-      base.incRefCount()
-    } else {
-      withResource(Arithmetic.round(base, dataType.scale, RoundMode.HALF_UP)) { rounded =>
-        if (resultDType.getTypeId != base.getType.getTypeId) {
-          rounded.castTo(resultDType)
-        } else {
-          rounded.incRefCount()
+  // SPARK-39190: snapshot the Origin at construction so the SQL query context survives the
+  // reflection-based plan reconstruction (e.g. GpuBindReferences → mapChildren → makeCopy)
+  // that otherwise resets `origin` to its default.
+  val capturedOrigin: Origin = origin
+
+  // Defensive: re-enter the captured origin around the case-class copy.  Spark's `mapChildren` /
+  // `withNewChildren` already wrap with `CurrentOrigin.withOrigin(this.origin)`, but if any future
+  // reconstruction path (e.g. direct reflection) bypasses that wrap, this override keeps the
+  // parser-set SQL context attached to the rebound instance.
+  override def withNewChildInternal(newChild: Expression): Expression =
+    CurrentOrigin.withOrigin(capturedOrigin) {
+      copy(child = newChild)
+    }
+
+  override protected def doColumnar(input: GpuColumnVector): ColumnVector =
+    CurrentOrigin.withOrigin(capturedOrigin) {
+      val base = input.getBase
+      val rounded = if (resultDType.equals(base.getType)) {
+        base.incRefCount()
+      } else {
+        withResource(Arithmetic.round(base, dataType.scale, RoundMode.HALF_UP)) { rounded =>
+          if (resultDType.getTypeId != base.getType.getTypeId) {
+            rounded.castTo(resultDType)
+          } else {
+            rounded.incRefCount()
+          }
         }
       }
+      withResource(rounded) { rounded =>
+        GpuCast.checkNFixDecimalBounds(rounded, dataType, !nullOnOverflow)
+      }
     }
-    withResource(rounded) { rounded =>
-      GpuCast.checkNFixDecimalBounds(rounded, dataType, !nullOnOverflow)
-    }
-  }
 
   override def nullable: Boolean = true
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckSuccess
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, ImplicitCastInputTypes, Literal, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData, TypeUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids._
@@ -837,36 +838,52 @@ case class GpuCheckOverflowAfterSum(
 
   override def sql: String = data.sql
 
-  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
-    withResource(data.columnarEval(batch)) { dataCol =>
-      val dataBase = dataCol.getBase
-      withResource(GpuCast.checkNFixDecimalBounds(dataBase, dataType, !nullOnOverflow)) {
-        fixedData =>
-          withResource(isEmpty.columnarEval(batch)) { isEmptyCol =>
-            val isEmptyBase = isEmptyCol.getBase
-            if (!nullOnOverflow) {
-              // ANSI mode
-              val problem = withResource(fixedData.isNull) { isNull =>
-                withResource(isEmptyBase.not()) { notEmpty =>
-                  isNull.and(notEmpty)
-                }
-              }
-              withResource(problem) { problem =>
-                withResource(problem.any()) { anyProblem =>
-                  if (anyProblem.isValid && anyProblem.getBoolean) {
-                    throw new ArithmeticException("Overflow in sum of decimals.")
+  // SPARK-39190: snapshot the Origin at construction so the SQL query context survives the
+  // reflection-based plan reconstruction that resets `origin`.  GpuDecimalSum.evaluateExpression
+  // (and friends) construct this node inside `CurrentOrigin.withOrigin(capturedOrigin)`, so the
+  // origin field has the parser-set SQL string at construction time.
+  val capturedOrigin: Origin = origin
+
+  // Defensive: re-enter the captured origin around the case-class copy.  Spark's `withNewChildren`
+  // and `makeCopy` already wrap with `CurrentOrigin.withOrigin(this.origin)`, but if any future
+  // reconstruction path (e.g. direct reflection) bypasses that wrap, this override keeps the
+  // parser-set SQL context attached to the rebound instance.
+  override def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
+    CurrentOrigin.withOrigin(capturedOrigin) {
+      copy(data = newChildren(0), isEmpty = newChildren(1))
+    }
+
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
+    CurrentOrigin.withOrigin(capturedOrigin) {
+      withResource(data.columnarEval(batch)) { dataCol =>
+        val dataBase = dataCol.getBase
+        withResource(GpuCast.checkNFixDecimalBounds(dataBase, dataType, !nullOnOverflow)) {
+          fixedData =>
+            withResource(isEmpty.columnarEval(batch)) { isEmptyCol =>
+              val isEmptyBase = isEmptyCol.getBase
+              if (!nullOnOverflow) {
+                // ANSI mode
+                val problem = withResource(fixedData.isNull) { isNull =>
+                  withResource(isEmptyBase.not()) { notEmpty =>
+                    isNull.and(notEmpty)
                   }
                 }
+                withResource(problem) { problem =>
+                  withResource(problem.any()) { anyProblem =>
+                    if (anyProblem.isValid && anyProblem.getBoolean) {
+                      throw new ArithmeticException("Overflow in sum of decimals.")
+                    }
+                  }
+                }
+                // No problems fall through...
               }
-              // No problems fall through...
+              withResource(GpuScalar.from(null, dataType)) { nullScale =>
+                GpuColumnVector.from(isEmptyBase.ifElse(nullScale, fixedData), dataType)
+              }
             }
-            withResource(GpuScalar.from(null, dataType)) { nullScale =>
-              GpuColumnVector.from(isEmptyBase.ifElse(nullScale, fixedData), dataType)
-            }
-          }
+        }
       }
     }
-  }
 
   override def children: Seq[Expression] = Seq(data, isEmpty)
 }
@@ -1141,7 +1158,13 @@ abstract class GpuDecimalSum(
     Seq(sum, isEmpty)
   }
 
-  override lazy val postUpdate: Seq[Expression] = {
+  // SPARK-39190: snapshot the Origin at construction (driver-side, inside RapidsMeta's
+  // `CurrentOrigin.withOrigin(wrapped.origin)` wrap so the SQL text is populated).  This val
+  // survives the reflection-based plan reconstruction that resets `origin` to its default,
+  // letting the lazy vals below propagate the SQL context to GpuCheckOverflowAfterSum.
+  val capturedOrigin: Origin = origin
+
+  override lazy val postUpdate: Seq[Expression] = CurrentOrigin.withOrigin(capturedOrigin) {
     if (failOnErrorOverride) {
       Seq(GpuCheckOverflowAfterSum(updateSum.attr, updateIsEmpty.attr, dt, !failOnErrorOverride),
         updateIsEmpty.attr)
@@ -1164,7 +1187,7 @@ abstract class GpuDecimalSum(
     Seq(mergeSum, mergeIsEmpty, mergeIsOverflow)
   }
 
-  override lazy val postMerge: Seq[Expression] = {
+  override lazy val postMerge: Seq[Expression] = CurrentOrigin.withOrigin(capturedOrigin) {
     if (failOnErrorOverride) {
       Seq(
         GpuCheckOverflowAfterSum(mergeSum.attr, mergeIsEmpty.attr, dt, !failOnErrorOverride),
@@ -1176,7 +1199,7 @@ abstract class GpuDecimalSum(
     }
   }
 
-  override lazy val evaluateExpression: Expression = {
+  override lazy val evaluateExpression: Expression = CurrentOrigin.withOrigin(capturedOrigin) {
     GpuCheckOverflowAfterSum(sum, isEmpty, dt, !failOnErrorOverride)
   }
 
@@ -1590,9 +1613,15 @@ case class GpuBasicAverage(child: Expression, dt: DataType, failOnError: Boolean
 abstract class GpuDecimalAverageBase(child: Expression, sumDataType: DecimalType,
                                      failOnError: Boolean)
   extends GpuAverage(child, sumDataType, failOnError) {
-  override lazy val postUpdate: Seq[Expression] =
-      Seq(GpuCheckOverflow(updateSum.attr, sumDataType, nullOnOverflow = !failOnError),
-        updateCount.attr)
+
+  // SPARK-39190: snapshot Origin at construction so GpuCheckOverflow nodes built in the lazy
+  // vals below inherit the SQL query context.  See GpuDecimalSum for the matching pattern.
+  val capturedOrigin: Origin = origin
+
+  override lazy val postUpdate: Seq[Expression] = CurrentOrigin.withOrigin(capturedOrigin) {
+    Seq(GpuCheckOverflow(updateSum.attr, sumDataType, nullOnOverflow = !failOnError),
+      updateCount.attr)
+  }
 
   // To be able to do decimal overflow detection, we need a CudfSum that does **not** ignore nulls.
   // Cudf does not have such an aggregation, so for merge we have to work around that with an extra
@@ -1604,11 +1633,13 @@ abstract class GpuDecimalAverageBase(child: Expression, sumDataType: DecimalType
 
   override lazy val mergeAggregates: Seq[CudfAggregate] = Seq(mergeSum, mergeCount, mergeIsOverflow)
 
-  override lazy val postMerge: Seq[Expression] = Seq(
-    GpuCheckOverflow(
-      GpuIf(mergeIsOverflow.attr, GpuLiteral.create(null, sumDataType), mergeSum.attr),
-          sumDataType, nullOnOverflow = !failOnError),
-    mergeCount.attr)
+  override lazy val postMerge: Seq[Expression] = CurrentOrigin.withOrigin(capturedOrigin) {
+    Seq(
+      GpuCheckOverflow(
+        GpuIf(mergeIsOverflow.attr, GpuLiteral.create(null, sumDataType), mergeSum.attr),
+            sumDataType, nullOnOverflow = !failOnError),
+      mergeCount.attr)
+  }
 
   // This is here to be bug for bug compatible with Spark. They round in the divide and then cast
   // the result to the final value. This loses some data in many cases and we need to be able to
@@ -1648,7 +1679,7 @@ case class GpuDecimal128Average(child: Expression, dt: DecimalType, failOnError:
 
   override lazy val updateAggregates: Seq[CudfAggregate] = updateSumChunks :+ updateCount
 
-  override lazy val postUpdate: Seq[Expression] = {
+  override lazy val postUpdate: Seq[Expression] = CurrentOrigin.withOrigin(capturedOrigin) {
     val assembleExpr = GpuAssembleSumChunks(updateSumChunks.map(_.attr), dt,
       nullOnOverflow = !failOnError, None)
     Seq(GpuCheckOverflow(assembleExpr, dt, nullOnOverflow = !failOnError), updateCount.attr)
@@ -1670,7 +1701,7 @@ case class GpuDecimal128Average(child: Expression, dt: DecimalType, failOnError:
   override lazy val mergeAggregates: Seq[CudfAggregate] =
     mergeSumChunks ++ Seq(mergeCount, mergeIsOverflow)
 
-  override lazy val postMerge: Seq[Expression] = {
+  override lazy val postMerge: Seq[Expression] = CurrentOrigin.withOrigin(capturedOrigin) {
     val assembleExpr = GpuAssembleSumChunks(mergeSumChunks.map(_.attr), dt,
       nullOnOverflow = !failOnError, Some(mergeIsOverflow.attr))
     Seq(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -25,7 +25,8 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.jni.{Arithmetic, CastStrings, ExceptionWithRowIndex, RoundMode}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
-import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.rapids.shims.{OriginContextShim, RapidsErrorUtils}
 import org.apache.spark.sql.types._
 
 abstract class CudfUnaryMathExpression(name: String) extends GpuUnaryMathExpression(name)
@@ -866,13 +867,11 @@ object RoundingErrorUtil {
    * @param outOfBounds A boolean column that indicates which value cannot be casted.
    * Users must make sure that there is at least one `true` in this column.
    * @param toType The type to cast.
-   * @param context The error context, default value is "".
    */
   def cannotChangeDecimalPrecisionError(
       values: ColumnView,
       outOfBounds: ColumnView,
-      toType: DecimalType,
-      context: String = ""): ArithmeticException = {
+      toType: DecimalType): ArithmeticException = {
     val rowId = withResource(outOfBounds.copyToHost()) { hcv =>
       (0L until outOfBounds.getRowCount)
         .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
@@ -881,6 +880,9 @@ object RoundingErrorUtil {
     val value = withResource(values.getScalarElement(rowId.toInt)) { s =>
       s.getBigDecimal
     }
-    RapidsErrorUtils.cannotChangeDecimalPrecisionError(Decimal(value), toType)
+    // Pass the SQL query context (set on the executor via `CurrentOrigin.withOrigin`
+    // around `doColumnar`) so the exception message preserves SPARK-39190 parity.
+    RapidsErrorUtils.cannotChangeDecimalPrecisionError(
+      Decimal(value), toType, OriginContextShim.queryContext(CurrentOrigin.get))
   }
 }

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -221,6 +221,5 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL -- jar contains udf class", ADJUST_UT("Replaced by testRapids version that uses testFile() to access Spark test resources instead of getContextClassLoader"))
     .exclude("SPARK-33482: Fix FileScan canonicalization", ADJUST_UT("Replaced by testRapids version using V1 sources with AQE and broadcast disabled to assert ReusedExchangeExec directly"))
     .exclude("SPARK-36093: RemoveRedundantAliases should not change expression's name", ADJUST_UT("Replaced by testRapids version that checks the partition column name of the GpuInsertIntoHadoopFsRelationCommand"))
-    .exclude("SPARK-39190,SPARK-39208,SPARK-39210: Query context of decimal overflow error should be serialized to executors when WSCG is off", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/14123"))
 }
 // scalastyle:on line.size.limit


### PR DESCRIPTION
Closes #14123

## Summary

SPARK-39190 / SPARK-39208 / SPARK-39210 (introduced in Spark 3.3) require that `SparkArithmeticException` for decimal overflow include the original SQL fragment so it survives serialization to executors when WSCG is off. On GPU the captured `Origin` was being lost across the executor-side plan reconstruction (`GpuBindReferences` → `mapChildren` → `makeCopy`), so decimal-overflow errors for `select d / 0.1`, `select sum(d)`, and `select avg(d)` lacked the SQL fragment that the test's `msg.contains(query)` assertion required.

## What changed

- `RoundingErrorUtil.cannotChangeDecimalPrecisionError` now threads the query context via `OriginContextShim.queryContext(CurrentOrigin.get)` instead of dropping it. The dead `context: String = ""` parameter is removed; the body previously discarded it.
- `GpuCheckOverflow` and `GpuCheckOverflowAfterSum` snapshot a `capturedOrigin` field and override `withNewChild(ren)Internal` to re-enter it around the case-class `copy()`. Spark's `mapChildren` / `withNewChildren` already wrap with `CurrentOrigin.withOrigin(this.origin)`; the override is defensive against reflection paths that bypass that wrap.
- `GpuDecimalSum` and `GpuDecimalAverageBase` capture their own origin and wrap `postUpdate` / `postMerge` / `evaluateExpression` lazy vals with `CurrentOrigin.withOrigin(capturedOrigin)` so the `GpuCheckOverflow*` nodes they construct inherit the parser-set context. `GpuDecimal128Average` applies the same wrap to its own `postUpdate` / `postMerge` overrides.
- `columnarEval` on `GpuCheckOverflow*` enters the captured origin so the static `GpuCast.checkNFixDecimalBounds` → `RoundingErrorUtil` chain reads it via `CurrentOrigin.get` at throw time.
- `RapidsTestSettings.scala` exclusion for `SPARK-39190,SPARK-39208,SPARK-39210: Query context of decimal overflow error should be serialized to executors when WSCG is off` is removed.

## Why the capture pattern

`val capturedOrigin = origin` snapshots the parser-set Origin at construction (driver-side, inside `RapidsMeta.convertToGpu`'s `withOrigin(wrapped.origin)`). The follow-up `withNewChild(ren)Internal` overrides preserve that snapshot across the case-class `copy()` that Spark drives via `mapChildren`/`makeCopy`, so the SQL context survives all the way to the executor-thrown exception.

## Local validation

Inside the worktree (`/home/allxu/work/spark-set/spark-rapids-14123-query-ctx`):

\`\`\`
mvn package -pl tests -am -Dbuildver=330 -Dmaven.repo.local=./.mvn-repo \\
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsSQLQuerySuite \\
  -Drapids.test.gpu.allocFraction=0.3 -Drapids.test.gpu.maxAllocFraction=0.3 \\
  -Drapids.test.gpu.minAllocFraction=0
\`\`\`

\`Tests: succeeded 225, failed 0, canceled 0, ignored 9, pending 0\`

Per-test trace for the recovered case (`SPARK-39190,SPARK-39208,SPARK-39210: Query context of decimal overflow error should be serialized to executors when WSCG is off`, Spark source `sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala:4496`): all three subqueries (`select d / 0.1`, `select sum(d)`, `select avg(d)`) now throw a `SparkArithmeticException` whose `getMessage` contains the originating SQL fragment, matching CPU behavior.

Shim compile coverage:
- `mvn package -DskipTests -pl sql-plugin -am -Dbuildver=330`: SUCCESS
- `mvn package -DskipTests -pl sql-plugin -am -Dbuildver=340`: SUCCESS
- `mvn package -DskipTests -pl sql-plugin -am -Dbuildver=400 -f scala2.13/pom.xml`: SUCCESS

## Follow-ups (out of scope here)

- `GpuDecimalSum.windowOutput` and `scanCombine` still call `GpuCast.checkNFixDecimalBounds` without a captured-origin wrap, so window/scan decimal-overflow messages will not carry the SQL fragment. SPARK-39190 does not exercise those paths; can be addressed separately.
- The `capturedOrigin` + `withNewChild(ren)Internal` boilerplate is repeated across four classes. Consolidating into a small `GpuOriginCapture` trait, or migrating to the `GpuCast`-style `otherCopyArgs` + second-parameter-list `origin` pattern, is a worthwhile refactor follow-up but kept out of this fix to minimize scope.

## Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

## Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

## Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required