### PR TITLE
[AutoSparkUT] regexp_test: raise maxStateMemoryBytes to 3 GiB (#14867)

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -27,14 +27,7 @@ if not is_jvm_charset_utf8():
 else:
     pytestmark = pytest.mark.regexp
 
-# Raised above the Integer.MAX_VALUE default so line-anchor + alternation
-# patterns (e.g. `(abc1a$|^ab2ab|a3abc)`) clear the post-#14849 estimator
-# (see #14867). 3 GiB matches the conf's documented "no more than 3x
-# batchSizeBytes" guidance.
-_regexp_conf = {
-    'spark.rapids.sql.regexp.enabled': True,
-    'spark.rapids.sql.regexp.maxStateMemoryBytes': str(3 * 1024 * 1024 * 1024),
-}
+_regexp_conf = { 'spark.rapids.sql.regexp.enabled': True }
 
 def mk_str_gen(pattern):
     return StringGen(pattern).with_special_case('').with_special_pattern('.{0,10}')
@@ -605,6 +598,13 @@ def test_character_classes():
 
 @datagen_overrides(seed=0, reason="https://github.com/NVIDIA/spark-rapids/issues/10641")
 def test_regexp_choice():
+    # Pattern `(abc1a$|^ab2ab|a3abc)` below transpiles to 21 states; with the
+    # default `gpuTargetBatchSizeBytes = 1 GiB` and default
+    # `maxRegExpStateMemory = Integer.MAX_VALUE`, the post-#14849 estimator
+    # (correctly) computes ~2.25 GiB and falls back to CPU, which drags the
+    # whole Project to CPU and trips assertIsOnTheGpu under IT mode.
+    # 3 GiB matches the conf's documented "no more than 3x batchSizeBytes"
+    # guidance. Tracked by #14867; long-term plugin-level fix is #14887.
     gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}[ \n\t\r]{0,2}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
@@ -621,7 +621,8 @@ def test_regexp_choice():
                 'regexp_replace(a, "[ab]$|[cd]$", "@")',
                 'regexp_replace(a, "[ab]+|^cd1", "@")'
             ),
