### PR TITLE
Keep row transition for final AQE exchanges [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4967,6 +4967,10 @@ object GpuOverrideUtil extends Logging {
 /** Tag the initial plan when AQE is enabled */
 case class GpuQueryStagePrepOverrides() extends Rule[SparkPlan] with Logging {
   override def apply(sparkPlan: SparkPlan): SparkPlan = GpuOverrideUtil.tryOverride { plan =>
+    // Exposing a bare exchange at the root is only valid while AQE is preparing a
+    // query stage. Tag the exchanges seen in this rule so transition cleanup can
+    // distinguish that path from final adaptive plan execution.
+    GpuTransitionOverrides.tagAqeQueryStageExchanges(plan)
     // Note that we disregard the GPU plan returned here and instead rely on side effects of
     // tagging the underlying SparkPlan.
     GpuOverrides().applyWithContext(plan, Some("AQE Query Stage Prep"))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -30,6 +30,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
@@ -132,19 +133,23 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       // because we need to return an operator that implements `BroadcastExchangeLike` or
       // `ShuffleExchangeLike`.
       bb.child match {
-        case GpuShuffleCoalesceExec(e: GpuShuffleExchangeExecBase, _) if parent.isEmpty =>
+        case GpuShuffleCoalesceExec(e: GpuShuffleExchangeExecBase, _)
+            if GpuTransitionOverrides.canExposeExchangeForAqeStage(e, parent) =>
           // The coalesce step gets added back into the plan later on, in a
           // future query stage that reads the output from this query stage. This
           // is handled in the case clauses below.
           e.withNewChildren(e.children.map(c => optimizeAdaptiveTransitions(c, Some(e))))
-        case GpuCoalesceBatches(e: GpuShuffleExchangeExecBase, _) if parent.isEmpty =>
+        case GpuCoalesceBatches(e: GpuShuffleExchangeExecBase, _)
+            if GpuTransitionOverrides.canExposeExchangeForAqeStage(e, parent) =>
           // The coalesce step gets added back into the plan later on, in a
           // future query stage that reads the output from this query stage. This
           // is handled in the case clauses below.
           e.withNewChildren(e.children.map(c => optimizeAdaptiveTransitions(c, Some(e))))
         case _ => optimizeAdaptiveTransitions(bb.child, Some(bb)) match {
-          case e: GpuBroadcastExchangeExecBase => e
-          case e: GpuShuffleExchangeExecBase => e
+          case e: GpuBroadcastExchangeExecBase
+              if GpuTransitionOverrides.canExposeExchangeForAqeStage(e, parent) => e
+          case e: GpuShuffleExchangeExecBase
+              if GpuTransitionOverrides.canExposeExchangeForAqeStage(e, parent) => e
           case other => GpuColumnarToRowExec(other)
         }
       }
@@ -870,6 +875,28 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
 }
 
 object GpuTransitionOverrides {
+  val aqeQueryStageExchange = TreeNodeTag[Boolean]("rapids.aqe.queryStageExchange")
+
+  def tagAqeQueryStageExchanges(plan: SparkPlan): Unit = {
+    plan.foreach {
+      case exchange: Exchange =>
+        exchange.setTagValue(aqeQueryStageExchange, true)
+      case _ =>
+    }
+  }
+
+  def copyAqeQueryStageExchangeTag(from: SparkPlan, to: SparkPlan): Unit = {
+    if (from.getTagValue(aqeQueryStageExchange).contains(true)) {
+      to.setTagValue(aqeQueryStageExchange, true)
+    }
+  }
+
+  private def canExposeExchangeForAqeStage(
+      exchange: SparkPlan,
+      parent: Option[SparkPlan]): Boolean = {
+    parent.isEmpty && exchange.getTagValue(aqeQueryStageExchange).contains(true)
+  }
+
   /**
    * Returning the underlying plan of a query stage, or the plan itself if it is not a
    * query stage. This method is typically used when we want to determine if a plan is

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -345,8 +345,10 @@ class GpuBroadcastMeta(
   }
 
   override def convertToGpu(): GpuExec = {
-    GpuBroadcastExchangeExec(exchange.mode, childPlans.head.convertIfNeeded())(
+    val gpuBroadcast = GpuBroadcastExchangeExec(exchange.mode, childPlans.head.convertIfNeeded())(
       exchange.canonicalized.asInstanceOf[BroadcastExchangeExec])
+    GpuTransitionOverrides.copyAqeQueryStageExchangeTag(exchange, gpuBroadcast)
+    gpuBroadcast
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
@@ -127,7 +127,9 @@ abstract class GpuShuffleMetaBase(
         SparkShimImpl.columnarAdaptivePlan(adaptive, goal)
       case _ => childPlans.head.convertIfNeeded()
     }
-    convertShuffleToGpu(newChild)
+    val gpuShuffle = convertShuffleToGpu(newChild)
+    GpuTransitionOverrides.copyAqeQueryStageExchangeTag(shuffle, gpuShuffle)
+    gpuShuffle
   }
 
   protected def convertShuffleToGpu(newChild: SparkPlan): GpuExec = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.joins.SortMergeJoinExec
 import org.apache.spark.sql.functions.{col, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{ExecutionPlanCaptureCallback, GpuFileSourceScanExec}
-import org.apache.spark.sql.rapids.execution.{GpuCustomShuffleReaderExec, GpuJoinExec}
+import org.apache.spark.sql.rapids.execution.{GpuCustomShuffleReaderExec, GpuJoinExec, GpuShuffleExchangeExecBase}
 import org.apache.spark.sql.rapids.shims.TrampolineConnectShims.SparkSession
 import org.apache.spark.sql.types.{ArrayType, DataTypes, DecimalType, IntegerType, StringType, StructField, StructType}
 
@@ -437,6 +437,35 @@ class AdaptiveQueryExecSuite
       // GpuColumnarToRowExec so we should see accurate metrics
       assert(transition.metrics("numOutputRows").value === 100)
 
+    }, conf)
+  }
+
+  test("Keep transition to row for final AQE repartition exchange") {
+    logError("Keep transition to row for final AQE repartition exchange")
+
+    val conf = new SparkConf()
+        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+        .set(SQLConf.ADAPTIVE_EXECUTION_FORCE_APPLY.key, "true")
+        .set(SQLConf.SORT_BEFORE_REPARTITION.key, "false")
+        .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "ShuffleExchangeExec,RoundRobinPartitioning")
+
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+
+      val df = Seq("a", "b", "c")
+          .toDF("s")
+          .selectExpr("s", "1 AS x")
+          .repartition(10)
+
+      val rows = df.collect()
+      assert(rows.map(_.getAs[String]("s")).toSet === Set("a", "b", "c"))
+
+      val finalPlan = df.queryExecution.executedPlan match {
+        case adaptive: AdaptiveSparkPlanExec => adaptive.executedPlan
+        case other => other
+      }
+      assert(!finalPlan.isInstanceOf[GpuShuffleExchangeExecBase],
+        s"Final plan should not execute a bare GPU exchange as rows: $finalPlan")
     }, conf)
   }
 


### PR DESCRIPTION
### Description

When AQE is enabled, transition cleanup can expose a bare GPU exchange at the root of the final adaptive plan. That is valid while Spark is preparing AQE query stages because Spark needs to see the exchange node, but it is invalid once Spark is collecting rows from the final plan. On a proprietary Spark distro this showed up as `IllegalStateException: Row-based execution should not occur for GpuColumnarExchange` for repartition collect paths.

This PR tags exchanges that are seen by `GpuQueryStagePrepOverrides` and copies that tag from CPU exchange nodes to the GPU exchange replacements. `optimizeAdaptiveTransitions` now exposes a root GPU exchange only when that tag is present, and otherwise keeps `GpuColumnarToRowExec` for final execution.

The user-visible effect is that final AQE repartition results can be collected normally. There are no new configs or documented behavior changes.

Test coverage added:

- `AdaptiveQueryExecSuite`: `Keep transition to row for final AQE repartition exchange`

Validation performed:

- `mvn package -pl tests -am -Dbuildver=358 -DwildcardSuites=com.nvidia.spark.rapids.AdaptiveQueryExecSuite -Dtests="Keep transition to row for final AQE repartition exchange"`
- Built and ran the affected `repart_test.py` subset in a proprietary Spark distro Docker image with AQE enabled and `NUM_LOCAL_EXECS=2`; 63 tests passed with 0 failures/errors
- Confirmed the pre-fix parent still reproduces the original failure without setting `NUM_LOCAL_EXECS`; 24 of 63 selected cases failed with the `GpuColumnarExchange` row-execution error

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
