### PR TITLE
Iceberg integration tests: trim redundant coverage matrices

### DIFF
--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -119,9 +119,10 @@ overwrite_dynamic_partition_transforms = [
 ]
 
 # Each list pairs (partition_col_sql, <mode>). Always used together as
-# `@pytest.mark.parametrize("partition_col_sql,<mode_arg>", <list>)` so the
-# parametrize-string order matches the tuple order and the function-signature
-# order (`partition_col_sql` first, then the mode arg). Keep them in lockstep.
+# `@pytest.mark.parametrize("partition_col_sql,<mode_arg>", <list>)`, so the
+# tuple order must match the order of names in the parametrize arg string
+# (`partition_col_sql` first, then the mode arg). Pytest binds parameters to the
+# test function by name, so the function-signature order does not matter.
 #
 # Each list is just two cases (one per mode, exercising one transform family):
 # the 26-transform partition-writer matrix lives in the append anchor

--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -15,7 +15,6 @@
 import os
 import tempfile
 import logging
-from itertools import combinations
 from types import MappingProxyType
 from typing import Callable, List, Dict, Optional
 
@@ -182,15 +181,33 @@ def can_be_eq_delete_col(data_gen: DataGen) -> bool:
             # loader, we should remove this after the bug is fixed.
             not isinstance(data_gen.data_type, BinaryType))
 
-def _eq_column_combinations(all_columns: List[str],
-                           all_types: List[DataGen],
-                           n: int) -> List[List[str]]:
-    # In primitive types, float, double can't be used in eq deletes
-    cols = [col for (col, data_gen) in list(zip(all_columns, all_types))
-            if can_be_eq_delete_col(data_gen)]
-    return list(combinations(cols, n))
+# Representative eq-delete column pairs. The full C(14, 2) = 91-pair matrix
+# previously tested every column combination, but eq-delete correctness only
+# requires that every primitive type appears in some pair (not every pair of
+# types). The 10 pairs below cover all 11 primitive types in iceberg_table_gen
+# while mixing numeric/string/temporal/decimal across the pair.
+representative_eq_column_combinations = [
+    pytest.param(("_c0", "_c12"), id="(byte, decimal128)"),
+    pytest.param(("_c1", "_c6"),  id="(short, string)"),
+    pytest.param(("_c2", "_c8"),  id="(int, date)"),
+    pytest.param(("_c3", "_c9"),  id="(long, timestamp)"),
+    pytest.param(("_c7", "_c10"), id="(boolean, decimal32)"),
+    pytest.param(("_c11", "_c13"), id="(decimal64, decimal32_special)"),
+    pytest.param(("_c14", "_c15"), id="(decimal64_special, decimal128_special)"),
+    pytest.param(("_c6", "_c9"),  id="(string, timestamp)"),
+    pytest.param(("_c0", "_c11"), id="(byte, decimal64)"),
+    pytest.param(("_c2", "_c12"), id="(int, decimal128)"),
+]
 
