### PR TITLE
[CHERRYPICK] Shuffle bytes double count metric fix + tests to cover shuffle removal at unregister

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillablePartialFileHandle.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/spill/SpillablePartialFileHandle.scala
@@ -20,6 +20,7 @@ import java.io.{BufferedInputStream, BufferedOutputStream, File, FileInputStream
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 
+import ai.rapids.cudf.HostMemoryBuffer
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.HostAlloc
 
@@ -239,6 +240,7 @@ class SpillablePartialFileHandle private (
         throw new IllegalStateException("Host buffer is null")
     }
   }
+
 
   /**
    * Spill current buffer content to file and switch to file-based mode.
@@ -571,13 +573,33 @@ class SpillablePartialFileHandle private (
   private var spillInProgress: Boolean = false
 
   /**
-   * Spill memory buffer to disk.
+   * Spill memory buffer to disk, as part of the shuffle commit
+   */
+  def spillForCommit(): Long = {
+    spillInternal(commit = true)
+  }
+
+  /**
+   * Spill memory buffer to disk, as part of memory pressure
+   */
+  override def spill(): Long = {
+    spillInternal(commit = false)
+  }
+
+  /**
+   * This method spills this handle to disk, and optionally tracks the time
+   * and bytes written as a spill metric given it is caused by memory pressure,
+   * which is signaled by commit = false.
    *
    * Following SpillFramework pattern: all state checks inside synchronized block.
    * IO operations are performed outside the synchronized block to allow
    * concurrent read() access to the buffer during the file write.
+   *
+   * @param commit if true, the spill is happening due to a shuffle commit phase
+   *               do not track the time/bytes in our spill metric.
+   * @return the number of bytes written to disk, or 0 if spilling was skipped
    */
