### PR TITLE
Fix Delta DV zero-column scan row counts [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
@@ -285,7 +285,8 @@ class GpuDeltaParquetFileFormatBase2(
             scalaBitmap, rowGroupOffsets, rowGroupNumRows)
 
           require(numDeletedRows <= totalNumRows,
-            s"Deletion vector cardinality ($numDeletedRows) exceeds file row count ($totalNumRows)")
+            s"Deleted row count in selected row groups ($numDeletedRows) exceeds selected " +
+              s"row-group row count ($totalNumRows)")
           Math.toIntExact(totalNumRows - numDeletedRows)
         }
       }
@@ -385,7 +386,7 @@ class GpuDeltaParquetFileFormatBase2(
      * Computes the number of deleted rows within the given row ranges
      * in the bitmap.
      */
-    def countDeletedRows(
+    private[GpuDeltaParquetFileFormatBase2] def countDeletedRows(
         scalaBitmap: RoaringBitmapArray,
         rowGroupOffsets: Array[Long],
         rowGroupNumRows: Array[Int]): Long = {

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
@@ -26,6 +26,7 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.delta.RapidsDeletionVectorRowCountUtils
 import com.nvidia.spark.rapids.jni.fileio.RapidsFileIO
 import com.nvidia.spark.rapids.parquet._
 import org.apache.hadoop.conf.Configuration
@@ -274,20 +275,17 @@ class GpuDeltaParquetFileFormatBase2(
           .get(FILE_ROW_INDEX_FILTER_ID_ENCODED).asInstanceOf[Option[String]]
         val filterTypeOpt = split.otherConstantMetadataColumnValues
           .get(FILE_ROW_INDEX_FILTER_TYPE).asInstanceOf[Option[RowIndexFilterType]]
-        val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
-          conf, dvDescriptorOpt, filterTypeOpt, tablePath.get)
-        if (scalaBitmap.cardinality == 0) {
+        if (dvDescriptorOpt.isEmpty && filterTypeOpt.isEmpty) {
           Math.toIntExact(totalNumRows)
         } else {
-          val (rowGroupOffsets, rowGroupNumRows) =
-            RapidsDeletionVectors.getRowGroupMetadata(chunkedBlocks)
-          val numDeletedRows = SpillableDeletionVectorInfo.countDeletedRows(
-            scalaBitmap, rowGroupOffsets, rowGroupNumRows)
-
-          require(numDeletedRows <= totalNumRows,
-            s"Deleted row count in selected row groups ($numDeletedRows) exceeds selected " +
-              s"row-group row count ($totalNumRows)")
-          Math.toIntExact(totalNumRows - numDeletedRows)
+          val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
+            conf, dvDescriptorOpt, filterTypeOpt, tablePath.get)
+          RapidsDeletionVectorRowCountUtils.computeNumRowsAlive(
+            totalNumRows, scalaBitmap.cardinality, chunkedBlocks) { countDeletedRow =>
+            scalaBitmap.forEach { deletedIndex: Long =>
+              countDeletedRow(deletedIndex)
+            }
+          }
         }
       }
     }
@@ -382,39 +380,13 @@ class GpuDeltaParquetFileFormatBase2(
 
   object SpillableDeletionVectorInfo {
 
-    /**
-     * Computes the number of deleted rows within the given row ranges
-     * in the bitmap.
-     */
-    def countDeletedRows(
-        scalaBitmap: RoaringBitmapArray,
-        rowGroupOffsets: Array[Long],
-        rowGroupNumRows: Array[Int]): Long = {
-      if (scalaBitmap.cardinality == 0) return 0L
-      var count = 0L
-      val rowRanges = rowGroupOffsets.zip(rowGroupNumRows)
-      // Computes the number of deleted rows by iterating only over the set bits
-      // in the bitmap (deleted row indices) and checking which row group each
-      // belongs to. This is O(deleted_rows * num_row_groups) instead of
-      // O(total_rows). The former is usually smaller than the latter.
-      // This is a temporary solution until we add a dedicated API in cuDF.
-      scalaBitmap.forEach { deletedIndex: Long =>
-        rowRanges.find { case (offset, numRows) =>
-          deletedIndex >= offset && deletedIndex < offset + numRows
-        }.foreach { _ =>
-          // If the deleted index falls within this row group, count it as deleted.
-          count += 1L
-        }
-      }
-      count
-    }
-
     def apply(
         serializedBitmap: HostMemoryBuffer,
         scalaBitmap: RoaringBitmapArray,
         rowGroupOffsets: Array[Long],
         rowGroupNumRows: Array[Int]): SpillableDeletionVectorInfo = {
-      val numRowsDeleted = countDeletedRows(scalaBitmap, rowGroupOffsets, rowGroupNumRows)
+      val numRowsDeleted =
+        RapidsDeletionVectors.countDeletedRows(scalaBitmap, rowGroupOffsets, rowGroupNumRows)
       new SpillableDeletionVectorInfo(
         SpillableHostBuffer(
           serializedBitmap,
@@ -1176,27 +1148,14 @@ class GpuDeltaParquetFileFormatBase2(
               SpillPriorities.ACTIVE_BATCHING_PRIORITY)
             closeOnExcept(gpuBitmap) { _ =>
               val filterTypeOpt = entry.dvDescriptor.map(_ => RowIndexFilterType.IF_CONTAINED)
-              val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
-                conf, entry.dvDescriptor, filterTypeOpt, tp)
               val totalRows = entry.rowGroupNumRows.map(_.toLong).sum
-              val numDeleted: Long = if (scalaBitmap.cardinality == 0) {
+              val numDeleted = if (entry.dvDescriptor.isEmpty) {
                 0L
               } else {
-                // Computes the number of rows deleted within given row ranges.
-                // This currently requires iterating through the bitmap and
-                // checking each deleted index against the row ranges.
-                // This is a temporary solution until we add a dedicated API in cuDF.
-                var count = 0L
-                val rowRanges = entry.rowGroupOffsets.zip(entry.rowGroupNumRows)
-                scalaBitmap.forEach { deletedIndex: Long =>
-                  rowRanges.find { case (offset, numRows) =>
-                    deletedIndex >= offset && deletedIndex < offset + numRows
-                  }.foreach { _ =>
-                    // If the deleted index falls within this row group, count it as deleted.
-                    count += 1L
-                  }
-                }
-                count
+                val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
+                  conf, entry.dvDescriptor, filterTypeOpt, tp)
+                RapidsDeletionVectors.countDeletedRows(
+                  scalaBitmap, entry.rowGroupOffsets, entry.rowGroupNumRows)
               }
               require(numDeleted <= totalRows,
                 s"Deletion vector cardinality ($numDeleted) exceeds " +

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
@@ -386,7 +386,7 @@ class GpuDeltaParquetFileFormatBase2(
      * Computes the number of deleted rows within the given row ranges
      * in the bitmap.
      */
-    private[GpuDeltaParquetFileFormatBase2] def countDeletedRows(
+    def countDeletedRows(
         scalaBitmap: RoaringBitmapArray,
         rowGroupOffsets: Array[Long],
         rowGroupNumRows: Array[Int]): Long = {

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/GpuDeltaParquetFileFormatBase2.scala
@@ -264,6 +264,33 @@ class GpuDeltaParquetFileFormatBase2(
     readDataSchema, debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,
     compressCfg, execMetrics, useFieldId) {
 
+    override protected def computeNumRowsAlive(
+        totalNumRows: Long,
+        chunkedBlocks: Seq[BlockMetaData]): Int = {
+      if (totalNumRows == 0 || tablePath.isEmpty) {
+        Math.toIntExact(totalNumRows)
+      } else {
+        val dvDescriptorOpt = split.otherConstantMetadataColumnValues
+          .get(FILE_ROW_INDEX_FILTER_ID_ENCODED).asInstanceOf[Option[String]]
+        val filterTypeOpt = split.otherConstantMetadataColumnValues
+          .get(FILE_ROW_INDEX_FILTER_TYPE).asInstanceOf[Option[RowIndexFilterType]]
+        val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
+          conf, dvDescriptorOpt, filterTypeOpt, tablePath.get)
+        if (scalaBitmap.cardinality == 0) {
+          Math.toIntExact(totalNumRows)
+        } else {
+          val (rowGroupOffsets, rowGroupNumRows) =
+            RapidsDeletionVectors.getRowGroupMetadata(chunkedBlocks)
+          val numDeletedRows = SpillableDeletionVectorInfo.countDeletedRows(
+            scalaBitmap, rowGroupOffsets, rowGroupNumRows)
+
+          require(numDeletedRows <= totalNumRows,
+            s"Deletion vector cardinality ($numDeletedRows) exceeds file row count ($totalNumRows)")
+          Math.toIntExact(totalNumRows - numDeletedRows)
+        }
+      }
+    }
+
     override protected def readBuffer(
         parquetOpts: ParquetOptions,
         colTypes: Array[DataType],
@@ -358,7 +385,7 @@ class GpuDeltaParquetFileFormatBase2(
      * Computes the number of deleted rows within the given row ranges
      * in the bitmap.
      */
-    private def countDeletedRows(
+    def countDeletedRows(
         scalaBitmap: RoaringBitmapArray,
         rowGroupOffsets: Array[Long],
         rowGroupNumRows: Array[Int]): Long = {

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/RapidsDeletionVectors.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/RapidsDeletionVectors.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.delta.common
 
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.delta.RapidsDeletionVectorRowCountUtils
 import com.nvidia.spark.rapids.jni.fileio.RapidsFileIO
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -168,16 +169,22 @@ object RapidsDeletionVectors extends Logging {
     }
   }
 
-  def getRowGroupMetadata(blocks: collection.Seq[BlockMetaData]): (Array[Long], Array[Int]) = {
-    val rowGroupOffsets = blocks.map(_.getRowIndexOffset)
-    if (rowGroupOffsets.find(offset => offset < 0).isDefined) {
-      throw new IllegalStateException("Found invalid row group offset")
+  def getRowGroupMetadata(blocks: collection.Seq[BlockMetaData]): (Array[Long], Array[Int]) =
+    RapidsDeletionVectorRowCountUtils.getRowGroupMetadata(blocks)
+
+  /**
+   * Computes the number of deleted rows within the given row ranges in the bitmap.
+   */
+  def countDeletedRows(
+      scalaBitmap: RoaringBitmapArray,
+      rowGroupOffsets: Array[Long],
+      rowGroupNumRows: Array[Int]): Long = {
+    RapidsDeletionVectorRowCountUtils.countDeletedRows(
+      scalaBitmap.cardinality, rowGroupOffsets, rowGroupNumRows) { countDeletedRow =>
+        scalaBitmap.forEach { deletedIndex: Long =>
+          countDeletedRow(deletedIndex)
+        }
     }
-    val rowGroupNumRows = blocks.map(_.getRowCount)
-    if (rowGroupNumRows.find(numRows => !numRows.isValidInt).isDefined) {
-      throw new IllegalStateException("Found invalid row group num rows")
-    }
-    (rowGroupOffsets.toArray, rowGroupNumRows.map(_.toInt).toArray)
   }
 
   /**

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeletionVectorRowCountUtils.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeletionVectorRowCountUtils.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta
+
+import org.apache.parquet.hadoop.metadata.BlockMetaData
+
+object RapidsDeletionVectorRowCountUtils {
+  def getRowGroupMetadata(blocks: collection.Seq[BlockMetaData]): (Array[Long], Array[Int]) = {
+    val rowGroupOffsets = blocks.map(_.getRowIndexOffset)
+    if (rowGroupOffsets.exists(_ < 0)) {
+      throw new IllegalStateException("Found invalid row group offset")
+    }
+    val rowGroupNumRows = blocks.map(_.getRowCount)
+    if (rowGroupNumRows.exists(numRows => !numRows.isValidInt)) {
+      throw new IllegalStateException("Found invalid row group num rows")
+    }
+    (rowGroupOffsets.toArray, rowGroupNumRows.map(_.toInt).toArray)
+  }
+
+  /**
+   * Computes the number of deleted rows within the given row ranges.
+   *
+   * The caller supplies bitmap iteration so OSS and Databricks shims can adapt
+   * their distinct RoaringBitmapArray types without coupling this shared source
+   * set to either implementation.
+   */
+  def countDeletedRows(
+      bitmapCardinality: Long,
+      rowGroupOffsets: Array[Long],
+      rowGroupNumRows: Array[Int])(
+      foreachDeletedRow: (Long => Unit) => Unit): Long = {
+    if (bitmapCardinality == 0) {
+      0L
+    } else {
+      var count = 0L
+      val rowRanges = rowGroupOffsets.zip(rowGroupNumRows)
+      // Computes the number of deleted rows by iterating only over the set bits
+      // in the bitmap (deleted row indices) and checking which row group each
+      // belongs to. This is O(deleted_rows * num_row_groups) instead of
+      // O(total_rows). The former is usually smaller than the latter.
+      // cuDF added a dedicated API in https://github.com/rapidsai/cudf/pull/21963.
+      // Track the Spark RAPIDS follow-up in
+      // https://github.com/NVIDIA/spark-rapids/issues/14628.
+      foreachDeletedRow { deletedIndex: Long =>
+        rowRanges.find { case (offset, numRows) =>
+          deletedIndex >= offset && deletedIndex < offset + numRows
+        }.foreach { _ =>
+          // If the deleted index falls within this row group, count it as deleted.
+          count += 1L
+        }
+      }
+      count
+    }
+  }
+
+  def computeNumRowsAlive(
+      totalNumRows: Long,
+      bitmapCardinality: Long,
+      chunkedBlocks: collection.Seq[BlockMetaData])(
+      foreachDeletedRow: (Long => Unit) => Unit): Int = {
+    val (rowGroupOffsets, rowGroupNumRows) = getRowGroupMetadata(chunkedBlocks)
+    val numDeletedRows = countDeletedRows(bitmapCardinality, rowGroupOffsets, rowGroupNumRows)(
+      foreachDeletedRow)
+
+    require(numDeletedRows <= totalNumRows,
+      s"Deleted row count in selected row groups ($numDeletedRows) exceeds selected " +
+        s"row-group row count ($totalNumRows)")
+    Math.toIntExact(totalNumRows - numDeletedRows)
+  }
+}

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeletionVectorRowCountUtils.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeletionVectorRowCountUtils.scala
@@ -16,11 +16,12 @@
 
 package com.nvidia.spark.rapids.delta
 
+import com.nvidia.spark.rapids.shims.parquet.GpuParquetUtilsShims
 import org.apache.parquet.hadoop.metadata.BlockMetaData
 
 object RapidsDeletionVectorRowCountUtils {
   def getRowGroupMetadata(blocks: collection.Seq[BlockMetaData]): (Array[Long], Array[Int]) = {
-    val rowGroupOffsets = blocks.map(_.getRowIndexOffset)
+    val rowGroupOffsets = blocks.map(GpuParquetUtilsShims.getRowIndexOffset)
     if (rowGroupOffsets.exists(_ < 0)) {
       throw new IllegalStateException("Found invalid row group offset")
     }

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
@@ -366,20 +366,19 @@ case class GpuDeltaParquetFileFormatNativeDV(
       if (totalNumRows == 0 || tablePathOpt.isEmpty) {
         Math.toIntExact(totalNumRows)
       } else {
-        val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
-          conf, split, tablePathOpt.get, deletionVectorReadInfo)
-        if (scalaBitmap.cardinality == 0) {
+        val dv = RapidsDeletionVectors.lookupDeletionVector(split, deletionVectorReadInfo)
+        if (dv.dvDescriptor.isEmpty && dv.filterType.isEmpty &&
+            dv.rowIndexFilterProvider.isEmpty) {
           Math.toIntExact(totalNumRows)
         } else {
-          val (rowGroupOffsets, rowGroupNumRows) =
-            RapidsDeletionVectors.getRowGroupMetadata(chunkedBlocks)
-          val numDeletedRows = SpillableDeletionVectorInfo.countDeletedRows(
-            scalaBitmap, rowGroupOffsets, rowGroupNumRows)
-
-          require(numDeletedRows <= totalNumRows,
-            s"Deleted row count in selected row groups ($numDeletedRows) exceeds selected " +
-              s"row-group row count ($totalNumRows)")
-          Math.toIntExact(totalNumRows - numDeletedRows)
+          val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
+            conf, dv.dvDescriptor, dv.filterType, dv.rowIndexFilterProvider, tablePathOpt.get)
+          RapidsDeletionVectorRowCountUtils.computeNumRowsAlive(
+            totalNumRows, scalaBitmap.cardinality, chunkedBlocks) { countDeletedRow =>
+            scalaBitmap.forEach { deletedIndex: Long =>
+              countDeletedRow(deletedIndex)
+            }
+          }
         }
       }
     }
@@ -413,41 +412,13 @@ case class GpuDeltaParquetFileFormatNativeDV(
 
   object SpillableDeletionVectorInfo {
 
-    /**
-     * Computes the number of deleted rows within the given row ranges
-     * in the bitmap.
-     */
-    def countDeletedRows(
-        scalaBitmap: RoaringBitmapArray,
-        rowGroupOffsets: Array[Long],
-        rowGroupNumRows: Array[Int]): Long = {
-      if (scalaBitmap.cardinality == 0) return 0L
-      var count = 0L
-      val rowRanges = rowGroupOffsets.zip(rowGroupNumRows)
-      // Computes the number of deleted rows by iterating only over the set bits
-      // in the bitmap (deleted row indices) and checking which row group each
-      // belongs to. This is O(deleted_rows * num_row_groups) instead of
-      // O(total_rows). The former is usually smaller than the latter.
-      // cuDF added a dedicated API in https://github.com/rapidsai/cudf/pull/21963.
-      // Track the Spark RAPIDS follow-up in
-      // https://github.com/NVIDIA/spark-rapids/issues/14628.
-      scalaBitmap.forEach { deletedIndex: Long =>
-        rowRanges.find { case (offset, numRows) =>
-          deletedIndex >= offset && deletedIndex < offset + numRows
-        }.foreach { _ =>
-          // If the deleted index falls within this row group, count it as deleted.
-          count += 1L
-        }
-      }
-      count
-    }
-
     def apply(
         serializedBitmap: HostMemoryBuffer,
         scalaBitmap: RoaringBitmapArray,
         rowGroupOffsets: Array[Long],
         rowGroupNumRows: Array[Int]): SpillableDeletionVectorInfo = {
-      val numRowsDeleted = countDeletedRows(scalaBitmap, rowGroupOffsets, rowGroupNumRows)
+      val numRowsDeleted =
+        RapidsDeletionVectors.countDeletedRows(scalaBitmap, rowGroupOffsets, rowGroupNumRows)
       new SpillableDeletionVectorInfo(
         SpillableHostBuffer(
           serializedBitmap,
@@ -1289,11 +1260,16 @@ case class GpuDeltaParquetFileFormatNativeDV(
             }
             closeOnExcept(gpuBitmap) { _ =>
               val filterTypeOpt = entry.dvDescriptor.map(_ => RowIndexFilterType.IF_CONTAINED)
-              val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
-                conf, entry.dvDescriptor, filterTypeOpt, entry.rowIndexFilterProvider, tp)
               val totalRows = entry.rowGroupNumRows.map(_.toLong).sum
-              val numDeleted = SpillableDeletionVectorInfo.countDeletedRows(
-                scalaBitmap, entry.rowGroupOffsets, entry.rowGroupNumRows)
+              val numDeleted =
+                if (entry.dvDescriptor.isEmpty && entry.rowIndexFilterProvider.isEmpty) {
+                  0L
+                } else {
+                  val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
+                    conf, entry.dvDescriptor, filterTypeOpt, entry.rowIndexFilterProvider, tp)
+                  RapidsDeletionVectors.countDeletedRows(
+                    scalaBitmap, entry.rowGroupOffsets, entry.rowGroupNumRows)
+                }
               require(numDeleted <= totalRows,
                 s"Deletion vector cardinality ($numDeleted) exceeds " +
                   s"file row count ($totalRows)")

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
@@ -377,7 +377,8 @@ case class GpuDeltaParquetFileFormatNativeDV(
             scalaBitmap, rowGroupOffsets, rowGroupNumRows)
 
           require(numDeletedRows <= totalNumRows,
-            s"Deletion vector cardinality ($numDeletedRows) exceeds file row count ($totalNumRows)")
+            s"Deleted row count in selected row groups ($numDeletedRows) exceeds selected " +
+              s"row-group row count ($totalNumRows)")
           Math.toIntExact(totalNumRows - numDeletedRows)
         }
       }

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormatNativeDV.scala
@@ -359,6 +359,29 @@ case class GpuDeltaParquetFileFormatNativeDV(
         }
       }
     }
+
+    override protected def computeNumRowsAlive(
+        totalNumRows: Long,
+        chunkedBlocks: Seq[BlockMetaData]): Int = {
+      if (totalNumRows == 0 || tablePathOpt.isEmpty) {
+        Math.toIntExact(totalNumRows)
+      } else {
+        val scalaBitmap = RapidsDeletionVectors.loadScalaBitmap(
+          conf, split, tablePathOpt.get, deletionVectorReadInfo)
+        if (scalaBitmap.cardinality == 0) {
+          Math.toIntExact(totalNumRows)
+        } else {
+          val (rowGroupOffsets, rowGroupNumRows) =
+            RapidsDeletionVectors.getRowGroupMetadata(chunkedBlocks)
+          val numDeletedRows = SpillableDeletionVectorInfo.countDeletedRows(
+            scalaBitmap, rowGroupOffsets, rowGroupNumRows)
+
+          require(numDeletedRows <= totalNumRows,
+            s"Deletion vector cardinality ($numDeletedRows) exceeds file row count ($totalNumRows)")
+          Math.toIntExact(totalNumRows - numDeletedRows)
+        }
+      }
+    }
   }
 
   ///////////////////////////////////////

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeletionVectors.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/RapidsDeletionVectors.scala
@@ -352,16 +352,22 @@ object RapidsDeletionVectors extends Logging {
     }
   }
 
-  def getRowGroupMetadata(blocks: collection.Seq[BlockMetaData]): (Array[Long], Array[Int]) = {
-    val rowGroupOffsets = blocks.map(_.getRowIndexOffset)
-    if (rowGroupOffsets.exists(_ < 0)) {
-      throw new IllegalStateException("Found invalid row group offset")
+  def getRowGroupMetadata(blocks: collection.Seq[BlockMetaData]): (Array[Long], Array[Int]) =
+    RapidsDeletionVectorRowCountUtils.getRowGroupMetadata(blocks)
+
+  /**
+   * Computes the number of deleted rows within the given row ranges in the bitmap.
+   */
+  def countDeletedRows(
+      scalaBitmap: RoaringBitmapArray,
+      rowGroupOffsets: Array[Long],
+      rowGroupNumRows: Array[Int]): Long = {
+    RapidsDeletionVectorRowCountUtils.countDeletedRows(
+      scalaBitmap.cardinality, rowGroupOffsets, rowGroupNumRows) { countDeletedRow =>
+        scalaBitmap.forEach { deletedIndex: Long =>
+          countDeletedRow(deletedIndex)
+        }
     }
-    val rowGroupNumRows = blocks.map(_.getRowCount)
-    if (rowGroupNumRows.exists(numRows => !numRows.isValidInt)) {
-      throw new IllegalStateException("Found invalid row group num rows")
-    }
-    (rowGroupOffsets.toArray, rowGroupNumRows.map(_.toInt).toArray)
   }
 
   /**

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -1040,18 +1040,24 @@ def test_db173_missing_row_index_filter_assertion_guard():
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.parametrize("parquet_reader_type", ["COALESCING", "MULTITHREADED"], ids=idfn)
+@pytest.mark.parametrize("parquet_reader_type", ["PERFILE", "COALESCING", "MULTITHREADED"],
+                         ids=idfn)
 @pytest.mark.parametrize("footer_type", ["NATIVE", "JAVA"], ids=idfn)
+@pytest.mark.parametrize("query", [
+    "SELECT COUNT(*) FROM delta.`{path}` WHERE part = 0",
+    "SELECT SUM(part + 1) FROM delta.`{path}` WHERE part = 0",
+], ids=["count_star", "partition_aggregate"])
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
 @pytest.mark.skipif(is_databricks_runtime() and not is_databricks173_or_later(),
                     reason="Deletion vector scan is not supported on Databricks before 17.3")
-def test_delta_deletion_vector_native_footer_multi_row_group_count_star(
-        spark_tmp_path, parquet_reader_type, footer_type):
+def test_delta_deletion_vector_native_footer_multi_row_group_zero_column_aggregate(
+        spark_tmp_path, parquet_reader_type, footer_type, query):
     """
-    Tests zero-column projection (COUNT(*)) with deletion vectors on a partitioned Delta
-    table where each partition's Parquet file has multiple row groups. Uses a partition
-    filter so Spark performs a true zero-column scan while still applying DVs.
+    Tests a zero-column Parquet scan with deletion vectors on a partitioned Delta table where
+    each partition's Parquet file has multiple row groups. The queries either count rows or
+    reference only a partition column so Spark performs a true zero-column data scan while still
+    applying DVs.
     """
     data_path = spark_tmp_path + "/DELTA_DATA"
     num_rows = 10000
@@ -1086,10 +1092,10 @@ def test_delta_deletion_vector_native_footer_multi_row_group_count_star(
 
     if is_databricks173_or_later():
         assert_cpu_and_gpu_are_equal_collect_with_capture(
-            lambda spark: spark.sql(f"SELECT COUNT(*) FROM delta.`{data_path}` WHERE part = 0"),
-            exist_classes="GpuFileSourceScanExec",
+            lambda spark: spark.sql(query.format(path=data_path)),
+            exist_classes=r"GpuFileGpuScan parquet .* ReadSchema: struct<>",
             conf=read_conf)
     else:
         assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: spark.sql(f"SELECT COUNT(*) FROM delta.`{data_path}` WHERE part = 0"),
+            lambda spark: spark.sql(query.format(path=data_path)),
             conf=read_conf)

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -1090,12 +1090,7 @@ def test_delta_deletion_vector_native_footer_multi_row_group_zero_column_aggrega
 
     with_cpu_session(setup_tables, conf=write_conf)
 
-    if is_databricks173_or_later():
-        assert_cpu_and_gpu_are_equal_collect_with_capture(
-            lambda spark: spark.sql(query.format(path=data_path)),
-            exist_classes=r"GpuFileGpuScan parquet .* ReadSchema: struct<>",
-            conf=read_conf)
-    else:
-        assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: spark.sql(query.format(path=data_path)),
-            conf=read_conf)
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: spark.sql(query.format(path=data_path)),
+        exist_classes=r"GpuFileGpuScan parquet .* ReadSchema: struct<>",
+        conf=read_conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/GpuParquetScan.scala
@@ -3565,7 +3565,8 @@ abstract class AbstractParquetPartitionReader(
         maxReadBatchSizeRows, maxReadBatchSizeBytes, readDataSchema)
       if (clippedParquetSchema.getFieldCount == 0) {
         // not reading any data, so return a degenerate ColumnarBatch with the row count
-        val numRows = currentChunkedBlocks.map(_.getRowCount).sum.toInt
+        val numRows = computeNumRowsAlive(
+          currentChunkedBlocks.map(_.getRowCount).sum, currentChunkedBlocks)
         if (numRows == 0) {
           EmptyGpuColumnarBatchIterator
         } else {
@@ -3606,6 +3607,16 @@ abstract class AbstractParquetPartitionReader(
       chunkedBlocks: Seq[BlockMetaData],
       dataBuffer: SpillableHostBuffer
   ): Iterator[ColumnarBatch]
+
+  /**
+   * Computes the number of rows alive in the output table. This is normally the same as
+   * totalNumRows, but formats with row-level deletes can override it for zero-column reads.
+   */
+  protected def computeNumRowsAlive(
+      totalNumRows: Long,
+      chunkedBlocks: Seq[BlockMetaData]): Int = {
+    Math.toIntExact(totalNumRows)
+  }
 }
 
 class ParquetPartitionReader(

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
@@ -35,6 +35,13 @@ object GpuParquetUtilsShims {
   def setRowIndexOffset(block: BlockMetaData, offset: Long): Unit = {}
 
   /**
+   * Gets the row index offset from the BlockMetaData. Not available in Spark 3.3.x.
+   */
+  def getRowIndexOffset(block: BlockMetaData): Long = {
+    throw new UnsupportedOperationException("Row index offsets are not available in Spark 3.3.x")
+  }
+
+  /**
    * Build a new BlockMetaData from an existing one, but with a new set of column chunks metadata.
    *
    * @param existingMetadata the existing BlockMetaData to copy row index offset from

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/parquet/GpuParquetUtilsShims.scala
@@ -51,6 +51,11 @@ object GpuParquetUtilsShims {
   }
 
   /**
+   * Gets the row index offset from the BlockMetaData.
+   */
+  def getRowIndexOffset(block: BlockMetaData): Long = block.getRowIndexOffset
+
+  /**
    * Build a new BlockMetaData from an existing one, but with a new set of column chunks metadata.
    *
    * @param existingMetadata the existing BlockMetaData to copy row count and row index offset from


### PR DESCRIPTION
Fixes  https://github.com/NVIDIA/spark-rapids/issues/14949

### Description
This fixes incorrect row counts for Delta tables with deletion vectors when the GPU uses the zero-column Parquet scan path, especially with the PERFILE reader.

The issue was confirmed on both DBR 17.3 and OSS Delta. A partition-only aggregate or `COUNT(*)` query could return `GPU=5000` while CPU returned `4950` because the zero-column path used the physical row-group row count without subtracting rows masked by deletion vectors.

Changes:
- Add a Parquet reader hook to adjust zero-column scan row counts.
- Override that hook in the DBR 17.3 native Delta DV reader to count live rows from deletion vectors for the selected row groups.
- Override the same hook in the OSS Delta 3.3.x+ native DV reader path.
- Reuse the existing deleted-row counting helper for selected row groups.
- Extend the Delta DV native footer test to cover:
  - PERFILE, COALESCING, and MULTITHREADED readers
  - native and Java footer readers
  - `COUNT(*)` and partition-only aggregate queries

### Testing:
**DBR 17.3:**
  ```
  bash integration_tests/run_pyspark_from_build.sh --runtime_env=databricks -m "delta_lake" --delta_lake --test_type=$TEST_TYPE -k "test_delta_deletion_vector_native_footer_multi_row_group_zero_column_aggregate"`
  Focused result: 12 passed, 39955 deselected
```

**OSS Spark 4.0 / Delta 4.0.0:**
  ```
TEST_PARALLEL=1 ./integration_tests/run_pyspark_from_build.sh   -m delta_lake   --delta_lake   -k test_delta_deletion_vector_native_footer_multi_row_group_zero_column_aggregate
Focused result: 12 passed, 39916 deselected
  ```
### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
