### PR TITLE
Fix Delta OPTIMIZE DV fallback NPE on DBR 17.3 [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_optimize_table_test.py
+++ b/integration_tests/src/main/python/delta_lake_optimize_table_test.py
@@ -71,6 +71,27 @@ def test_delta_optimize_fallback_with_existing_deletion_vectors(spark_tmp_path):
         post_setup_func=_delete_rows_and_disable_deletion_vectors)
 
 
+@delta_lake
+@allow_non_gpu('ExecutedCommandExec', *delta_meta_allow)
+@pytest.mark.skipif(not is_databricks173_or_later(),
+                    reason="Partitioned existing-DV OPTIMIZE fallback guard is for Databricks 17.3+")
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(), reason="Deletion vectors aren't supported")
+def test_delta_optimize_fallback_partitioned_table_with_existing_deletion_vectors(spark_tmp_path):
+    conf = copy_and_update(_optimize_conf, {
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.sql.adaptive.enabled": "false"
+    })
+    _assert_optimize_fallback(
+        True,
+        spark_tmp_path,
+        partition_columns=["a"],
+        conf=conf,
+        post_setup_func=_delete_rows_with_deletion_vectors,
+        # Partitioned CPU OPTIMIZE can produce different compacted files and commit
+        # metadata across independent tables, so verify fallback and data parity here.
+        check_delta_log=False)
+
+
 def _write_many_small_files(spark, enable_deletion_vectors, path, partition_columns=None, clustering_columns=None):
     if partition_columns and clustering_columns:
         raise ValueError("Only one of partition_columns or clustering_columns can be specified")
@@ -144,6 +165,11 @@ def _delete_rows_and_disable_deletion_vectors(spark, path):
     assert num_deleted > 0, "Expected DELETE to create deletion vectors"
     spark.sql(f"ALTER TABLE delta.`{path}` SET TBLPROPERTIES " +
               "('delta.enableDeletionVectors' = 'false')")
+
+
+def _delete_rows_with_deletion_vectors(spark, path):
+    num_deleted = spark.sql(f"DELETE FROM delta.`{path}` WHERE b = 'a'").collect()[0][0]
+    assert num_deleted > 0, "Expected DELETE to create deletion vectors"
 
 
 def _read_sorted(spark, path):
@@ -228,7 +254,8 @@ def _assert_optimize_parity(enable_deletion_vectors, spark_tmp_path, partition_c
 
 
 def _assert_optimize_fallback(enable_deletion_vectors, spark_tmp_path, partition_columns=None,
-                              clustering_columns=None, conf=_optimize_conf, post_setup_func=None):
+                              clustering_columns=None, conf=_optimize_conf, post_setup_func=None,
+                              check_delta_log=True):
     data_path = spark_tmp_path + "/DELTA_OPTIMIZE_FALLBACK"
     cpu_path = data_path + "/CPU"
     gpu_path = data_path + "/GPU"
@@ -255,7 +282,8 @@ def _assert_optimize_fallback(enable_deletion_vectors, spark_tmp_path, partition
     gpu_data = with_cpu_session(lambda s: _read_sorted(s, gpu_path).collect(), conf=conf)
     assert_equal(cpu_data, gpu_data)
 
-    with_cpu_session(lambda s: assert_gpu_and_cpu_latest_delta_log_equivalent(s, data_path))
+    if check_delta_log:
+        with_cpu_session(lambda s: assert_gpu_and_cpu_latest_delta_log_equivalent(s, data_path))
 
 
 @allow_non_gpu(*delta_meta_allow)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -5095,12 +5095,15 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         val foundExprs = project.expressions.flatMap { e =>
           PlanUtils.findExpressions(e, {
             case udf: ScalaUDF =>
-              val contains = udf.function.getClass.getCanonicalName.contains("tahoe.Snapshot")
-              if (contains) {
-                logDebug(s"Found ScalaUDF with tahoe.Snapshot: $udf," +
-                  s" function class name is: ${udf.function.getClass.getCanonicalName}")
+              val functionClassName = Option(udf.function.getClass.getCanonicalName)
+              functionClassName.exists { name =>
+                val contains = name.contains("tahoe.Snapshot")
+                if (contains) {
+                  logDebug(s"Found ScalaUDF with tahoe.Snapshot: $udf," +
+                    s" function class name is: $name")
+                }
+                contains
               }
-              contains
             case _ => false
           })
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -5095,15 +5095,15 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         val foundExprs = project.expressions.flatMap { e =>
           PlanUtils.findExpressions(e, {
             case udf: ScalaUDF =>
-              val functionClassName = Option(udf.function.getClass.getCanonicalName)
-              functionClassName.exists { name =>
-                val contains = name.contains("tahoe.Snapshot")
-                if (contains) {
-                  logDebug(s"Found ScalaUDF with tahoe.Snapshot: $udf," +
-                    s" function class name is: $name")
-                }
-                contains
+              val functionClass = udf.function.getClass
+              val functionClassName = Option(functionClass.getCanonicalName)
+                .getOrElse(functionClass.getName)
+              val contains = functionClassName.contains("tahoe.Snapshot")
+              if (contains) {
+                logDebug(s"Found ScalaUDF with tahoe.Snapshot: $udf," +
+                  s" function class name is: $functionClassName")
               }
+              contains
             case _ => false
           })
         }


### PR DESCRIPTION
Fixes #14944.

### Description

On DBR 17.3, `OPTIMIZE` on a Delta table with existing deletion vectors should fall back to CPU when RAPIDS is enabled. The command fallback itself is correctly triggered for DV tables, but Databricks `OPTIMIZE` runs internal Delta metadata/file-listing queries during execution. RAPIDS analyzes those internal plans and can hit an NPE in `GpuOverrides.isDeltaLakeMetadataQuery`.

The crash happens because the Delta metadata query detector assumes `udf.function.getClass.getCanonicalName` is non-null:

```scala
udf.function.getClass.getCanonicalName.contains("tahoe.Snapshot")
```
In the DBR 17.3 OPTIMIZE metadata path, some ScalaUDF function classes can be anonymous/synthetic, so getCanonicalName() returns null.

This PR makes that check null-safe by wrapping the canonical name in Option(...), preserving the existing matching behavior while avoiding the planning-time NPE.

This PR also adds a Python integration regression test for DBR 17.3+ covering partitioned Delta OPTIMIZE fallback on a table with existing deletion vectors.

### Testing
Ran the new test and verified that the test passes with the fix
```
bash integration_tests/run_pyspark_from_build.sh \
    --runtime_env=databricks \
    -m "delta_lake" \
    --delta_lake \
    --test_type=$TEST_TYPE \
    -k test_delta_optimize_fallback_partitioned_table_with_existing_deletion_vectors

======== 1 passed, 39959 deselected, 123 warnings in 103.39s (0:01:43) =========
```


### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