-  override def spill(): Long = {
+  private def spillInternal(commit: Boolean): Long = {
     if (storageMode != PartialFileStorageMode.MEMORY_WITH_SPILL) {
       return 0L  // Nothing to spill for FILE_ONLY mode
     }
@@ -597,32 +619,14 @@ class SpillablePartialFileHandle private (
       }
     }
 
-    // Perform IO outside lock - read() can still access buffer during this time
-    // Wrap with spillToDiskTime to track spill timing metrics
-    GpuTaskMetrics.get.spillToDiskTime {
-      try {
-        val fos = new FileOutputStream(file)
-        try {
-          val channel = fos.getChannel
-          val bb = bufferToSpill.asByteBuffer()
-          bb.limit(totalBytesWritten.toInt)
-          while (bb.hasRemaining) {
-            channel.write(bb)
-          }
-          if (syncWrites) {
-            channel.force(true)
-          }
-        } finally {
-          fos.close()
-        }
-      } catch {
-        case e: Exception =>
-          // IO failed, reset flag and propagate
-          synchronized {
-            spillInProgress = false
-            notifyAll()  // Wake up any waiting doClose()
-          }
-          throw e
+
+    if (commit) {
+      doSpill(bufferToSpill)
+    } else {
+      // we are spilling due to memory pressure. Lets measure the doSpill
+      // time since it's not part of the regular shuffle commit.
+      GpuTaskMetrics.get.spillToDiskTime {
+        doSpill(bufferToSpill)
       }
     }
 
@@ -643,13 +647,46 @@ class SpillablePartialFileHandle private (
       bufferToSpill.close()
       host = None
 
-      // Record spill bytes metric
-      TrampolineUtil.incTaskMetricsDiskBytesSpilled(totalBytesWritten)
+      if (!commit) {
+        // if we are not committing, we want to account for these bytes
+        // in the spill to disk metric, otherwise we are going to account
+        // for them in the shuffle write metric.
+        TrampolineUtil.incTaskMetricsDiskBytesSpilled(totalBytesWritten)
+      }
 
       logDebug(s"Spilled to ${file.getAbsolutePath} " +
         s"($totalBytesWritten bytes)")
 
       totalBytesWritten
+    }
+  }
+
+  // Performs IO outside lock - read() can still access buffer during this time
+  // Only to be called from spillInternal!
+  private def doSpill(bufferToSpill: HostMemoryBuffer): Unit = {
+    try {
+      val fos = new FileOutputStream(file)
+      try {
+        val channel = fos.getChannel
+        val bb = bufferToSpill.asByteBuffer()
+        bb.limit(totalBytesWritten.toInt)
+        while (bb.hasRemaining) {
+          channel.write(bb)
+        }
+        if (syncWrites) {
+          channel.force(true)
+        }
+      } finally {
+        fos.close()
+      }
+    } catch {
+      case e: Exception =>
+        // IO failed, reset flag and propagate
+        synchronized {
+          spillInProgress = false
+          notifyAll() // Wake up any waiting doClose()
+        }
+        throw e
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/shuffle/sort/io/RapidsLocalDiskShuffleMapOutputWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/shuffle/sort/io/RapidsLocalDiskShuffleMapOutputWriter.scala
@@ -198,7 +198,7 @@ class RapidsLocalDiskShuffleMapOutputWriter(
       // If memory-based and not spilled yet, force spill to create file
       // writeMetadataFileAndCommit requires a valid file
       if (handle.isMemoryBased && !handle.isSpilled) {
-        handle.spill()
+        handle.spillForCommit()
       }
     }
 

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/spill/SpillablePartialFileHandleMetricSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/spill/SpillablePartialFileHandleMetricSuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.spill
+
+import java.io.File
+
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.RapidsConf
+import com.nvidia.spark.rapids.spill.{SpillablePartialFileHandle, SpillFramework}
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.TaskContext
+import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+
+/**
+ * Regression tests for issue #14704: `SpillablePartialFileHandle` must not bump
+ * the disk-bytes-spilled task metric when the spill is triggered as part of a
+ * shuffle commit (those bytes are already accounted for in shuffle-write
+ * metrics). The `spill()` path — invoked by the spill framework under memory
+ * pressure — must still bump the metric.
+ *
+ * Lives in `org.apache.spark.*` so we have access to package-private members
+ * such as `TaskMetrics#diskBytesSpilled` and the `TaskContext` constructor.
+ */
+class SpillablePartialFileHandleMetricSuite extends AnyFunSuite with BeforeAndAfterEach {
+
+  private val testMaxBufferSize = 1L * 1024 * 1024 * 1024
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    val conf = new RapidsConf(Map(
+      "spark.rapids.memory.host.partialFileBufferMaxSize" -> testMaxBufferSize.toString
+    ))
+    SpillFramework.initialize(conf)
+  }
+
+  override def afterEach(): Unit = {
+    SpillFramework.shutdown()
+    super.afterEach()
+  }
+
+  // Install a TaskContext returning a real TaskMetrics so that
+  // TrampolineUtil.incTaskMetricsDiskBytesSpilled actually records into it.
+  // (TaskMetrics is `private[spark]`-constructed; we have access here because
+  // this test lives in the org.apache.spark.* package tree.)
+  private def withTaskContext[T](f: TaskMetrics => T): T = {
+    val taskMetrics = new TaskMetrics
+    val taskContext = mock(classOf[TaskContext])
+    when(taskContext.taskMetrics()).thenReturn(taskMetrics)
+    TrampolineUtil.setTaskContext(taskContext)
+    try f(taskMetrics)
+    finally TrampolineUtil.unsetTaskContext()
+  }
+
+  test("spillForCommit must NOT increment diskBytesSpilled (issue #14704)") {
+    // Bytes written during a shuffle commit are reported by the shuffle-write
+    // metrics; charging them again as memory-pressure spill produces the
+    // double-count described in the bug.
+    val tempFile = File.createTempFile("test-spill-for-commit-metric-", ".tmp")
+    try {
+      withTaskContext { taskMetrics =>
+        withResource(SpillablePartialFileHandle.createMemoryWithSpill(
+          initialCapacity = 1024,
+          maxBufferSize = testMaxBufferSize,
+          memoryThreshold = 0.5,
+          spillFile = tempFile)) { handle =>
+
+          val testData = "Bytes flushed as part of shuffle commit".getBytes("UTF-8")
+          handle.write(testData, 0, testData.length)
+          handle.finishWrite()
+
+          assert(taskMetrics.diskBytesSpilled == 0L)
+
+          val flushed = handle.spillForCommit()
+          assert(flushed == testData.length)
+          assert(handle.isSpilled)
+
+          assert(taskMetrics.diskBytesSpilled == 0L,
+            s"spillForCommit should not increment diskBytesSpilled, " +
+              s"but got ${taskMetrics.diskBytesSpilled}")
+        }
+      }
+    } finally {
+      tempFile.delete()
+    }
+  }
+
+  test("spill (memory pressure) increments diskBytesSpilled (issue #14704)") {
+    // Counterpart of the fix: spill() — used for memory-pressure eviction —
+    // must still account bytes against the disk-bytes-spilled task metric.
+    val tempFile = File.createTempFile("test-spill-pressure-metric-", ".tmp")
+    try {
+      withTaskContext { taskMetrics =>
+        withResource(SpillablePartialFileHandle.createMemoryWithSpill(
+          initialCapacity = 1024,
+          maxBufferSize = testMaxBufferSize,
+          memoryThreshold = 0.5,
+          spillFile = tempFile)) { handle =>
+
+          val testData = "Bytes spilled due to memory pressure".getBytes("UTF-8")
+          handle.write(testData, 0, testData.length)
+          handle.finishWrite()
+
+          assert(taskMetrics.diskBytesSpilled == 0L)
+
+          val spilled = handle.spill()
+          assert(spilled == testData.length)
+          assert(handle.isSpilled)
+
+          assert(taskMetrics.diskBytesSpilled == testData.length.toLong,
+            s"spill should increment diskBytesSpilled to ${testData.length}, " +
+              s"but got ${taskMetrics.diskBytesSpilled}")
+        }
+      }
+    } finally {
+      tempFile.delete()
+    }
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleManagerUnregisterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleManagerUnregisterSuite.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "321"}
+{"spark": "330"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+{"spark": "350"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "358"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids
+
+import org.mockito.ArgumentMatchers.{anyInt, anyLong}
+import org.mockito.Mockito.{never, verify}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.SparkConf
+import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleBlockResolver}
+import org.apache.spark.sql.rapids.shims.GpuShuffleBlockResolver
+import org.apache.spark.util.collection.OpenHashSet
+
+/**
+ * Regression tests for issue #14695: when the RAPIDS shuffle manager is using a
+ * [[GpuShuffleBlockResolver]] (e.g. multi-threaded / skipMerge=false path),
+ * `unregisterShuffle` must drive `removeDataByMap` on the wrapped
+ * [[IndexShuffleBlockResolver]] for every tracked map id so that the on-disk
+ * shuffle files are removed when Spark GCs the shuffle id upstream.
+ */
+class RapidsShuffleManagerUnregisterSuite extends AnyFunSuite with MockitoSugar {
+
+  // Subclass that lets us swap in a controlled `shuffleBlockResolver` and
+  // populate the `taskIdMapsForShuffle` book-keeping that `getWriter` would
+  // normally fill in during a real shuffle.
+  private class TestableRapidsShuffleManager(
+      conf: SparkConf,
+      injectedResolver: ShuffleBlockResolver)
+    extends RapidsShuffleInternalManagerBase(conf, isDriver = true) {
+
+    override def shuffleBlockResolver: ShuffleBlockResolver = injectedResolver
+
+    def trackMapForShuffle(shuffleId: Int, mapId: Long): Unit = {
+      val ids = taskIdMapsForShuffle.computeIfAbsent(
+        shuffleId, _ => new OpenHashSet[Long](16))
+      ids.synchronized {
+        ids.add(mapId)
+      }
+    }
+  }
+
+  private def newConf(): SparkConf = new SparkConf(loadDefaults = false)
+    .set("spark.app.id", "sampleApp")
+    // Default rapids.shuffle.mode is MULTITHREADED, but be explicit so the
+    // test does not rely on default values.
+    .set("spark.rapids.shuffle.mode", "MULTITHREADED")
+    .set("spark.rapids.shuffle.multiThreaded.writer.threads", "0")
+    .set("spark.rapids.shuffle.multiThreaded.reader.threads", "0")
+
+  test("unregisterShuffle removes data via wrapped IndexShuffleBlockResolver " +
+       "when using GpuShuffleBlockResolver (issue #14695)") {
+    val mockIsbr = mock[IndexShuffleBlockResolver]
+    val gpuResolver = new GpuShuffleBlockResolver(mockIsbr, null)
+
+    val manager = new TestableRapidsShuffleManager(newConf(), gpuResolver)
+
+    val shuffleId = 7
+    val mapIds = Seq(11L, 22L, 33L)
+    mapIds.foreach(manager.trackMapForShuffle(shuffleId, _))
+
+    val result = manager.unregisterShuffle(shuffleId)
+
+    mapIds.foreach { mid =>
+      verify(mockIsbr).removeDataByMap(shuffleId, mid)
+    }
+    assert(result, "expected SortShuffleManager.unregisterShuffle to return true")
+  }
+
+  test("unregisterShuffle on shuffle id with no tracked maps does not call " +
+       "removeDataByMap (issue #14695)") {
+    val mockIsbr = mock[IndexShuffleBlockResolver]
+    val gpuResolver = new GpuShuffleBlockResolver(mockIsbr, null)
+
+    val manager = new TestableRapidsShuffleManager(newConf(), gpuResolver)
+
+    val unknownShuffleId = 99
+    val result = manager.unregisterShuffle(unknownShuffleId)
+
+    verify(mockIsbr, never()).removeDataByMap(anyInt(), anyLong())
+    assert(result)
+  }
+
+  test("unregisterShuffle still cleans up when the resolver is a plain " +
+       "IndexShuffleBlockResolver (compat path, issue #14695)") {
+    val mockIsbr = mock[IndexShuffleBlockResolver]
+
+    val manager = new TestableRapidsShuffleManager(newConf(), mockIsbr)
+
+    val shuffleId = 5
+    val mapIds = Seq(101L, 202L)
+    mapIds.foreach(manager.trackMapForShuffle(shuffleId, _))
+
+    val result = manager.unregisterShuffle(shuffleId)
+
+    mapIds.foreach { mid =>
+      verify(mockIsbr).removeDataByMap(shuffleId, mid)
+    }
+    assert(result)
+  }
+}

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleManagerUnregisterSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/RapidsShuffleManagerUnregisterSuite.scala
@@ -15,7 +15,6 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "321"}
 {"spark": "330"}
 {"spark": "331"}
 {"spark": "332"}


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14704 
Fixes https://github.com/NVIDIA/spark-rapids/issues/14683
Cherry-pick #14714

This PR is a cherry pick from #14714. 

----


### Description
This PR is a bit of a combo. It is primarily targeted to fix https://github.com/NVIDIA/spark-rapids/issues/14704, so we stop double counting shuffle write bytes as spill, but it also adds a test for https://github.com/NVIDIA/spark-rapids/issues/14683 to close it out (so we make sure we remove shuffle on unrgister)

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required