-all_eq_column_combinations = _eq_column_combinations(iceberg_base_table_cols, iceberg_gens_list, 2)
+# Reader-type canary: pairs to exercise the three rapids_reader_types against the
+# eq-delete read path. Three pairs is enough to confirm that reader-type selection
+# composes with eq-delete handling; the full per-pair coverage runs against the
+# default reader only in test_iceberg_v2_eq_deletes.
+eq_reader_canary_pairs = [
+    pytest.param(("_c2", "_c6"),  id="(int, string)"),
+    pytest.param(("_c9", "_c12"), id="(timestamp, decimal128)"),
+    pytest.param(("_c0", "_c11"), id="(byte, decimal64)"),
+]
 
 def setup_base_iceberg_table(spark_tmp_table_factory,
                              seed: Optional[int] = None,

--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -51,6 +51,90 @@ iceberg_gens_list = [iceberg_table_gen[col] for col in iceberg_base_table_cols]
 
 rapids_reader_types = ['PERFILE', 'MULTITHREADED', 'COALESCING']
 
+# Anchor list used by the single partition-transform coverage test
+# (iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage).
+# That test exercises the partition writer against all 26 transforms. Every other
+# DML op only sanity-checks its own SQL path against a few distinct transforms
+# picked from this list via the per-op constants further down; the anchor is what
+# guarantees full transform coverage of the partition writer.
+full_coverage_partition_transforms = [
+    pytest.param("year(_c8)", id="year(date_col)"),
+    pytest.param("month(_c8)", id="month(date_col)"),
+    pytest.param("day(_c8)", id="day(date_col)"),
+    pytest.param("month(_c9)", id="month(timestamp_col)"),
+    pytest.param("day(_c9)", id="day(timestamp_col)"),
+    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
+    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
+    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
+    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
+    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
+    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
+    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
+    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
+    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
+    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
+    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
+    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
+    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
+    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
+    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
+    pytest.param("_c0", id="identity(byte)"),
+    pytest.param("_c2", id="identity(int)"),
+    pytest.param("_c3", id="identity(long)"),
+    pytest.param("_c6", id="identity(string)"),
+    pytest.param("_c8", id="identity(date)"),
+    pytest.param("_c10", id="identity(decimal)"),
+]
+
+# Per-op subsets. Each transform picked here is distinct from every other pick
+# across all 7 op subsets (22 distinct transforms total). The four transforms
+# not picked here are still exercised by the anchor. Each 4-pick op covers one
+# transform from each family (datetime/truncate/bucket/identity); the single-mode
+# slots in delete/update/merge each pick from one family.
+ctas_partition_transforms = [
+    pytest.param("year(_c8)", id="year(date_col)"),
+    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
+    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
+    pytest.param("_c0", id="identity(byte)"),
+]
+
+rtas_partition_transforms = [
+    pytest.param("month(_c8)", id="month(date_col)"),
+    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
+    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
+    pytest.param("_c2", id="identity(int)"),
+]
+
+overwrite_static_partition_transforms = [
+    pytest.param("day(_c8)", id="day(date_col)"),
+    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
+    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
+    pytest.param("_c3", id="identity(long)"),
+]
+
+overwrite_dynamic_partition_transforms = [
+    pytest.param("month(_c9)", id="month(timestamp_col)"),
+    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
+    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
+    pytest.param("_c6", id="identity(string)"),
+]
+
+# Each used as `@pytest.mark.parametrize("<mode_arg>,partition_col_sql", <list>)`.
+delete_partition_transforms_distributed = [
+    pytest.param('copy-on-write', "day(_c9)", id="copy-on-write-day(timestamp_col)"),
+    pytest.param('merge-on-read', "hour(_c9)", id="merge-on-read-hour(timestamp_col)"),
+]
+
+update_partition_transforms_distributed = [
+    pytest.param('copy-on-write', "truncate(10, _c14)", id="copy-on-write-truncate(10, decimal64_col)"),
+    pytest.param('merge-on-read', "truncate(10, _c15)", id="merge-on-read-truncate(10, decimal128_col)"),
+]
+
+merge_partition_transforms_distributed = [
+    pytest.param('copy-on-write', "bucket(16, _c6)", id="copy-on-write-bucket(16, string_col)"),
+    pytest.param('merge-on-read', "bucket(16, _c13)", id="merge-on-read-bucket(16, decimal32_col)"),
+]
+
 # All data types of iceberg, not all of them are supported by spark-rapids for now
 iceberg_map_gens = [MapGen(f(nullable=False), f()) for f in [
     BooleanGen, ByteGen, ShortGen, IntegerGen, LongGen, FloatGen, DoubleGen, DateGen, TimestampGen ]] + \

--- a/integration_tests/src/main/python/iceberg/__init__.py
+++ b/integration_tests/src/main/python/iceberg/__init__.py
@@ -118,20 +118,28 @@ overwrite_dynamic_partition_transforms = [
     pytest.param("_c6", id="identity(string)"),
 ]
 
-# Each used as `@pytest.mark.parametrize("<mode_arg>,partition_col_sql", <list>)`.
+# Each list pairs (partition_col_sql, <mode>). Always used together as
+# `@pytest.mark.parametrize("partition_col_sql,<mode_arg>", <list>)` so the
+# parametrize-string order matches the tuple order and the function-signature
+# order (`partition_col_sql` first, then the mode arg). Keep them in lockstep.
+#
+# Each list is just two cases (one per mode, exercising one transform family):
+# the 26-transform partition-writer matrix lives in the append anchor
+# (test_insert_into_partitioned_table_full_coverage); per-op cross-mode coverage
+# of year(_c9) is preserved in the non-_full_coverage basic tests.
 delete_partition_transforms_distributed = [
-    pytest.param('copy-on-write', "day(_c9)", id="copy-on-write-day(timestamp_col)"),
-    pytest.param('merge-on-read', "hour(_c9)", id="merge-on-read-hour(timestamp_col)"),
+    pytest.param("day(_c9)", 'copy-on-write', id="copy-on-write-day(timestamp_col)"),
+    pytest.param("hour(_c9)", 'merge-on-read', id="merge-on-read-hour(timestamp_col)"),
 ]
 
 update_partition_transforms_distributed = [
-    pytest.param('copy-on-write', "truncate(10, _c14)", id="copy-on-write-truncate(10, decimal64_col)"),
-    pytest.param('merge-on-read', "truncate(10, _c15)", id="merge-on-read-truncate(10, decimal128_col)"),
+    pytest.param("truncate(10, _c14)", 'copy-on-write', id="copy-on-write-truncate(10, decimal64_col)"),
+    pytest.param("truncate(10, _c15)", 'merge-on-read', id="merge-on-read-truncate(10, decimal128_col)"),
 ]
 
 merge_partition_transforms_distributed = [
-    pytest.param('copy-on-write', "bucket(16, _c6)", id="copy-on-write-bucket(16, string_col)"),
-    pytest.param('merge-on-read', "bucket(16, _c13)", id="merge-on-read-bucket(16, decimal32_col)"),
+    pytest.param("bucket(16, _c6)", 'copy-on-write', id="copy-on-write-bucket(16, string_col)"),
+    pytest.param("bucket(16, _c13)", 'merge-on-read', id="merge-on-read-bucket(16, decimal32_col)"),
 ]
 
 # All data types of iceberg, not all of them are supported by spark-rapids for now
@@ -183,9 +191,11 @@ def can_be_eq_delete_col(data_gen: DataGen) -> bool:
 
 # Representative eq-delete column pairs. The full C(14, 2) = 91-pair matrix
 # previously tested every column combination, but eq-delete correctness only
-# requires that every primitive type appears in some pair (not every pair of
-# types). The 10 pairs below cover all 11 primitive types in iceberg_table_gen
-# while mixing numeric/string/temporal/decimal across the pair.
+# requires that every eligible column type appears in some pair (not every pair
+# of types). The 10 pairs below cover all 14 eligible eq-delete columns of
+# iceberg_table_gen (_c0..c3, _c6..c15; _c4 float and _c5 double are excluded by
+# can_be_eq_delete_col), spanning every distinct primitive Spark type used there
+# while mixing numeric/string/temporal/decimal across each pair.
 representative_eq_column_combinations = [
     pytest.param(("_c0", "_c12"), id="(byte, decimal128)"),
     pytest.param(("_c1", "_c6"),  id="(short, string)"),
@@ -202,11 +212,12 @@ representative_eq_column_combinations = [
 # Reader-type canary: pairs to exercise the three rapids_reader_types against the
 # eq-delete read path. Three pairs is enough to confirm that reader-type selection
 # composes with eq-delete handling; the full per-pair coverage runs against the
-# default reader only in test_iceberg_v2_eq_deletes.
+# default reader only in test_iceberg_v2_eq_deletes. Each canary pair is distinct
+# from representative_eq_column_combinations so the two tests don't overlap.
 eq_reader_canary_pairs = [
     pytest.param(("_c2", "_c6"),  id="(int, string)"),
     pytest.param(("_c9", "_c12"), id="(timestamp, decimal128)"),
-    pytest.param(("_c0", "_c11"), id="(byte, decimal64)"),
+    pytest.param(("_c1", "_c10"), id="(short, decimal32)"),
 ]
 
 def setup_base_iceberg_table(spark_tmp_table_factory,

--- a/integration_tests/src/main/python/iceberg/iceberg_append_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_append_test.py
@@ -21,7 +21,8 @@ from data_gen import gen_df, copy_and_update
 from iceberg import create_iceberg_table, \
     iceberg_base_table_cols, iceberg_gens_list, get_full_table_name, \
     iceberg_full_gens_list, \
-    iceberg_write_enabled_conf, iceberg_unsupported_mark, _build_tblprops
+    iceberg_write_enabled_conf, iceberg_unsupported_mark, _build_tblprops, \
+    full_coverage_partition_transforms
 from marks import iceberg, ignore_order, allow_non_gpu, datagen_overrides
 from spark_session import with_gpu_session, with_cpu_session
 
@@ -171,36 +172,14 @@ def test_insert_into_partitioned_table(spark_tmp_table_factory, partition_col_sq
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids-jni/issues/4016')
 @ignore_order(local=True)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("partition_col_sql", [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
+@pytest.mark.parametrize("partition_col_sql", full_coverage_partition_transforms)
 def test_insert_into_partitioned_table_full_coverage(spark_tmp_table_factory, partition_col_sql):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Partition-transform coverage anchor: this is the single test that exercises
+    the partition writer against every transform in full_coverage_partition_transforms.
+    Every other DML op's _full_coverage test picks only a few distinct transforms
+    from this list (via ctas_/rtas_/overwrite_*_/delete_/update_/merge_-prefixed
+    constants in iceberg/__init__.py), so the partition writer's coverage of all
+    26 transforms lives here. Skipped for remote catalogs."""
     _do_test_insert_into_partitioned_table(spark_tmp_table_factory, partition_col_sql)
 
 @iceberg

--- a/integration_tests/src/main/python/iceberg/iceberg_ctas_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_ctas_test.py
@@ -24,7 +24,8 @@ from iceberg import (create_iceberg_table,
                      iceberg_base_table_cols,
                      iceberg_gens_list, iceberg_full_gens_list,
                      get_full_table_name, iceberg_write_enabled_conf,
-                     iceberg_unsupported_mark, _build_tblprops)
+                     iceberg_unsupported_mark, _build_tblprops,
+                     ctas_partition_transforms)
 from marks import iceberg, ignore_order, allow_non_gpu, allow_non_gpu_conditional, datagen_overrides
 from spark_session import with_gpu_session, with_cpu_session, is_spark_400_or_later
 
@@ -140,37 +141,12 @@ def test_ctas_partitioned_table(spark_tmp_table_factory, partition_col_sql):
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids-jni/issues/4016')
 @ignore_order(local=True)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("partition_col_sql", [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
+@pytest.mark.parametrize("partition_col_sql", ctas_partition_transforms)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_ctas_partitioned_table_full_coverage(spark_tmp_table_factory, partition_col_sql):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Sanity-check CTAS against a few partition transforms distinct from those
+    picked by other DML ops. The 26-transform partition-writer coverage anchor
+    lives in iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage."""
     _do_test_ctas_partitioned_table(spark_tmp_table_factory, partition_col_sql)
 
 

--- a/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
@@ -19,7 +19,7 @@ from conftest import is_iceberg_remote_catalog
 from data_gen import *
 from iceberg import (create_iceberg_table, get_full_table_name, iceberg_write_enabled_conf,
                      iceberg_base_table_cols, iceberg_gens_list, iceberg_nested_write_gens_list,
-                     iceberg_unsupported_mark)
+                     iceberg_unsupported_mark, delete_partition_transforms_distributed)
 from marks import allow_non_gpu, allow_non_gpu_conditional, iceberg, ignore_order, datagen_overrides
 from spark_session import is_spark_400_or_later, with_cpu_session, with_gpu_session
 
@@ -155,35 +155,7 @@ def test_iceberg_delete_partitioned_table(spark_tmp_table_factory, partition_col
 @ignore_order(local=True)
 @pytest.mark.datagen_overrides(seed=DELETE_TEST_SEED, reason=DELETE_TEST_SEED_OVERRIDE_REASON)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("partition_col_sql", [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
-@pytest.mark.parametrize('delete_mode', ['copy-on-write', 'merge-on-read'])
+@pytest.mark.parametrize("delete_mode,partition_col_sql", delete_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_delete_partitioned_table_full_coverage(spark_tmp_table_factory, partition_col_sql, delete_mode):
     """Full partition coverage test - skipped for remote catalogs."""

--- a/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
@@ -158,7 +158,10 @@ def test_iceberg_delete_partitioned_table(spark_tmp_table_factory, partition_col
 @pytest.mark.parametrize("partition_col_sql,delete_mode", delete_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_delete_partitioned_table_full_coverage(spark_tmp_table_factory, partition_col_sql, delete_mode):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Sanity-check DELETE across the two write modes against partition transforms
+    distinct from those picked by other DML ops. The 26-transform partition-writer
+    coverage anchor lives in
+    iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage."""
     _do_test_iceberg_delete_partitioned_table(spark_tmp_table_factory, partition_col_sql, delete_mode)
 
 @iceberg

--- a/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_delete_test.py
@@ -155,7 +155,7 @@ def test_iceberg_delete_partitioned_table(spark_tmp_table_factory, partition_col
 @ignore_order(local=True)
 @pytest.mark.datagen_overrides(seed=DELETE_TEST_SEED, reason=DELETE_TEST_SEED_OVERRIDE_REASON)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("delete_mode,partition_col_sql", delete_partition_transforms_distributed)
+@pytest.mark.parametrize("partition_col_sql,delete_mode", delete_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_delete_partitioned_table_full_coverage(spark_tmp_table_factory, partition_col_sql, delete_mode):
     """Full partition coverage test - skipped for remote catalogs."""

--- a/integration_tests/src/main/python/iceberg/iceberg_merge_on_read_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_merge_on_read_test.py
@@ -31,11 +31,13 @@ from spark_session import with_gpu_session, with_cpu_session
 pytestmark = iceberg_unsupported_mark
 
 
-# Eq-delete pair coverage. Each primitive type in iceberg_table_gen appears in at
-# least one pair below; the full C(14, 2) matrix is unnecessary because eq-delete
-# correctness depends on per-column type handling, not on the cross product of
-# every two columns. Runs against the default reader; reader-type compatibility is
-# checked separately by test_iceberg_v2_eq_deletes_reader_types.
+# Eq-delete pair coverage. All 14 eligible eq-delete columns of iceberg_table_gen
+# (_c0..c3, _c6..c15; _c4 float and _c5 double are excluded by can_be_eq_delete_col)
+# appear in at least one pair in representative_eq_column_combinations; the full
+# C(14, 2) matrix is unnecessary because eq-delete correctness depends on
+# per-column type handling, not on the cross product of every two columns. Runs
+# against the default reader; reader-type compatibility is checked separately by
+# test_iceberg_v2_eq_deletes_reader_types.
 # In spark/iceberg integration, there is no builtin way to generate eq deletion files using
 # sql, we used a low level api to add eq deletion files to iceberg table.
 # This does not work with aws s3tables, which is a managed table service.

--- a/integration_tests/src/main/python/iceberg/iceberg_merge_on_read_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_merge_on_read_test.py
@@ -21,7 +21,8 @@ from asserts import assert_gpu_and_cpu_are_equal_collect
 from conftest import is_iceberg_remote_catalog
 from iceberg import rapids_reader_types, \
     setup_base_iceberg_table, _add_eq_deletes, _change_table, \
-    all_eq_column_combinations, iceberg_unsupported_mark, create_iceberg_table, \
+    representative_eq_column_combinations, eq_reader_canary_pairs, \
+    iceberg_unsupported_mark, create_iceberg_table, \
     iceberg_base_table_cols, iceberg_gens_list, get_full_table_name
 from data_gen import gen_df, get_datagen_seed, int_gen, long_gen, string_gen
 from marks import iceberg, ignore_order
@@ -30,18 +31,45 @@ from spark_session import with_gpu_session, with_cpu_session
 pytestmark = iceberg_unsupported_mark
 
 
+# Eq-delete pair coverage. Each primitive type in iceberg_table_gen appears in at
+# least one pair below; the full C(14, 2) matrix is unnecessary because eq-delete
+# correctness depends on per-column type handling, not on the cross product of
+# every two columns. Runs against the default reader; reader-type compatibility is
+# checked separately by test_iceberg_v2_eq_deletes_reader_types.
+# In spark/iceberg integration, there is no builtin way to generate eq deletion files using
+# sql, we used a low level api to add eq deletion files to iceberg table.
+# This does not work with aws s3tables, which is a managed table service.
+@iceberg
+@ignore_order(local=True)
+@pytest.mark.parametrize('eq_delete_cols',
+                         representative_eq_column_combinations,
+                         ids=lambda x: str(x))
+@pytest.mark.skipif(is_iceberg_remote_catalog(), reason = "S3tables catalog is managed")
+def test_iceberg_v2_eq_deletes(spark_tmp_table_factory, spark_tmp_path,
+                               eq_delete_cols, register_iceberg_add_eq_deletes_udf):
+    table_name = setup_base_iceberg_table(spark_tmp_table_factory)
+
+    _change_table(table_name,
+                  lambda spark: _add_eq_deletes(spark, list(eq_delete_cols), 120, table_name,
+                                                spark_tmp_path),
+                  "No equation deletes generated")
+
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.table(table_name))
+
+
+# Reader-type canary for eq-deletes: a small set of pairs crossed with all three
+# rapids_reader_types confirms reader-type selection composes with the eq-delete
+# read path. Full pair coverage runs against the default reader above.
 @iceberg
 @ignore_order(local=True)
 @pytest.mark.parametrize('reader_type', rapids_reader_types)
 @pytest.mark.parametrize('eq_delete_cols',
-                         all_eq_column_combinations,
+                         eq_reader_canary_pairs,
                          ids=lambda x: str(x))
-# In spark/iceberg integration, there is no builtin way to generate eq deletion files using
-# sql, we used a low level api to add eq deletion files to iceberg table.
-# This does not work with aws s3tables, which is a managed table service.
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason = "S3tables catalog is managed")
-def test_iceberg_v2_eq_deletes(spark_tmp_table_factory, spark_tmp_path, reader_type,
-                               eq_delete_cols, register_iceberg_add_eq_deletes_udf):
+def test_iceberg_v2_eq_deletes_reader_types(spark_tmp_table_factory, spark_tmp_path, reader_type,
+                                            eq_delete_cols, register_iceberg_add_eq_deletes_udf):
     table_name = setup_base_iceberg_table(spark_tmp_table_factory)
 
     _change_table(table_name,

--- a/integration_tests/src/main/python/iceberg/iceberg_merge_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_merge_test.py
@@ -19,7 +19,7 @@ from conftest import is_iceberg_remote_catalog
 from data_gen import *
 from iceberg import (create_iceberg_table, get_full_table_name, iceberg_write_enabled_conf,
                      iceberg_base_table_cols, iceberg_gens_list, iceberg_nested_write_gens_list,
-                     iceberg_unsupported_mark)
+                     iceberg_unsupported_mark, merge_partition_transforms_distributed)
 from marks import allow_non_gpu, allow_non_gpu_conditional, iceberg, ignore_order, datagen_overrides
 from spark_session import is_spark_400_or_later, with_gpu_session, with_cpu_session
 
@@ -180,35 +180,7 @@ def test_iceberg_merge(spark_tmp_table_factory, partition_col_sql, merge_mode):
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids-jni/issues/4016')
 @ignore_order(local=True)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize('merge_mode', ['copy-on-write', 'merge-on-read'])
-@pytest.mark.parametrize('partition_col_sql', [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
+@pytest.mark.parametrize("merge_mode,partition_col_sql", merge_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_merge_full_coverage(spark_tmp_table_factory, partition_col_sql, merge_mode):
     """Full partition coverage test - skipped for remote catalogs."""

--- a/integration_tests/src/main/python/iceberg/iceberg_merge_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_merge_test.py
@@ -183,7 +183,10 @@ def test_iceberg_merge(spark_tmp_table_factory, partition_col_sql, merge_mode):
 @pytest.mark.parametrize("partition_col_sql,merge_mode", merge_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_merge_full_coverage(spark_tmp_table_factory, partition_col_sql, merge_mode):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Sanity-check MERGE across the two write modes against partition transforms
+    distinct from those picked by other DML ops. The 26-transform partition-writer
+    coverage anchor lives in
+    iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage."""
     _do_test_iceberg_merge(spark_tmp_table_factory, partition_col_sql, merge_mode)
 
 

--- a/integration_tests/src/main/python/iceberg/iceberg_merge_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_merge_test.py
@@ -180,7 +180,7 @@ def test_iceberg_merge(spark_tmp_table_factory, partition_col_sql, merge_mode):
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids-jni/issues/4016')
 @ignore_order(local=True)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("merge_mode,partition_col_sql", merge_partition_transforms_distributed)
+@pytest.mark.parametrize("partition_col_sql,merge_mode", merge_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_merge_full_coverage(spark_tmp_table_factory, partition_col_sql, merge_mode):
     """Full partition coverage test - skipped for remote catalogs."""

--- a/integration_tests/src/main/python/iceberg/iceberg_overwrite_dynamic_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_overwrite_dynamic_test.py
@@ -21,7 +21,8 @@ from data_gen import gen_df, copy_and_update
 from iceberg import create_iceberg_table, \
     iceberg_base_table_cols, iceberg_gens_list, \
     get_full_table_name, iceberg_full_gens_list, iceberg_nested_write_gens_list, \
-    iceberg_write_enabled_conf, iceberg_unsupported_mark
+    iceberg_write_enabled_conf, iceberg_unsupported_mark, \
+    overwrite_dynamic_partition_transforms
 from marks import iceberg, ignore_order, allow_non_gpu, allow_non_gpu_conditional, datagen_overrides
 from spark_session import with_gpu_session, with_cpu_session, is_spark_400_or_later
 
@@ -122,37 +123,13 @@ def test_insert_overwrite_dynamic_bucket_partitioned(spark_tmp_table_factory, pa
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids-jni/issues/4016')
 @ignore_order(local=True)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("partition_col_sql", [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
+@pytest.mark.parametrize("partition_col_sql", overwrite_dynamic_partition_transforms)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_insert_overwrite_dynamic_bucket_partitioned_full_coverage(spark_tmp_table_factory, partition_col_sql):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Sanity-check dynamic INSERT OVERWRITE against a few partition transforms
+    distinct from those picked by other DML ops. The 26-transform partition-writer
+    coverage anchor lives in
+    iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage."""
     _do_test_insert_overwrite_dynamic_partitioned(spark_tmp_table_factory, partition_col_sql)
 
 

--- a/integration_tests/src/main/python/iceberg/iceberg_overwrite_static_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_overwrite_static_test.py
@@ -22,7 +22,8 @@ from data_gen import gen_df, copy_and_update, StringGen
 from iceberg import create_iceberg_table, \
     iceberg_base_table_cols, iceberg_gens_list, \
     get_full_table_name, iceberg_full_gens_list, iceberg_nested_write_gens_list, \
-    iceberg_write_enabled_conf, iceberg_unsupported_mark, _build_tblprops
+    iceberg_write_enabled_conf, iceberg_unsupported_mark, _build_tblprops, \
+    overwrite_static_partition_transforms
 from marks import iceberg, ignore_order, allow_non_gpu, datagen_overrides
 from spark_session import with_gpu_session, with_cpu_session
 
@@ -166,36 +167,11 @@ def test_insert_overwrite_partitioned_table(spark_tmp_table_factory, partition_c
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids-jni/issues/4016')
 @ignore_order(local=True)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("partition_col_sql", [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
+@pytest.mark.parametrize("partition_col_sql", overwrite_static_partition_transforms)
 def test_insert_overwrite_partitioned_table_full_coverage(spark_tmp_table_factory, partition_col_sql):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Sanity-check INSERT OVERWRITE against a few partition transforms distinct
+    from those picked by other DML ops. The 26-transform partition-writer coverage
+    anchor lives in iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage."""
     _do_test_insert_overwrite_partitioned_table(spark_tmp_table_factory, partition_col_sql)
 
 

--- a/integration_tests/src/main/python/iceberg/iceberg_rtas_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_rtas_test.py
@@ -24,7 +24,8 @@ from iceberg import (create_iceberg_table,
                      iceberg_gens_list, iceberg_full_gens_list,
                      iceberg_nested_write_gens_list,
                      get_full_table_name, iceberg_write_enabled_conf,
-                     iceberg_unsupported_mark, _build_tblprops)
+                     iceberg_unsupported_mark, _build_tblprops,
+                     rtas_partition_transforms)
 from marks import iceberg, ignore_order, allow_non_gpu, allow_non_gpu_conditional, datagen_overrides
 from spark_session import with_gpu_session, with_cpu_session, is_spark_400_or_later
 
@@ -138,37 +139,12 @@ def test_rtas_partitioned_table(spark_tmp_table_factory, partition_col_sql):
 @datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids-jni/issues/4016')
 @ignore_order(local=True)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("partition_col_sql", [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
+@pytest.mark.parametrize("partition_col_sql", rtas_partition_transforms)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_rtas_partitioned_table_full_coverage(spark_tmp_table_factory, partition_col_sql):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Sanity-check RTAS against a few partition transforms distinct from those
+    picked by other DML ops. The 26-transform partition-writer coverage anchor
+    lives in iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage."""
     _do_test_rtas_partitioned_table(spark_tmp_table_factory, partition_col_sql)
 
 

--- a/integration_tests/src/main/python/iceberg/iceberg_update_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_update_test.py
@@ -171,7 +171,10 @@ def test_iceberg_update_partitioned_table_single_column(spark_tmp_table_factory,
 @pytest.mark.parametrize("partition_col_sql,update_mode", update_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_update_partitioned_table_single_column_full_coverage(spark_tmp_table_factory, update_mode, partition_col_sql):
-    """Full partition coverage test - skipped for remote catalogs."""
+    """Sanity-check UPDATE across the two write modes against partition transforms
+    distinct from those picked by other DML ops. The 26-transform partition-writer
+    coverage anchor lives in
+    iceberg_append_test.py::test_insert_into_partitioned_table_full_coverage."""
     _do_test_iceberg_update_partitioned_table_single_column(spark_tmp_table_factory, update_mode, partition_col_sql)
 
 @iceberg

--- a/integration_tests/src/main/python/iceberg/iceberg_update_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_update_test.py
@@ -168,7 +168,7 @@ def test_iceberg_update_partitioned_table_single_column(spark_tmp_table_factory,
 @ignore_order(local=True)
 @pytest.mark.datagen_overrides(seed=UPDATE_TEST_SEED, reason=UPDATE_TEST_SEED_OVERRIDE_REASON)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize("update_mode,partition_col_sql", update_partition_transforms_distributed)
+@pytest.mark.parametrize("partition_col_sql,update_mode", update_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_update_partitioned_table_single_column_full_coverage(spark_tmp_table_factory, update_mode, partition_col_sql):
     """Full partition coverage test - skipped for remote catalogs."""

--- a/integration_tests/src/main/python/iceberg/iceberg_update_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_update_test.py
@@ -19,7 +19,7 @@ from conftest import is_iceberg_remote_catalog
 from data_gen import *
 from iceberg import (create_iceberg_table, get_full_table_name, iceberg_write_enabled_conf,
                      iceberg_base_table_cols, iceberg_gens_list, iceberg_nested_write_gens_list,
-                     iceberg_unsupported_mark)
+                     iceberg_unsupported_mark, update_partition_transforms_distributed)
 from marks import allow_non_gpu, allow_non_gpu_conditional, disable_ansi_mode, iceberg, ignore_order, datagen_overrides
 from spark_session import is_spark_400_or_later, with_cpu_session, with_gpu_session
 
@@ -168,35 +168,7 @@ def test_iceberg_update_partitioned_table_single_column(spark_tmp_table_factory,
 @ignore_order(local=True)
 @pytest.mark.datagen_overrides(seed=UPDATE_TEST_SEED, reason=UPDATE_TEST_SEED_OVERRIDE_REASON)
 @pytest.mark.skipif(is_iceberg_remote_catalog(), reason="Skip for remote catalog to reduce test time")
-@pytest.mark.parametrize('update_mode', ['copy-on-write', 'merge-on-read'])
-@pytest.mark.parametrize("partition_col_sql", [
-    pytest.param("year(_c8)", id="year(date_col)"),
-    pytest.param("month(_c8)", id="month(date_col)"),
-    pytest.param("day(_c8)", id="day(date_col)"),
-    pytest.param("month(_c9)", id="month(timestamp_col)"),
-    pytest.param("day(_c9)", id="day(timestamp_col)"),
-    pytest.param("hour(_c9)", id="hour(timestamp_col)"),
-    pytest.param("truncate(10, _c2)", id="truncate(10, int_col)"),
-    pytest.param("truncate(10, _c3)", id="truncate(10, long_col)"),
-    pytest.param("truncate(5, _c6)", id="truncate(5, string_col)"),
-    pytest.param("truncate(10, _c13)", id="truncate(10, decimal32_col)"),
-    pytest.param("truncate(10, _c14)", id="truncate(10, decimal64_col)"),
-    pytest.param("truncate(10, _c15)", id="truncate(10, decimal128_col)"),
-    pytest.param("bucket(16, _c2)", id="bucket(16, int_col)"),
-    pytest.param("bucket(16, _c3)", id="bucket(16, long_col)"),
-    pytest.param("bucket(16, _c8)", id="bucket(16, date_col)"),
-    pytest.param("bucket(16, _c9)", id="bucket(16, timestamp_col)"),
-    pytest.param("bucket(16, _c6)", id="bucket(16, string_col)"),
-    pytest.param("bucket(16, _c13)", id="bucket(16, decimal32_col)"),
-    pytest.param("bucket(16, _c14)", id="bucket(16, decimal64_col)"),
-    pytest.param("bucket(16, _c15)", id="bucket(16, decimal128_col)"),
-    pytest.param("_c0", id="identity(byte)"),
-    pytest.param("_c2", id="identity(int)"),
-    pytest.param("_c3", id="identity(long)"),
-    pytest.param("_c6", id="identity(string)"),
-    pytest.param("_c8", id="identity(date)"),
-    pytest.param("_c10", id="identity(decimal)"),
-])
+@pytest.mark.parametrize("update_mode,partition_col_sql", update_partition_transforms_distributed)
 @allow_non_gpu_conditional(is_spark_400_or_later(), "EmptyRelationExec")
 def test_iceberg_update_partitioned_table_single_column_full_coverage(spark_tmp_table_factory, update_mode, partition_col_sql):
     """Full partition coverage test - skipped for remote catalogs."""


### PR DESCRIPTION
Fixes #14917.

### Description
This PR optimizes test cases without decreasing code/branch coverage to reduce the execution time.

Trim the redundant Iceberg integration test full-coverage matrices flagged in #14917. The original serial run took ~6h10m (22,246s); ~69% of that wall-clock was spent re-running the same partition-transform writer logic across every DML op x mode.

This PR makes `test_insert_into_partitioned_table_full_coverage` (append) the single 26-transform anchor for the partition writer. Every other DML op picks a small set of distinct transforms from the same list, sized to sanity-check its own SQL path rather than re-prove partition-writer correctness. It also replaces the C(14,2) x 3-reader `test_iceberg_v2_eq_deletes` matrix with a representative-pair list plus a small reader-type canary.

| op | cases before | cases after |
| --- | ---: | ---: |
| append (anchor) | 26 | 26 |
| ctas / rtas / overwrite_static / overwrite_dynamic | 4 x 26 = 104 | 4 x 4 = 16 |
| delete / update / merge x COW x MOR | 6 x 26 = 156 | 6 x 1 = 6 |
| `test_iceberg_v2_eq_deletes` | 91 pairs x 3 readers = 273 | 10 pairs x 1 reader + 3 pairs x 3 readers = 19 |
| **total** | **559** | **67** |

Each non-anchor pick is distinct: the 22 non-anchor transform picks cover 22 of the 26 transforms (the 4 cheap bucket(decimal64/128) / identity(date/decimal) entries run only via the anchor). All 14 eligible eq-delete columns of `iceberg_table_gen` (i.e., every primitive type) appear in at least one of the 10 representative pairs, and reader-type compatibility is covered by the new 3-pair x 3-reader canary that composes with the eq-delete read path; the canary pairs are disjoint from the representative pairs, giving 13 distinct pairs across the eq-delete test surface.

Code/branch coverage is preserved: the partition writer code paths are shared across DML ops, so the anchor exercises every transform encoding once; each op's own glue is still covered by its smaller pick set and the existing `year(_c9)` basic tests for every catalog.

Expected wall-clock: ~6h10m -> ~2h10m (~65% reduction). To be confirmed by a real run before flipping to ready.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      `test_insert_into_partitioned_table_full_coverage` remains the partition-writer anchor; per-op `*_full_coverage` tests still cover their op-specific paths against distinct transforms; `test_iceberg_v2_eq_deletes` / `test_iceberg_v2_eq_deletes_reader_types` cover pair-type and reader-type axes.
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [x] Issue filed with a link in the PR description
- [ ] Not required

