### PR TITLE
Show GPU plan for V2 table writes in the SQL UI / History Server

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -12,14 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from iceberg import get_full_table_name, iceberg_write_enabled_conf, \
     iceberg_unsupported_mark, _BASE_TBLPROPS_SQL
 from marks import iceberg
 from spark_session import with_gpu_session
 
 pytestmark = iceberg_unsupported_mark
+
+# A V2 write node (e.g. GpuAppendData) shows up in the write execution's plan graph
+# with one of these markers in its node name.
+_WRITE_MARKERS = ("Append", "Overwrite", "Replace", "Write")
+
+
+def _is_write_node(name):
+    return any(m in name for m in _WRITE_MARKERS)
 
 
 @iceberg
@@ -36,30 +42,39 @@ def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
     def run(spark):
         spark.sql(f"CREATE TABLE {table_name} (grp BIGINT, cnt BIGINT) "
                   f"USING ICEBERG {_BASE_TBLPROPS_SQL}")
-        # GROUP BY -> shuffle -> AQE re-plans; the INSERT is the write SQL execution
-        # and is the last execution, so executionsList().last() is the write.
+        # GROUP BY -> shuffle -> AQE re-plans; the INSERT is the V2 write execution.
         spark.sql(f"INSERT INTO {table_name} "
                   f"SELECT id % 8 AS grp, count(*) AS cnt FROM range(0, 100000) GROUP BY id % 8")
         # Make sure the listener bus has drained the posted plan-update events.
         spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty(30000)
         sql_store = spark._jsparkSession.sharedState().statusStore()
-        write_exec = sql_store.executionsList().last()
-        nodes = sql_store.planGraph(write_exec.executionId()).allNodes()
-        names = []
-        it = nodes.iterator()
+
+        def node_names(exec_id):
+            names = []
+            it = sql_store.planGraph(exec_id).allNodes().iterator()
+            while it.hasNext():
+                names.append(it.next().name())
+            return names
+
+        # Pick the write execution by plan content rather than list position:
+        # executionsList() ordering is implementation-defined and varies across Spark
+        # releases, and the CREATE TABLE above is its own SQL execution. The write
+        # execution is the one whose plan graph is rooted at / contains a write node.
+        execs = sql_store.executionsList()
+        it = execs.iterator()
         while it.hasNext():
-            names.append(it.next().name())
-        return names
+            names = node_names(it.next().executionId())
+            if any(_is_write_node(n) for n in names):
+                return names
+        return []
 
     names = with_gpu_session(run, conf=iceberg_write_enabled_conf)
 
-    write_markers = ("Append", "Overwrite", "Replace", "Write")
-    is_write = lambda n: any(m in n for m in write_markers)
-    # the write node itself must be there (sanity)
-    assert any(is_write(n) for n in names), \
-        f"no V2 write node in the write execution plan graph: {names}"
+    # the write node itself must be there (sanity / confirms we found the write execution)
+    assert any(_is_write_node(n) for n in names), \
+        f"no V2 write node found in any SQL execution's plan graph: {names}"
     # the regression: GPU child operators under the write must be present
-    gpu_children = [n for n in names if n.startswith("Gpu") and not is_write(n)]
+    gpu_children = [n for n in names if n.startswith("Gpu") and not _is_write_node(n)]
     assert gpu_children, \
         f"SQL UI plan graph for the V2 write is missing GPU child operators " \
         f"(only the write node is shown): {names}"

--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from iceberg import get_full_table_name, iceberg_write_enabled_conf, \
+    iceberg_unsupported_mark, _BASE_TBLPROPS_SQL
+from marks import iceberg
+from spark_session import with_gpu_session
+
+pytestmark = iceberg_unsupported_mark
+
+
+@iceberg
+def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
+    """Regression test: the SQL UI / History Server must show the GPU child
+    operators under a DataSource V2 table write (GpuV2TableWriteExec), not just
+    the write node. GpuV2TableWriteExec wraps its query in an AdaptiveSparkPlanExec
+    whose own final-plan update only refreshes its subtree, so without re-posting
+    the final plan the write execution's plan graph only contains the write node
+    and the GPU operators under it are missing. See GpuV2TableWriteExec
+    .postFinalPlanUpdateToSqlUi."""
+    table_name = get_full_table_name(spark_tmp_table_factory)
+
+    def run(spark):
+        spark.sql(f"CREATE TABLE {table_name} (grp BIGINT, cnt BIGINT) "
+                  f"USING ICEBERG {_BASE_TBLPROPS_SQL}")
+        # GROUP BY -> shuffle -> AQE re-plans; the INSERT is the write SQL execution
+        # and is the last execution, so executionsList().last() is the write.
+        spark.sql(f"INSERT INTO {table_name} "
+                  f"SELECT id % 8 AS grp, count(*) AS cnt FROM range(0, 100000) GROUP BY id % 8")
+        # Make sure the listener bus has drained the posted plan-update events.
+        spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty(30000)
+        sql_store = spark._jsparkSession.sharedState().statusStore()
+        write_exec = sql_store.executionsList().last()
+        nodes = sql_store.planGraph(write_exec.executionId()).allNodes()
+        names = []
+        it = nodes.iterator()
+        while it.hasNext():
+            names.append(it.next().name())
+        return names
+
+    names = with_gpu_session(run, conf=iceberg_write_enabled_conf)
+
+    write_markers = ("Append", "Overwrite", "Replace", "Write")
+    is_write = lambda n: any(m in n for m in write_markers)
+    # the write node itself must be there (sanity)
+    assert any(is_write(n) for n in names), \
+        f"no V2 write node in the write execution plan graph: {names}"
+    # the regression: GPU child operators under the write must be present
+    gpu_children = [n for n in names if n.startswith("Gpu") and not is_write(n)]
+    assert gpu_children, \
+        f"SQL UI plan graph for the V2 write is missing GPU child operators " \
+        f"(only the write node is shown): {names}"

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -126,10 +126,14 @@ trait GpuV2TableWriteExec extends V2CommandExec with UnaryExecNode with GpuExec 
           case aqe: AdaptiveSparkPlanExec => aqe.executedPlan
         }
         val planForUi = this.withNewChildren(Seq(finalChildPlan))
