### PR TITLE
[BUG] Fix Int overflow in GpuShuffleCoalesceExec concat row-count sums (#14962)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -306,6 +306,19 @@ sealed trait SerializedTableOperator[T <: AutoCloseable, R] {
   def getNumRows(table: T): Int
 
   def concat(tables: Array[T]): R
+
+  /**
+   * Sum the per-table row counts as `Long` so the accumulation cannot wrap, and
+   * fail fast if the total exceeds the `Int` row-count limit of the downstream
+   * batch metadata rather than silently propagating a wrapped (possibly
+   * negative) count.
+   */
+  final def totalNumRows(tables: Array[T]): Int = {
+    val total = tables.foldLeft(0L)((acc, t) => acc + getNumRows(t).toLong)
+    require(total <= Int.MaxValue,
+      s"coalesced row count $total exceeds Int.MaxValue")
+    total.toInt
+  }
 }
 
 class JCudfCoalescedHostResult(hostConcatResult: HostConcatResult) extends CoalescedHostResult {
@@ -329,7 +342,7 @@ class JCudfTableOperator
     assert(tables.nonEmpty, "no tables to be concatenated")
     val numCols = tables.head.header.getNumColumns
     val ret = if (numCols == 0) {
-      val totalRowsNum = tables.map(getNumRows).sum
+      val totalRowsNum = totalNumRows(tables)
       cudf_utils.HostConcatResultUtil.rowsOnlyHostConcatResult(totalRowsNum)
     } else {
       val (headers, buffers) = tables.map(t => (t.header, t.hostBuffer)).unzip
@@ -378,7 +391,7 @@ class KudoTableOperator(kudo: Option[KudoSerializer], readOption: CoalesceReadOp
     require(columns.nonEmpty, "no tables to be concatenated")
     val numCols = columns.head.spillableKudoTable.header.getNumColumns
     if (numCols == 0) {
-      val totalRowsNum = columns.map(getNumRows).sum
+      val totalRowsNum = totalNumRows(columns)
       RowCountOnlyMergeResult(totalRowsNum)
     } else {
       // "lock" all input tables in memory before merge
@@ -406,7 +419,7 @@ class KudoGpuTableOperator(dataTypes: Array[DataType])
     require(columns.nonEmpty, "no tables to be concatenated")
     val numCols = columns.head.spillableKudoTable.header.getNumColumns
     if (numCols == 0) {
-      val totalRowsNum = columns.map(getNumRows).sum
+      val totalRowsNum = totalNumRows(columns)
       new ColumnarBatch(Array.empty, totalRowsNum)
     } else {
       withResource(columns.safeMap(_.spillableKudoTable.makeKudoTable)) { kudoTables =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceSuite.scala
@@ -16,10 +16,11 @@
 
 package com.nvidia.spark.rapids
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream}
 import java.math.RoundingMode
 
-import ai.rapids.cudf.{ColumnVector, Cuda, DType, Table}
-import com.nvidia.spark.rapids.Arm.withResource
+import ai.rapids.cudf.{ColumnVector, Cuda, DType, HostMemoryBuffer, JCudfSerialization, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.jni.RmmSpark
 import com.nvidia.spark.rapids.jni.kudo.DumpOption
 import org.scalatest.BeforeAndAfterEach
@@ -267,6 +268,54 @@ class GpuShuffleCoalesceSuite extends AnyFunSuite with BeforeAndAfterEach {
       targetBatchSize = 100000,
       minSplitSize = Some(1L),
       forceSplitRetry = true)
+  }
+
+  /**
+   * Build a rows-only (zero-column) SerializedTableColumn carrying `numRows`.
+   * `writeRowsToStream` serializes only header metadata, so a row count near
+   * Int.MaxValue costs nothing to construct (no per-row allocation).
+   */
+  private def rowsOnlySerializedColumn(numRows: Int): SerializedTableColumn = {
+    val outStream = new ByteArrayOutputStream()
+    JCudfSerialization.writeRowsToStream(outStream, numRows)
+    val dIn = new DataInputStream(new ByteArrayInputStream(outStream.toByteArray))
+    val header = new JCudfSerialization.SerializedTableHeader(dIn)
+    closeOnExcept(HostMemoryBuffer.allocate(header.getDataLen, false)) { hostBuffer =>
+      JCudfSerialization.readTableIntoBuffer(dIn, header, hostBuffer)
+      new SerializedTableColumn(header, hostBuffer)
+    }
+  }
+
+  test("issue-14962: concat row-count sum widens to Long and fails fast past Int.MaxValue") {
+    val op = new JCudfTableOperator
+    // Two rows-only tables whose Int sum overflows: Int.MaxValue + a positive
+    // count wraps to a negative number under the old `.map(getNumRows).sum`.
+    withResource(rowsOnlySerializedColumn(Int.MaxValue)) { big =>
+      withResource(rowsOnlySerializedColumn(100)) { small =>
+        val tables = Array(big, small)
+
+        // RED witness: the previous Int accumulation silently wraps negative.
+        val oldIntSum = tables.map(t => t.header.getNumRows).sum
+        assert(oldIntSum < 0,
+          s"expected the old Int sum to wrap negative, got $oldIntSum")
+        assert(oldIntSum.toLong != Int.MaxValue.toLong + 100L,
+          "old Int sum should not equal the true Long total")
+
+        // GREEN: totalNumRows sums in Long and fails fast instead of wrapping.
+        val ex = intercept[IllegalArgumentException] {
+          op.totalNumRows(tables)
+        }
+        assert(ex.getMessage.contains("exceeds Int.MaxValue"),
+          s"unexpected message: ${ex.getMessage}")
+
+        // Parity: an in-range total is returned unchanged (no spurious throw).
+        withResource(rowsOnlySerializedColumn(7)) { a =>
+          withResource(rowsOnlySerializedColumn(35)) { b =>
+            assertResult(42)(op.totalNumRows(Array(a, b)))
+          }
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Closes #14962
Contributes to #14471

## What this fixes

The zero-column (rows-only) branch of all three `SerializedTableOperator.concat` implementations in `GpuShuffleCoalesceExec` computes the coalesced row count with `.map(getNumRows).sum`. `getNumRows` returns `Int`, so the sum accumulates in `Int` and silently wraps to a wrong (possibly negative) row count once the total exceeds `Int.MaxValue`. The wrapped count then flows into the batch metadata (`rowsOnlyHostConcatResult`, `RowCountOnlyMergeResult`, `ColumnarBatch`).

This is a latent integer-overflow defect catalogued by the audit in #14471. It is not a reproduced runtime failure — triggering it requires coalescing enough rows-only batches that the summed row count exceeds `Int.MaxValue` (> 2^31 rows), which is impractical to allocate in a unit test.

## Approach

Add a shared `totalNumRows` helper on the `SerializedTableOperator` trait and call it from all three sites:

```scala
final def totalNumRows(tables: Array[T]): Int = {
  val total = tables.foldLeft(0L)((acc, t) => acc + getNumRows(t).toLong)
  require(total <= Int.MaxValue,
    s"coalesced row count $total exceeds Int.MaxValue")
  total.toInt
}
```

All three sinks consume an `Int` (`ColumnarBatch`'s `numRows`, `rowsOnlyHostConcatResult`, `RowCountOnlyMergeResult`), so the total cannot be represented any wider downstream. Rather than re-introduce a silent `.toInt` truncation, the helper accumulates in `Long` and fails fast with a clear message if the (genuinely unrepresentable) total exceeds `Int.MaxValue`. In-range behavior is unchanged. The per-batch `canAddToBatch` guard already bounds a normally-built batch to `<= Int.MaxValue`; this is defense-in-depth for the three `concat` sites that do not enforce that guard themselves.

## Testing

A boundary unit test in `GpuShuffleCoalesceSuite`. Rows-only `SerializedTableColumn`s are built via `JCudfSerialization.writeRowsToStream`, which serializes only header metadata, so a row count near `Int.MaxValue` costs nothing to construct (no per-row / multi-GB allocation). The test asserts: (a) the old `.map(getNumRows).sum` wraps negative at `Int.MaxValue + 100` (documents the bug), (b) `totalNumRows` fails fast past `Int.MaxValue`, and (c) an in-range total (`7 + 35`) is returned unchanged.

## Local validation

Compile (`buildver=330`, `-pl sql-plugin -am`):

```
RAPIDS Accelerator for Apache Spark SQL Plugin ..... SUCCESS [02:17 min]
BUILD SUCCESS
```

Suite `GpuShuffleCoalesceSuite`:

```
Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
```

## Performance impact

Cold / per-batch: the three sums live in the zero-column branch of `concat`, which runs once per coalesced output batch (not per row). `totalNumRows` does one `foldLeft` pass — the same iteration count as the old `.map(getNumRows).sum` — plus a single `require`. No new allocation; widening the accumulator to `Long` is free on 64-bit. Negligible.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
