### PR TITLE
Add regression tests for to_timestamp bug fixes

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -734,18 +734,17 @@ def test_formats_for_legacy_mode_other_formats_tz_rules():
         {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
-# Under LEGACY, Spark parses with SimpleDateFormat, which skips leading whitespace ([ \t]) before
-# every numeric field. So a multi-space date/time separator, a space/tab run after the separator,
-# and whitespace after ':' all parse to the same instant as a single space. The fixed inputs avoid
-# DST transitions so the result is unambiguous under any session timezone.
+# LEGACY parses with SimpleDateFormat, which skips leading [ \t] before every numeric field, so a
+# multi-space separator and whitespace after ':' parse the same as a single space. Inputs avoid DST
+# transitions so the instant is unambiguous in any session timezone.
 @disable_ansi_mode  # ANSI mode is tested separately.
 @tz_sensitive_test
 @pytest.mark.parametrize("input_str", [
-    "1999-12-31 11:59:59",     # single space (baseline, parses everywhere)
-    "1999-12-31  11:59:59",    # double space between date and time
-    "1999-12-31   11:59:59",   # triple space
-    "1999-12-31 \t 11:59:59",  # mixed space/tab run after the separator
-    "1999-12-31 11: 59: 59",   # whitespace after ':' before minute/second
+    "1999-12-31 11:59:59",
+    "1999-12-31  11:59:59",
+    "1999-12-31   11:59:59",
+    "1999-12-31 \t 11:59:59",
+    "1999-12-31 11: 59: 59",
 ], ids=idfn)
 def test_to_timestamp_legacy_multi_whitespace(input_str):
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -750,6 +750,26 @@ def test_to_timestamp_legacy_multi_whitespace(input_str):
         {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
+# LEGACY SimpleDateFormat skips only space and tab before fields, so a leading space/tab parses but
+# any other leading control byte (\r \f \v \b ...) is NULL on CPU. The GPU outer trim must match
+# and not strip arbitrary control characters.
+@disable_ansi_mode
+@tz_sensitive_test
+@pytest.mark.parametrize("input_str", [
+    " 2024-05-06",
+    "\t2024-05-06",
+    "\r2024-05-06",
+    "\f2024-05-06",
+    "\v2024-05-06",
+    "\b2024-05-06",
+], ids=idfn)
+def test_to_timestamp_legacy_leading_control_chars(input_str):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.createDataFrame([(input_str,)], "a string")
+            .select(f.to_timestamp(f.col("a"), "yyyy-MM-dd")),
+        {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
+         'spark.rapids.sql.incompatibleDateFormats.enabled': True})
+
 @disable_ansi_mode
 @tz_sensitive_test
 @pytest.mark.parametrize("parser_policy", ['LEGACY', 'CORRECTED'], ids=idfn)

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -734,10 +734,7 @@ def test_formats_for_legacy_mode_other_formats_tz_rules():
         {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
-# LEGACY parses with SimpleDateFormat, which skips leading [ \t] before every numeric field, so a
-# multi-space separator and whitespace after ':' parse the same as a single space. Inputs avoid DST
-# transitions so the instant is unambiguous in any session timezone.
-@disable_ansi_mode  # ANSI mode is tested separately.
+@disable_ansi_mode
 @tz_sensitive_test
 @pytest.mark.parametrize("input_str", [
     "1999-12-31 11:59:59",
@@ -753,9 +750,7 @@ def test_to_timestamp_legacy_multi_whitespace(input_str):
         {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
-# A literal space in the pattern matches exactly one ' ' under both LEGACY and CORRECTED, so a 'T'
-# separator does not parse and Spark yields NULL (unlike the format-less cast, which accepts 'T').
-@disable_ansi_mode  # ANSI mode is tested separately.
+@disable_ansi_mode
 @tz_sensitive_test
 @pytest.mark.parametrize("parser_policy", ['LEGACY', 'CORRECTED'], ids=idfn)
 def test_to_timestamp_rejects_t_separator(parser_policy):
@@ -768,8 +763,7 @@ def test_to_timestamp_rejects_t_separator(parser_policy):
             .select(f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
         conf)
 
-# Same 'T'-rejection contract for a packed-date legacy timestamp format.
-@disable_ansi_mode  # ANSI mode is tested separately.
+@disable_ansi_mode
 @tz_sensitive_test
 def test_to_timestamp_legacy_packed_rejects_t_separator():
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -20,7 +20,7 @@ from datetime import date, datetime, timezone
 from dateutil import tz
 from marks import allow_non_gpu, approximate_float, datagen_overrides, disable_ansi_mode, ignore_order, incompat, tz_sensitive_test
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, is_before_spark_330, is_before_spark_350, is_databricks143_or_later
+from spark_session import with_cpu_session, is_before_spark_330, is_before_spark_350, is_before_spark_400, is_databricks143_or_later
 import pyspark.sql.functions as f
 from timezones import all_timezones, fixed_offset_timezones, fixed_offset_timezones_iana, variable_offset_timezones, variable_offset_timezones_iana
 
@@ -772,6 +772,21 @@ def test_to_timestamp_legacy_packed_rejects_t_separator():
             .select(f.to_timestamp(f.col("a"), "yyyyMMdd HH:mm:ss")),
         {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
+
+# Spark 4.0+ defaults timeParserPolicy to CORRECTED, while the plugin's getTimeParserPolicy falls
+# back to EXCEPTION. Both route through the non-legacy parser, so with the policy left UNSET the
+# GPU and CPU must still agree: one ' ' separator only, no leading-whitespace trim ('T', double
+# space, leading control char all NULL).
+@disable_ansi_mode  # ANSI mode is tested separately.
+@tz_sensitive_test
+@pytest.mark.skipif(is_before_spark_400(),
+                    reason="Spark 4.0+ defaults timeParserPolicy to CORRECTED")
+def test_to_timestamp_unset_policy_corrected_default():
+    data = [("2024-05-06 11:59:59",), ("2024-05-06  11:59:59",),
+            ("2024-05-06T11:59:59",), ("\r2024-05-06 11:59:59",)]
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.createDataFrame(data, "a string")
+            .select(f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")))
 
 @tz_sensitive_test
 @pytest.mark.parametrize("ansi_enabled", [True, False], ids=['ANSI_ON', 'ANSI_OFF'])

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -734,6 +734,52 @@ def test_formats_for_legacy_mode_other_formats_tz_rules():
         {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
          'spark.rapids.sql.incompatibleDateFormats.enabled': True})
 
+# Under LEGACY, Spark parses with SimpleDateFormat, which skips leading whitespace ([ \t]) before
+# every numeric field. So a multi-space date/time separator, a space/tab run after the separator,
+# and whitespace after ':' all parse to the same instant as a single space. The fixed inputs avoid
+# DST transitions so the result is unambiguous under any session timezone.
+@disable_ansi_mode  # ANSI mode is tested separately.
+@tz_sensitive_test
+@pytest.mark.parametrize("input_str", [
+    "1999-12-31 11:59:59",     # single space (baseline, parses everywhere)
+    "1999-12-31  11:59:59",    # double space between date and time
+    "1999-12-31   11:59:59",   # triple space
+    "1999-12-31 \t 11:59:59",  # mixed space/tab run after the separator
+    "1999-12-31 11: 59: 59",   # whitespace after ':' before minute/second
+], ids=idfn)
+def test_to_timestamp_legacy_multi_whitespace(input_str):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.createDataFrame([(input_str,)], "a string")
+            .select(f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
+        {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
+         'spark.rapids.sql.incompatibleDateFormats.enabled': True})
+
+# A literal space in the pattern matches exactly one ' ' under both LEGACY and CORRECTED, so a 'T'
+# separator does not parse and Spark yields NULL (unlike the format-less cast, which accepts 'T').
+@disable_ansi_mode  # ANSI mode is tested separately.
+@tz_sensitive_test
+@pytest.mark.parametrize("parser_policy", ['LEGACY', 'CORRECTED'], ids=idfn)
+def test_to_timestamp_rejects_t_separator(parser_policy):
+    conf = {'spark.sql.legacy.timeParserPolicy': parser_policy}
+    if parser_policy == 'LEGACY':
+        conf['spark.rapids.sql.incompatibleDateFormats.enabled'] = True
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.createDataFrame(
+            [("1999-12-31 11:59:59",), ("1999-12-31T11:59:59",)], "a string")
+            .select(f.to_timestamp(f.col("a"), "yyyy-MM-dd HH:mm:ss")),
+        conf)
+
+# Same 'T'-rejection contract for a packed-date legacy timestamp format.
+@disable_ansi_mode  # ANSI mode is tested separately.
+@tz_sensitive_test
+def test_to_timestamp_legacy_packed_rejects_t_separator():
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.createDataFrame(
+            [("20241231 23:59:58",), ("20241231T23:59:58",)], "a string")
+            .select(f.to_timestamp(f.col("a"), "yyyyMMdd HH:mm:ss")),
+        {'spark.sql.legacy.timeParserPolicy': 'LEGACY',
+         'spark.rapids.sql.incompatibleDateFormats.enabled': True})
+
 @tz_sensitive_test
 @pytest.mark.parametrize("ansi_enabled", [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
 def test_to_date(ansi_enabled):


### PR DESCRIPTION
Regression tests for the GPU `to_timestamp` parser fixes in https://github.com/NVIDIA/spark-rapids-jni/pull/4661.

### Description

The fused timestamp parser (`CastStrings.parseTimestampWithFormat`) diverged from Spark CPU on whitespace and the date/time separator for space-separated formats such as `yyyy-MM-dd HH:mm:ss`. Both cases produced silent wrong results — the GPU value differed from the CPU value with no error:

- **Whitespace (LEGACY).** Spark's `SimpleDateFormat` skips leading `[ \t]` before every numeric field, so a multi-space date/time separator, a space/tab run after the separator, or whitespace after `:` all parse on CPU. The GPU returned NULL.
- **`'T'` separator (LEGACY and CORRECTED).** A literal space in the pattern matches exactly one `' '` on CPU, so `1999-12-31T11:59:59` is NULL. The GPU accepted `'T'`.

These tests compare GPU vs CPU under `timeParserPolicy=LEGACY`/`CORRECTED` with ANSI off, using fixed inputs that avoid DST transitions so the parsed instant is unambiguous across session timezones. Added tests:

- `test_to_timestamp_legacy_multi_whitespace` — multi-space separator and whitespace after `:` (LEGACY).
- `test_to_timestamp_rejects_t_separator` — `'T'` separator rejected under both LEGACY and CORRECTED.
- `test_to_timestamp_legacy_packed_rejects_t_separator` — same `'T'` contract for the packed `yyyyMMdd HH:mm:ss` format.

**Depends on** spark-rapids-jni PR #4661 and the corresponding JNI version bump. These tests fail on the current build and pass once the fixed JNI is consumed.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
