### PR TITLE
Fall back from /dev/tty to /dev/stdout in buildall single-shim builds

### DIFF
--- a/build/buildall
+++ b/build/buildall
@@ -241,8 +241,19 @@ function build_single_shim() {
   [[ "$BUILD_ALL_DEBUG" == "1" ]] && set -x
   BUILD_VER=$1
   mkdir -p "$MVN_BASE_DIR/target"
-  (( BUILD_PARALLEL == 1 || NUM_SHIMS == 1 )) && LOG_FILE="/dev/tty" || \
+  if (( BUILD_PARALLEL == 1 || NUM_SHIMS == 1 )); then
+    # Single-shim/serial build: stream Maven output live rather than to a log
+    # file. Prefer the controlling terminal, but fall back to stdout when there
+    # is none (CI, containers, xargs workers) so the build does not fail on a
+    # missing /dev/tty.
+    if { : > /dev/tty; } 2>/dev/null; then
+      LOG_FILE="/dev/tty"
+    else
+      LOG_FILE="/dev/stdout"
+    fi
+  else
     LOG_FILE="$MVN_BASE_DIR/target/mvn-build-$BUILD_VER.log"
+  fi
 
   if [[ "$BUILD_VER" == "$BASE_VER" ]]; then
     SKIP_CHECKS="false"
@@ -268,7 +279,12 @@ function build_single_shim() {
       -Dmaven.scaladoc.skip \
       -Dmaven.scalastyle.skip="$SKIP_CHECKS" \
       -pl tools -am > "$LOG_FILE" 2>&1 || {
-        [[ "$LOG_FILE" != "/dev/tty" ]] && echo "$LOG_FILE:" && tail -500 "$LOG_FILE" || true
+        # Only tail when output went to a real log file; for a live stream
+        # (/dev/tty or /dev/stdout) the failure output is already on screen.
+        case "$LOG_FILE" in
+          /dev/tty|/dev/stdout) ;;
+          *) echo "$LOG_FILE:"; tail -500 "$LOG_FILE" ;;
+        esac
         exit 255
       }
 }

--- a/build/buildall
+++ b/build/buildall
@@ -243,13 +243,13 @@ function build_single_shim() {
   mkdir -p "$MVN_BASE_DIR/target"
   if (( BUILD_PARALLEL == 1 || NUM_SHIMS == 1 )); then
     # Single-shim/serial build: stream Maven output live rather than to a log
-    # file. Prefer the controlling terminal, but fall back to stdout when there
-    # is none (CI, containers, xargs workers) so the build does not fail on a
-    # missing /dev/tty.
+    # file. Prefer the controlling terminal, but fall back to existing stdout
+    # when there is none (CI, containers, xargs workers) so the build does not
+    # fail on a missing /dev/tty or an unavailable /dev/stdout path.
     if { : > /dev/tty; } 2>/dev/null; then
       LOG_FILE="/dev/tty"
     else
-      LOG_FILE="/dev/stdout"
+      LOG_FILE=""
     fi
   else
     LOG_FILE="$MVN_BASE_DIR/target/mvn-build-$BUILD_VER.log"
@@ -271,18 +271,25 @@ function build_single_shim() {
     MVN_PHASE="package"
   fi
 
-  echo "#### REDIRECTING mvn output to $LOG_FILE ####"
-  $MVN -U "$MVN_PHASE" \
-      -DskipTests \
-      -Dbuildver="$BUILD_VER" \
-      -Drat.skip="$SKIP_CHECKS" \
-      -Dmaven.scaladoc.skip \
-      -Dmaven.scalastyle.skip="$SKIP_CHECKS" \
-      -pl tools -am > "$LOG_FILE" 2>&1 || {
+  echo "#### REDIRECTING mvn output to ${LOG_FILE:-stdout} ####"
+  (
+    if [[ "$LOG_FILE" == "" ]]; then
+      exec 2>&1 || exit $?
+    else
+      exec > "$LOG_FILE" 2>&1 || exit $?
+    fi
+    $MVN -U "$MVN_PHASE" \
+        -DskipTests \
+        -Dbuildver="$BUILD_VER" \
+        -Drat.skip="$SKIP_CHECKS" \
+        -Dmaven.scaladoc.skip \
+        -Dmaven.scalastyle.skip="$SKIP_CHECKS" \
+        -pl tools -am
+  ) || {
         # Only tail when output went to a real log file; for a live stream
-        # (/dev/tty or /dev/stdout) the failure output is already on screen.
+        # (/dev/tty or existing stdout) the failure output is already on screen.
         case "$LOG_FILE" in
-          /dev/tty|/dev/stdout) ;;
+          ""|/dev/tty) ;;
           *) echo "$LOG_FILE:"; tail -500 "$LOG_FILE" ;;
         esac
         exit 255


### PR DESCRIPTION
### Description

Small change that allows using buildall without a tty present. Better for automation or inside of a docker container.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