+        // Redact the plan description with the configured pattern, mirroring Spark's
+        // explain / AQE update path, so sensitive strings (e.g. credentials in options)
+        // are not written to the SQL UI / History Server event log.
+        val planDescription = Utils.redact(conf.stringRedactionPattern, planForUi.toString)
         TrampolineUtil.postEvent(sparkContext,
           SparkListenerSQLAdaptiveExecutionUpdate(
             executionIdStr.toLong,
-            planForUi.toString,
+            planDescription,
             SparkPlanInfo.fromSparkPlan(planForUi)))
       } catch {
         case NonFatal(e) =>

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -32,6 +32,8 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2
 
+import scala.util.control.NonFatal
+
 import ai.rapids.cudf.{ColumnVector => CudfColumnVector, Scalar => CudfScalar}
 import com.nvidia.spark.rapids.{GpuColumnarToRowExec, GpuColumnVector, GpuDeltaWrite, GpuExec, GpuMetric, GpuWrite}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
@@ -114,15 +116,26 @@ trait GpuV2TableWriteExec extends V2CommandExec with UnaryExecNode with GpuExec 
   protected def postFinalPlanUpdateToSqlUi(): Unit = {
     val executionIdStr = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     if (executionIdStr != null) {
-      val finalChildPlan = finalQuery.transformDown {
-        case aqe: AdaptiveSparkPlanExec => aqe.executedPlan
+      // This is a purely observational UI refresh and is called inside the write's
+      // try/catch that aborts the write on any Throwable. A failure here (e.g. building
+      // SparkPlanInfo for an unusual plan node, or posting while the SparkContext is
+      // stopping) must never abort a write whose tasks have already committed, so log
+      // and swallow non-fatal errors instead of letting them propagate.
+      try {
+        val finalChildPlan = finalQuery.transformDown {
+          case aqe: AdaptiveSparkPlanExec => aqe.executedPlan
+        }
+        val planForUi = this.withNewChildren(Seq(finalChildPlan))
+        TrampolineUtil.postEvent(sparkContext,
+          SparkListenerSQLAdaptiveExecutionUpdate(
+            executionIdStr.toLong,
+            planForUi.toString,
+            SparkPlanInfo.fromSparkPlan(planForUi)))
+      } catch {
+        case NonFatal(e) =>
+          logWarning("Failed to post the final GPU plan to the SQL UI for this V2 " +
+            "write; the write itself is unaffected.", e)
       }
-      val planForUi = this.withNewChildren(Seq(finalChildPlan))
-      TrampolineUtil.postEvent(sparkContext,
-        SparkListenerSQLAdaptiveExecutionUpdate(
-          executionIdStr.toLong,
-          planForUi.toString,
-          SparkPlanInfo.fromSparkPlan(planForUi)))
     }
   }
 

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -47,10 +47,12 @@ import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{DELETE_OPERATION, UPDAT
 import org.apache.spark.sql.catalyst.util.WriteDeltaProjections
 import org.apache.spark.sql.connector.write.{BatchWrite, DataWriter, DataWriterFactory, DeltaWriter, PhysicalWriteInfoImpl, Write, WriterCommitMessage}
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{SparkPlan, SparkPlanInfo, SQLExecution, UnaryExecNode}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources.v2.GpuDelteWritingSparkTask.filterByOperation
 import org.apache.spark.sql.execution.metric.{CustomMetrics, SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{LongAccumulator, Utils}
 
@@ -95,6 +97,35 @@ trait GpuV2TableWriteExec extends V2CommandExec with UnaryExecNode with GpuExec 
       case p => p
   }
 
+  /**
+   * Re-post the final, post-AQE plan to the SQL UI so the GPU nodes show up.
+   *
+   * An Iceberg (V2) write wraps its query in an `AdaptiveSparkPlanExec`. AQE's own
+   * final-plan update only refreshes its own subtree, so the SQL UI keeps showing this
+   * write node's pre-AQE plan and the GPU operators under it never appear. Once the write
+   * has executed (the AQE `executedPlan` is settled) we re-post a
+   * `SparkListenerSQLAdaptiveExecutionUpdate` for this execution with every
+   * `AdaptiveSparkPlanExec` replaced by its `executedPlan`.
+   *
+   * Uses `transformDown` (not a shallow match on the root) so nested
+   * `AdaptiveSparkPlanExec` — e.g. wrapped under a `ProjectExec` — are also unwrapped,
+   * keeping the unwrap symmetric with the deep AQE that produced the plan.
+   */
+  protected def postFinalPlanUpdateToSqlUi(): Unit = {
+    val executionIdStr = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    if (executionIdStr != null) {
+      val finalChildPlan = finalQuery.transformDown {
+        case aqe: AdaptiveSparkPlanExec => aqe.executedPlan
+      }
+      val planForUi = this.withNewChildren(Seq(finalChildPlan))
+      TrampolineUtil.postEvent(sparkContext,
+        SparkListenerSQLAdaptiveExecutionUpdate(
+          executionIdStr.toLong,
+          planForUi.toString,
+          SparkPlanInfo.fromSparkPlan(planForUi)))
+    }
+  }
+
   protected def writeWithV2(batchWrite: BatchWrite): Seq[InternalRow] = {
     val rdd: RDD[ColumnarBatch] = {
       val tempRdd = finalQuery.executeColumnar()
@@ -133,6 +164,11 @@ trait GpuV2TableWriteExec extends V2CommandExec with UnaryExecNode with GpuExec 
           batchWrite.onDataWriterCommit(commitMessage)
         }
       )
+
+      // The write has executed and the AQE plan is settled; refresh the SQL UI so the
+      // GPU plan is visible for this V2 write. Done before commit so the UI reflects the
+      // executed plan even if the commit later fails.
+      postFinalPlanUpdateToSqlUi()
 
       logInfo(s"Data source write support $batchWrite is committing.")
       batchWrite.commit(messages)


### PR DESCRIPTION
Fixes #14972

### Description

Vanilla Spark 3.5.6 + Spark-Rapids also triggers this bug


With the RAPIDS Accelerator and AQE enabled, the Spark SQL UI / History Server does
not reflect the executed GPU plan for DataSource V2 table writes. The write node
(e.g. `GpuAppendData`) is shown, but its child operators are missing — the plan tree
under the write shows nothing, while the actual GPU operators (`GpuHashAggregate`,
`GpuShuffleCoalesce`, ...) are absent.

Root cause: `GpuV2TableWriteExec` wraps the query in an `AdaptiveSparkPlanExec`. AQE's
own final-plan update only refreshes its own subtree, so the write node keeps the
initial (pre-AQE) `SparkPlanInfo` it was registered with, and the GPU children never
reach the UI. Plain (non-RAPIDS) Spark does not have this problem — its V2 write node's
plan includes the child subtree.

Fix: after the write has executed (the AQE `executedPlan` is settled, before commit),
re-post a `SparkListenerSQLAdaptiveExecutionUpdate` for the execution with every
`AdaptiveSparkPlanExec` replaced by its `executedPlan` (deep `transformDown`, so nested
AQE is also unwrapped). This makes the SQL UI / History Server show the GPU plan under
the write node. It is UI-only (no change to execution or results) and a no-op when
there is no active SQL execution id.

Scope: all V2 existing-table writes route through `writeWithV2`
(`GpuAppendData`, `GpuOverwritePartitionsDynamic`, `GpuOverwriteByExpression`,
`GpuWriteDelta`); CTAS/RTAS (`GpuAtomic{Create,Replace}TableAsSelect`) delegate their
data write to a nested append, so they are covered too. The outer CTAS/RTAS command
node showing no children matches plain Spark.

### Verification

New test `iceberg/iceberg_write_sql_ui_test.py::test_v2_write_sql_ui_shows_gpu_child_operators`
runs a GPU Iceberg V2 append of a `GROUP BY` (shuffle -> AQE) and asserts the write
execution's plan graph (as the SQL UI / History Server sees it via the
`SQLAppStatusStore`) contains GPU child operators, not just the write node.

Manual before/after on apache Spark 3.5.6 + RAPIDS (buildver 356), inspecting the event
log's posted `SparkPlanInfo` for the write execution:

| | write node | GPU compute children in posted plan |
|---|---|---|
| before | `GpuAppendData` | 0 |
| after | `GpuAppendData` (extra AQE update) | 6 (`GpuHashAggregate`, `GpuColumnarExchange`, `GpuShuffleCoalesce`, `GpuProject`, `GpuRange`, `GpuCustomShuffleReader`) |

Confirmed reproducible and fixed on stock apache Spark (not cloud/distribution-specific).

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