-        conf=_regexp_conf)
+        conf={**_regexp_conf,
+              'spark.rapids.sql.regexp.maxStateMemoryBytes': str(3 * 1024 * 1024 * 1024)})
 
 def test_regexp_hexadecimal_digits():
     gen = mk_str_gen(

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,14 @@ if not is_jvm_charset_utf8():
 else:
     pytestmark = pytest.mark.regexp
 
-_regexp_conf = { 'spark.rapids.sql.regexp.enabled': True }
+# Raised above the Integer.MAX_VALUE default so line-anchor + alternation
+# patterns (e.g. `(abc1a$|^ab2ab|a3abc)`) clear the post-#14849 estimator
+# (see #14867). 3 GiB matches the conf's documented "no more than 3x
+# batchSizeBytes" guidance.
+_regexp_conf = {
+    'spark.rapids.sql.regexp.enabled': True,
+    'spark.rapids.sql.regexp.maxStateMemoryBytes': str(3 * 1024 * 1024 * 1024),
+}
 
 def mk_str_gen(pattern):
     return StringGen(pattern).with_special_case('').with_special_pattern('.{0,10}')


### PR DESCRIPTION
Contributes to #14867. Related feature: #14887.

## Summary

`test_regexp_choice` started failing on Dataproc Serverless 2.2 IT (`rapids-it-dataproc-serverless-2.2/472`) after #14849 fixed an `Int` overflow in `RegexComplexityEstimator`. Pattern `(abc1a$|^ab2ab|a3abc)` transpiles to 21 states; with the default `gpuTargetBatchSizeBytes = 1 GiB` and default `maxRegExpStateMemory = Integer.MAX_VALUE`, the estimator now (correctly) computes `21 * 53,687,091 * 2 ≈ 2.25 GiB`, which exceeds the limit, so it falls back to CPU. Since `test_regexp_choice` puts all 12 regex expressions in a single `Project`, the whole `Project` drops to CPU; under the IT's `spark.rapids.sql.test.enabled=true`, `GpuTransitionOverrides.assertIsOnTheGpu` then raises `IllegalArgumentException: Part of the plan is not columnar class org.apache.spark.sql.execution.ProjectExec`.

Pre-#14849 the same multiplication overflowed `Int` to a negative number, which always satisfied `<= maxRegExpStateMemory`, so the pattern silently ran on the GPU for many releases.

This PR is the minimal IT-localized remediation: bump `spark.rapids.sql.regexp.maxStateMemoryBytes` to 3 GiB **only on `test_regexp_choice`'s call site** (`conf={**_regexp_conf, 'spark.rapids.sql.regexp.maxStateMemoryBytes': str(3 * 1024 * 1024 * 1024)}`). The shared `_regexp_conf` dict is unchanged, so the other 58 tests that use it keep the pre-PR default. 3 GiB matches the conf's own doc string ("not more than 3 times `spark.rapids.sql.batchSizeBytes`"). No plugin code is changed.

The longer-term plugin-level fix is tracked in **#14887**: use Catalyst row statistics as a `rowsHint` so `RegexComplexityEstimator.isValid` doesn't always assume a full 1 GiB batch (`numRows ≈ 53.7M`). Post-#14849, patterns that previously slipped through `Int` overflow now get correctly rejected at the per-batch ceiling even when the actual input is tiny — same root over-rejection that this PR sidesteps. Once #14887 lands, the conf override added here can be removed.

## Per-pattern repro evidence

Reproduced locally on a fresh `origin/main` build (`26.08.0-SNAPSHOT`, buildver=330, Spark 3.3.0, default conf) using the same 12 `selectExpr` expressions from `test_regexp_choice`.

Before the bump — only pattern 5 falls back (others all `*Expression ... will run on GPU`):

```
!Exec <ProjectExec> cannot run on GPU because not all expressions can be replaced
    !Expression <RegExpExtract> regexp_extract(a#40, (abc1a$|^ab2ab|a3abc), 1) cannot run on GPU because estimated memory needed for regular expression exceeds the maximum. Set spark.rapids.sql.regexp.maxStateMemoryBytes to change it.
```

After the bump (3 GiB) — all 12 expressions tag GPU and the resulting `Project` becomes `GpuProject`:

```
*Exec <ProjectExec> will run on GPU
  *Expression <RegExpExtract> regexp_extract(a#0, (abc1a$|^ab2ab|a3abc), 1) will run on GPU
  *Expression <RLike> RLIKE(a#0, abd1a$|^ab2a) will run on GPU
  *Expression <RegExpReplace> regexp_replace(a#0, [abcd]$|^abc, @, 1) will run on GPU
  ... (9 more, all GPU)
+- GpuProject [...], true
   +- GpuFileSourceScanExec ...
```

## Validation

- Local spark-shell, `26.08.0-SNAPSHOT` from this branch, default `gpuTargetBatchSizeBytes`, conf with `maxStateMemoryBytes = 3 GiB`. All 12 patterns lift to `GpuProject`; `.collect()` succeeds; no `cannot run on GPU because estimated memory` warning remains.
- Python AST parse of `regexp_test.py` confirms the new key is well-formed.
- **Local pytest run** (`spark-rapids` worktree at `9aeb5a67`, `dist/` JAR + `integration_tests/` JAR built against `-Dbuildver=330`, Spark 3.3.0 runtime, Python 3.10 venv, default `gpuTargetBatchSizeBytes`):

  ```
  TEST=test_regexp_choice bash ./run_pyspark_from_build.sh
  ...
  collected 39875 items / 39874 deselected / 1 selected
  test_regexp_choice[DATAGEN_SEED_OVERRIDE=0, TZ=UTC]  PASSED  [100%]
  =============== 1 passed, 39874 deselected, 8 warnings in 18.97s ===============
  ```

  The plugin log line `WARN com.nvidia.spark.rapids.RapidsConf - spark.rapids.sql.regexp.maxStateMemoryBytes is more than 3 times spark.rapids.sql.batchSizeBytes` confirms the per-test override is actually reaching the conf parser. Only CPU-side op in the plan is the test-data `RDDScanExec` (expected — the `Project` and all 12 regex expressions execute on GPU).

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (`test_regexp_choice` at `integration_tests/src/main/python/regexp_test.py:600`)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
