### PR TITLE
Reduce bucketed parquet test scale [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -884,12 +884,12 @@ _BUCKET_TEST_LEFT_ROWS = 100_000
 _BUCKET_TEST_RIGHT_ROWS = 1_000_000
 
 def createBucketedTableAndJoin(spark, tbl_1, tbl_2):
-    # Keep this large enough to exercise bucketed joins, but small enough that the CPU
-    # sort/shuffle path stays stable when all reader configs run concurrently in CI.
-    spark.range(_BUCKET_TEST_LEFT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id") \
-        .sortBy("id").mode('overwrite').saveAsTable(tbl_1)
-    spark.range(_BUCKET_TEST_RIGHT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id") \
-        .sortBy("id").mode('overwrite').saveAsTable(tbl_2)
+    # Keep this large enough to exercise bucketed joins, while reducing CPU-side sort
+    # pressure. Both sides use the same bucket count so the bucketed join still applies.
+    (spark.range(_BUCKET_TEST_LEFT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id")
+        .sortBy("id").mode('overwrite').saveAsTable(tbl_1))
+    (spark.range(_BUCKET_TEST_RIGHT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id")
+        .sortBy("id").mode('overwrite').saveAsTable(tbl_2))
     bucketed_left = spark.table(tbl_1)
     bucketed_right = spark.table(tbl_2)
     return bucketed_left.join(bucketed_right, "id")

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -879,12 +879,20 @@ def test_parquet_input_meta_fallback(spark_tmp_path, v1_enabled_list, reader_con
                         'input_file_block_length()'),
             conf=all_confs)
 
+_BUCKET_TEST_NUM_BUCKETS = 8
+_BUCKET_TEST_LEFT_ROWS = 100_000
+_BUCKET_TEST_RIGHT_ROWS = 1_000_000
+
 def createBucketedTableAndJoin(spark, tbl_1, tbl_2):
-    spark.range(10e4).write.bucketBy(4, "id").sortBy("id").mode('overwrite').saveAsTable(tbl_1)
-    spark.range(10e6).write.bucketBy(4, "id").sortBy("id").mode('overwrite').saveAsTable(tbl_2)
-    bucketed_4_10e4 = spark.table(tbl_1)
-    bucketed_4_10e6 = spark.table(tbl_2)
-    return bucketed_4_10e4.join(bucketed_4_10e6, "id")
+    # Keep this large enough to exercise bucketed joins, but small enough that the CPU
+    # sort/shuffle path stays stable when all reader configs run concurrently in CI.
+    spark.range(_BUCKET_TEST_LEFT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id") \
+        .sortBy("id").mode('overwrite').saveAsTable(tbl_1)
+    spark.range(_BUCKET_TEST_RIGHT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id") \
+        .sortBy("id").mode('overwrite').saveAsTable(tbl_2)
+    bucketed_left = spark.table(tbl_1)
+    bucketed_right = spark.table(tbl_2)
+    return bucketed_left.join(bucketed_right, "id")
 
 @ignore_order
 @allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -879,13 +879,14 @@ def test_parquet_input_meta_fallback(spark_tmp_path, v1_enabled_list, reader_con
                         'input_file_block_length()'),
             conf=all_confs)
 
+# More buckets reduce per-task CPU sort pressure. Both sides must use the same
+# bucket count so Spark can still use the bucketed join path.
 _BUCKET_TEST_NUM_BUCKETS = 8
 _BUCKET_TEST_LEFT_ROWS = 100_000
 _BUCKET_TEST_RIGHT_ROWS = 1_000_000
 
 def createBucketedTableAndJoin(spark, tbl_1, tbl_2):
-    # Keep this large enough to exercise bucketed joins, while reducing CPU-side sort
-    # pressure. Both sides use the same bucket count so the bucketed join still applies.
+    # Keep this large enough to exercise bucketed joins, while reducing CPU-side sort pressure.
     (spark.range(_BUCKET_TEST_LEFT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id")
         .sortBy("id").mode('overwrite').saveAsTable(tbl_1))
     (spark.range(_BUCKET_TEST_RIGHT_ROWS).write.bucketBy(_BUCKET_TEST_NUM_BUCKETS, "id")

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -22,9 +22,15 @@ import params
 
 
 def get_test_report_path_prefix():
-    """Return the remote repo root whose integration_tests/target contains run_dir outputs."""
+    """Return the remote repo root whose integration_tests/target contains run_dir outputs.
+
+    Spark 4+ Databricks builds run from scala2.13/pom.xml, so run_pyspark_from_build.sh
+    writes run_dir* under spark-rapids/scala2.13/integration_tests/target. Spark 3.x
+    builds still use the root pom and write under spark-rapids/integration_tests/target.
+    """
     source_path = (params.jar_path if params.jar_path else "/home/ubuntu/spark-rapids").rstrip("/")
-    if params.base_spark_pom_version.startswith("4.") and not source_path.endswith("/scala2.13"):
+    if int(params.base_spark_pom_version.split(".", 1)[0]) >= 4 and \
+            not source_path.endswith("/scala2.13"):
         return "%s/scala2.13" % source_path
     return source_path
 

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -21,6 +21,14 @@ from clusterutils import ClusterUtils
 import params
 
 
+def get_test_report_path_prefix():
+    """Return the remote repo root whose integration_tests/target contains run_dir outputs."""
+    source_path = (params.jar_path if params.jar_path else "/home/ubuntu/spark-rapids").rstrip("/")
+    if params.base_spark_pom_version.startswith("4.") and not source_path.endswith("/scala2.13"):
+        return "%s/scala2.13" % source_path
+    return source_path
+
+
 def main():
     """Define main function."""
     master_addr = ClusterUtils.cluster_get_master_addr(params.workspace, params.clusterid, params.token)
@@ -45,16 +53,17 @@ def main():
     try:
         subprocess.check_call(ssh_command, shell=True)
     finally:
-        print("Copying test report tarball back")
-        if params.base_spark_pom_version.startswith("4."):
-            default_jar_path = "/home/ubuntu/spark-rapids/scala2.13"
-        else:
-            default_jar_path = "/home/ubuntu/spark-rapids"
-        report_path_prefix = params.jar_path if params.jar_path else default_jar_path
-        rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:%s/integration_tests/target/run_dir*/TEST-pytest-*.xml ./" % \
-            (ssh_args, master_addr, report_path_prefix)
+        print("Copying test reports back")
+        report_target_path = "%s/integration_tests/target" % get_test_report_path_prefix()
+        subprocess.check_call("mkdir -p integration_tests/target", shell=True)
+        rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:%s/run_dir* integration_tests/target/" % \
+            (ssh_args, master_addr, report_target_path)
         print("rsync command: %s" % rsync_command)
-        subprocess.check_call(rsync_command, shell = True)
+        subprocess.check_call(rsync_command, shell=True)
+        rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:%s/integration_tests/target/run_dir*/TEST-pytest-*.xml ./" % \
+            (ssh_args, master_addr, get_test_report_path_prefix())
+        print("rsync command: %s" % rsync_command)
+        subprocess.check_call(rsync_command, shell=True)
 
 
 if __name__ == '__main__':

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -24,13 +24,16 @@ import params
 def get_test_report_path_prefix():
     """Return the remote repo root whose integration_tests/target contains run_dir outputs.
 
-    Spark 4+ Databricks builds run from scala2.13/pom.xml, so run_pyspark_from_build.sh
-    writes run_dir* under spark-rapids/scala2.13/integration_tests/target. Spark 3.x
-    builds still use the root pom and write under spark-rapids/integration_tests/target.
+    When jar_path is provided, tests run from that uploaded JAR directory. Otherwise Spark
+    4+ Databricks builds run from scala2.13/pom.xml, so run_pyspark_from_build.sh writes
+    run_dir* under spark-rapids/scala2.13/integration_tests/target.
     """
-    source_path = (params.jar_path if params.jar_path else "/home/ubuntu/spark-rapids").rstrip("/")
-    if int(params.base_spark_pom_version.split(".", 1)[0]) >= 4 and \
-            not source_path.endswith("/scala2.13"):
+    source_path = (params.jar_path or "/home/ubuntu/spark-rapids").rstrip("/")
+    if params.jar_path:
+        return source_path
+
+    spark_major_version = int(params.base_spark_pom_version.split(".", 1)[0])
+    if spark_major_version >= 4:
         return "%s/scala2.13" % source_path
     return source_path
 

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -62,14 +62,16 @@ def main():
         print("Copying test reports back")
         report_target_path = "%s/integration_tests/target" % get_test_report_path_prefix()
         subprocess.check_call("mkdir -p integration_tests/target", shell=True)
+        # Copy the full run directories because they contain more diagnostics than the
+        # JUnit XML files, such as Spark event logs and worker logs.
         rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:%s/run_dir* integration_tests/target/" % \
             (ssh_args, master_addr, report_target_path)
         print("rsync command: %s" % rsync_command)
         subprocess.check_call(rsync_command, shell=True)
-        rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:%s/integration_tests/target/run_dir*/TEST-pytest-*.xml ./" % \
-            (ssh_args, master_addr, get_test_report_path_prefix())
-        print("rsync command: %s" % rsync_command)
-        subprocess.check_call(rsync_command, shell=True)
+        # Keep the existing Jenkins JUnit publishing flow, which expects XML files in this directory.
+        copy_xml_command = "cp integration_tests/target/run_dir*/TEST-pytest-*.xml ./"
+        print("copy xml command: %s" % copy_xml_command)
+        subprocess.check_call(copy_xml_command, shell=True)
 
 
 if __name__ == '__main__':

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -69,7 +69,7 @@ def main():
         print("rsync command: %s" % rsync_command)
         subprocess.check_call(rsync_command, shell=True)
         # Keep the existing Jenkins JUnit publishing flow, which expects XML files in this directory.
-        copy_xml_command = "cp integration_tests/target/run_dir*/TEST-pytest-*.xml ./"
+        copy_xml_command = "cp integration_tests/target/run_dir*/TEST-pytest-*.xml ./ || true"
         print("copy xml command: %s" % copy_xml_command)
         subprocess.check_call(copy_xml_command, shell=True)
 

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -32,7 +32,12 @@ def get_test_report_path_prefix():
     if params.jar_path:
         return source_path
 
-    spark_major_version = int(params.base_spark_pom_version.split(".", 1)[0])
+    try:
+        spark_major_version = int(params.base_spark_pom_version.split(".", 1)[0])
+    except ValueError:
+        print("WARNING: unable to parse base Spark version '%s'; using the default report path" %
+              params.base_spark_pom_version)
+        spark_major_version = 0
     if spark_major_version >= 4:
         return "%s/scala2.13" % source_path
     return source_path
@@ -63,18 +68,26 @@ def main():
         subprocess.check_call(ssh_command, shell=True)
     finally:
         print("Copying test reports back")
-        report_target_path = "%s/integration_tests/target" % get_test_report_path_prefix()
-        subprocess.check_call("mkdir -p integration_tests/target", shell=True)
-        # Copy the full run directories because they contain more diagnostics than the
-        # JUnit XML files, such as Spark event logs and worker logs.
-        rsync_command = "rsync -I -Pave \"ssh %s\" ubuntu@%s:%s/run_dir* integration_tests/target/" % \
-            (ssh_args, master_addr, report_target_path)
-        print("rsync command: %s" % rsync_command)
-        subprocess.check_call(rsync_command, shell=True)
-        # Keep the existing Jenkins JUnit publishing flow, which expects XML files in this directory.
-        copy_xml_command = "cp integration_tests/target/run_dir*/TEST-pytest-*.xml ./ || true"
-        print("copy xml command: %s" % copy_xml_command)
-        subprocess.check_call(copy_xml_command, shell=True)
+        try:
+            report_target_path = "%s/integration_tests/target" % get_test_report_path_prefix()
+            subprocess.check_call("mkdir -p integration_tests/target", shell=True)
+            # Copy the diagnostics needed by Jenkins while avoiding unrelated run_dir contents.
+            rsync_command = "rsync -I -Pave \"ssh %s\" --prune-empty-dirs " \
+                "--include='run_dir*/' " \
+                "--include='run_dir*/TEST-pytest-*.xml' " \
+                "--include='run_dir*/eventlog_*/***' " \
+                "--include='run_dir*/*_worker_logs.log' " \
+                "--exclude='*' ubuntu@%s:%s/ integration_tests/target/" % \
+                (ssh_args, master_addr, report_target_path)
+            print("rsync command: %s" % rsync_command)
+            subprocess.check_call(rsync_command, shell=True)
+            # Keep the existing Jenkins JUnit publishing flow, which expects XML files in this
+            # directory.
+            copy_xml_command = "cp integration_tests/target/run_dir*/TEST-pytest-*.xml ./ || true"
+            print("copy xml command: %s" % copy_xml_command)
+            subprocess.check_call(copy_xml_command, shell=True)
+        except subprocess.CalledProcessError as e:
+            print("WARNING: test report collection failed: %s" % e)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #14582.

### Description

- Reduce the larger bucketed Parquet join test table from 10M rows to 1M rows and increase the bucket count from 4 to 8 so Databricks CI is less likely to hit CPU-side sort/shuffle OOMs while preserving bucketed join coverage.
- Add named constants and an inline comment to make the test scale explicit, while noting that both sides keep the same bucket count so the bucketed join still applies.
- Fix Databricks test report collection for Spark 4.x by copying run directories from the Scala 2.13 integration test target path back to `integration_tests/target`, so event logs and pytest reports can be archived from the expected location.
- Validation: `mvn -s ~/.m2/settings_art.xml -f scala2.13/pom.xml -Dbuildver=411 -Dcuda.version=cuda13 -DskipTests -Drat.skip=true -DallowConventionalDistJar=true clean package -pl dist,integration_tests -am`.
- Validation: `SPARK_HOME=/usr/local/spark TEST_PARALLEL=8 TESTS="parquet_test.py::test_buckets" ./run_pyspark_from_build.sh` passed with 26 tests.
- Validation: local Python checks for `get_test_report_path_prefix` covered Spark 3.x and Spark 4.x report roots, including repo-root and `scala2.13` jar paths.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required