### PR TITLE
Fix Delta DV predicate pushdown with CPU FilterExec [databricks]

### DIFF
--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -203,6 +203,16 @@ abstract class DeltaProviderBase extends DeltaIOProvider {
         dvRoot.withNewChildren(Seq(
           dvFilter.withNewChildren(Seq(
             pruneMetadataProject(dvFilterInput, fsse)))))
+      // Defensive match for a CPU FilterExec shape before GPU/CPU transitions are inserted.
+      case dvRoot @ GpuProjectExec(outputList,
+      dvFilter @ FilterExec(condition,
+      dvFilterInput @ GpuProjectExec(inputList, fsse: GpuFileSourceScanExec, _)), _)
+        if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) &&
+          !outputList.flatMap(_.references).exists(_.name == "_metadata") &&
+          inputList.exists(_.name == "_metadata") =>
+        dvRoot.withNewChildren(Seq(
+          dvFilter.withNewChildren(Seq(
+            pruneMetadataProject(dvFilterInput, fsse)))))
       case dvRoot @ GpuProjectExec(outputList,
       rowToCol @ RowToColumnarExec(
       dvFilter @ FilterExec(condition,

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -24,7 +24,7 @@ import com.nvidia.spark.rapids.shims.InvalidateCacheShims
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Expression, Literal}
 import org.apache.spark.sql.delta.{DeltaLog, DeltaParquetFileFormat}
 import org.apache.spark.sql.delta.DeltaParquetFileFormat.IS_ROW_DELETED_COLUMN_NAME
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
@@ -194,6 +194,22 @@ abstract class DeltaProviderBase extends DeltaIOProvider {
                   requiredSchema = StructType(
                     fsse.requiredSchema.filterNot(_.name == "_tmp_metadata_row_index")
                   ))(fsse.rapidsConf)))))))
+      case dvRoot @ GpuProjectExec(outputList,
+      dvFilter @ FilterExec(condition,
+      dvFilterInput @ GpuProjectExec(inputList, fsse: GpuFileSourceScanExec, _)), _)
+        if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) &&
+          !outputList.flatMap(_.references).exists(_.name == "_metadata") &&
+          inputList.exists(_.name == "_metadata") =>
+        dvRoot.withNewChildren(Seq(
+          dvFilter.withNewChildren(Seq(
+            dvFilterInput.copy(projectList = inputList.filterNot(_.name == "_metadata"))
+              .withNewChildren(Seq(
+                fsse.copy(
+                  originalOutput =
+                    fsse.originalOutput.filterNot(_.name == "_tmp_metadata_row_index"),
+                  requiredSchema = StructType(
+                    fsse.requiredSchema.filterNot(_.name == "_tmp_metadata_row_index")
+                  ))(fsse.rapidsConf)))))))
       case _ =>
         plan.withNewChildren(plan.children.map(pruneFileMetadata))
     }
@@ -277,36 +293,55 @@ object DVPredicatePushdown extends ShimPredicateHelper {
       }
     }
 
+    def hasNativeDeletionVectorGpuScan(plan: SparkPlan): Boolean = {
+      plan.exists {
+        case fsse: GpuFileSourceScanExec =>
+          fsse.relation.fileFormat.isInstanceOf[GpuDeltaParquetFileFormatBase2]
+        case _ => false
+      }
+    }
+
+    def rewriteFilter(
+        condition: Expression,
+        child: SparkPlan,
+        combinePredicates: (Expression, Expression) => Expression,
+        copyFilter: (Expression, SparkPlan) => SparkPlan): Option[SparkPlan] = {
+      val conjuncts = splitConjunctivePredicates(condition)
+      val (dvPredicate, otherPredicates) = conjuncts.partition { predicate =>
+        predicate.references.size == 1 &&
+          predicate.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) &&
+          isDVCondition(predicate)
+      }
+
+      val otherPredicatesReadingIsRowDeleted = otherPredicates.exists { predicate =>
+        predicate.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME)
+      }
+
+      if (dvPredicate.nonEmpty &&
+          !otherPredicatesReadingIsRowDeleted &&
+          hasNativeDeletionVectorGpuScan(child)) {
+        val newChild = pruneIsRowDeletedColumn(child)
+        Some(if (otherPredicates.isEmpty) {
+          newChild
+        } else {
+          copyFilter(otherPredicates.reduce(combinePredicates), newChild)
+        })
+      } else {
+        None
+      }
+    }
+
     plan.transformUp {
       case filter @ GpuFilterExec(condition, child)
         if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) =>
-        // Decompose the condition into CNF
-        val conjuncts = splitConjunctivePredicates(condition)
-        // the dv condition should be "IS_ROW_DELETED_COLUMN_NAME == 0"
-        val (dvPredicate, otherPredicates) = conjuncts.partition(p =>
-          p.references.size == 1 &&
-            p.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) &&
-            isDVCondition(p)
-        )
-
-        val otherPredicatesReadingIsRowDeleted = otherPredicates.filter(
-          p => p.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME)
-        )
-
-        val newChild = if (dvPredicate.nonEmpty && otherPredicatesReadingIsRowDeleted.isEmpty) {
-          // Since we are going to drop this dvPredicate and isRowDeleted is not used in other
-          // predicates, we can prune isRowDeleted column from the child plan
-          pruneIsRowDeletedColumn(child)
-        } else {
-          child
-        }
-
-        if (otherPredicates.isEmpty) {
-          newChild
-        } else {
-          filter.copy(condition = otherPredicates.reduce(GpuAnd),
-            child = newChild)(filter.coalesceAfter)
-        }
+        rewriteFilter(condition, child, GpuAnd(_, _),
+          (newCondition, newChild) => filter.copy(condition = newCondition,
+            child = newChild)(filter.coalesceAfter)).getOrElse(filter)
+      case filter @ FilterExec(condition, child)
+        if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) =>
+        rewriteFilter(condition, child, And(_, _),
+          (newCondition, newChild) => filter.copy(condition = newCondition, child = newChild))
+          .getOrElse(filter)
     }
   }
 

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -307,11 +307,24 @@ object DVPredicatePushdown extends ShimPredicateHelper {
       }
     }
 
-    def rewriteFilter(
+    /**
+     * Removes DV predicates from the filter condition and, when safe, prunes the
+     * [[IS_ROW_DELETED_COLUMN_NAME]] column from the child plan.
+     *
+     * DV predicates are always dropped from the returned predicate list. Pruning the column
+     * from the child is safe only when no other predicate in the condition also reads
+     * [[IS_ROW_DELETED_COLUMN_NAME]].
+     *
+     * Returns a pair of:
+     *   - `Some(newChild)` with [[IS_ROW_DELETED_COLUMN_NAME]] pruned from the subtree, or
+     *     `None` if column pruning is not safe (the caller should use the original child)
+     *   - the remaining non-DV predicates that the caller should re-attach as a new filter
+     *     (empty if the entire condition consisted of DV predicates)
+     */
+    def pruneDvPredicate(
         condition: Expression,
-        child: SparkPlan,
-        combinePredicates: (Expression, Expression) => Expression,
-        copyFilter: (Expression, SparkPlan) => SparkPlan): Option[SparkPlan] = {
+        child: SparkPlan): (Option[SparkPlan], Seq[Expression]) = {
+      // Decompose the condition into CNF
       val conjuncts = splitConjunctivePredicates(condition)
       // the dv condition should be "IS_ROW_DELETED_COLUMN_NAME == 0"
       val (dvPredicate, otherPredicates) = conjuncts.partition { predicate =>
@@ -324,30 +337,35 @@ object DVPredicatePushdown extends ShimPredicateHelper {
         predicate.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME)
       }
 
-      if (dvPredicate.nonEmpty &&
-          !otherPredicatesReadingIsRowDeleted) {
-        val newChild = pruneIsRowDeletedColumn(child)
-        Some(if (otherPredicates.isEmpty) {
-          newChild
-        } else {
-          copyFilter(otherPredicates.reduce(combinePredicates), newChild)
-        })
+      if (dvPredicate.nonEmpty && !otherPredicatesReadingIsRowDeleted) {
+        // Since we are going to drop this dvPredicate and isRowDeleted is not used in other
+        // predicates, we can prune isRowDeleted column from the child plan
+        val pruned = pruneIsRowDeletedColumn(child)
+        (Some(pruned), otherPredicates)
       } else {
-        None
+        (None, otherPredicates)
       }
     }
 
     plan.transformUp {
       case filter @ GpuFilterExec(condition, child)
         if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) =>
-        rewriteFilter(condition, child, GpuAnd(_, _),
-          (newCondition, newChild) => filter.copy(condition = newCondition,
-            child = newChild)(filter.coalesceAfter)).getOrElse(filter)
+        val (maybeNewChild, nonDvPredicates) = pruneDvPredicate(condition, child)
+        val newChild = maybeNewChild.getOrElse(child)
+        if (nonDvPredicates.isEmpty) {
+          newChild
+        } else {
+          filter.copy(condition = nonDvPredicates.reduce(GpuAnd), child = newChild)(filter.coalesceAfter)
+        }
       case filter @ FilterExec(condition, child)
         if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) =>
-        rewriteFilter(condition, child, And(_, _),
-          (newCondition, newChild) => filter.copy(condition = newCondition, child = newChild))
-          .getOrElse(filter)
+        val (maybeNewChild, nonDvPredicates) = pruneDvPredicate(condition, child)
+        val newChild = maybeNewChild.getOrElse(child)
+        if (nonDvPredicates.isEmpty) {
+          newChild
+        } else {
+          filter.copy(condition = nonDvPredicates.reduce(And), child = newChild)
+        }
     }
   }
 

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -146,24 +146,20 @@ abstract class DeltaProviderBase extends DeltaIOProvider {
   }
 
   override def tryPushDVPredicateDownToScan(plan: SparkPlan): SparkPlan = {
-    if (DVPredicatePushdown.hasNativeDeletionVectorGpuScan(plan)) {
-      val pushed = DVPredicatePushdown.pushToScan(plan)
+    val pushed = DVPredicatePushdown.pushToScan(plan)
 
-      // Spark often generates a plan that looks like below for deletion vector scans:
-      // ...
-      // ProjectExec <- prune is_row_deleted
-      //   FilterExec <- condition on is_row_deleted
-      //     ProjectExec <- project is_row_deleted
-      //       FileSourceScanExec
-      //
-      // The FilterExec can be removed during the pushdown if the only remaining predicates
-      // are deletion vector predicates. If the FilterExec is removed, the `is_row_deleted`
-      // column is pruned from the subtree below the FilterExec. This can leave two consecutive
-      // identical ProjectExecs. We merge them here to simplify the plan.
-      DVPredicatePushdown.mergeIdenticalProjects(pushed)
-    } else {
-      plan
-    }
+    // Spark often generates a plan that looks like below for deletion vector scans:
+    // ...
+    // ProjectExec <- prune is_row_deleted
+    //   FilterExec <- condition on is_row_deleted
+    //     ProjectExec <- project is_row_deleted
+    //       FileSourceScanExec
+    //
+    // The FilterExec can be removed during the pushdown if the only remaining predicates
+    // are deletion vector predicates. If the FilterExec is removed, the `is_row_deleted`
+    // column is pruned from the subtree below the FilterExec. This can leave two consecutive
+    // identical ProjectExecs. We merge them here to simplify the plan.
+    DVPredicatePushdown.mergeIdenticalProjects(pushed)
   }
 
   override def pruneFileMetadata(plan: SparkPlan): SparkPlan = {
@@ -321,15 +317,15 @@ object DVPredicatePushdown extends ShimPredicateHelper {
      * Removes DV predicates from the filter condition and, when safe, prunes the
      * [[IS_ROW_DELETED_COLUMN_NAME]] column from the child plan.
      *
-     * DV predicates are always dropped from the returned predicate list. Pruning the column
-     * from the child is safe only when no other predicate in the condition also reads
-     * [[IS_ROW_DELETED_COLUMN_NAME]].
+     * DV predicates are dropped from the returned predicate list only when the filter child
+     * contains a native deletion-vector GPU scan. Pruning the column from the child is safe
+     * only when no other predicate in the condition also reads [[IS_ROW_DELETED_COLUMN_NAME]].
      *
      * Returns a pair of:
      *   - `Some(newChild)` with [[IS_ROW_DELETED_COLUMN_NAME]] pruned from the subtree, or
      *     `None` if column pruning is not safe (the caller should use the original child)
-     *   - the remaining non-DV predicates that the caller should re-attach as a new filter
-     *     (empty if the entire condition consisted of DV predicates)
+     *   - the remaining predicates that the caller should re-attach as a new filter
+     *     (empty if the entire condition consisted of pushed deletion-vector predicates)
      */
     def pruneDvPredicate(
         condition: Expression,
@@ -347,13 +343,17 @@ object DVPredicatePushdown extends ShimPredicateHelper {
         predicate.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME)
       }
 
-      if (dvPredicate.nonEmpty && !otherPredicatesReadingIsRowDeleted) {
+      val canDropDvPredicate = dvPredicate.nonEmpty && hasNativeDeletionVectorGpuScan(child)
+
+      if (canDropDvPredicate && !otherPredicatesReadingIsRowDeleted) {
         // Since we are going to drop this dvPredicate and isRowDeleted is not used in other
         // predicates, we can prune isRowDeleted column from the child plan
         val pruned = pruneIsRowDeletedColumn(child)
         (Some(pruned), otherPredicates)
-      } else {
+      } else if (canDropDvPredicate) {
         (None, otherPredicates)
+      } else {
+        (None, Seq(condition))
       }
     }
 

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -309,6 +309,7 @@ object DVPredicatePushdown extends ShimPredicateHelper {
         combinePredicates: (Expression, Expression) => Expression,
         copyFilter: (Expression, SparkPlan) => SparkPlan): Option[SparkPlan] = {
       val conjuncts = splitConjunctivePredicates(condition)
+      // the dv condition should be "IS_ROW_DELETED_COLUMN_NAME == 0"
       val (dvPredicate, otherPredicates) = conjuncts.partition { predicate =>
         predicate.references.size == 1 &&
           predicate.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) &&

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -365,7 +365,9 @@ object DVPredicatePushdown extends ShimPredicateHelper {
         if (nonDvPredicates.isEmpty) {
           newChild
         } else {
-          filter.copy(condition = nonDvPredicates.reduce(GpuAnd), child = newChild)(filter.coalesceAfter)
+          filter.copy(
+            condition = nonDvPredicates.reduce(GpuAnd),
+            child = newChild)(filter.coalesceAfter)
         }
       case filter @ FilterExec(condition, child)
         if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) =>

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -163,6 +163,18 @@ abstract class DeltaProviderBase extends DeltaIOProvider {
   }
 
   override def pruneFileMetadata(plan: SparkPlan): SparkPlan = {
+    def pruneMetadataProject(
+        project: GpuProjectExec,
+        scan: GpuFileSourceScanExec): SparkPlan = {
+      project.copy(projectList = project.projectList.filterNot(_.name == "_metadata"))
+        .withNewChildren(Seq(
+          scan.copy(
+            originalOutput = scan.originalOutput.filterNot(_.name == "_tmp_metadata_row_index"),
+            requiredSchema = StructType(
+              scan.requiredSchema.filterNot(_.name == "_tmp_metadata_row_index")
+            ))(scan.rapidsConf)))
+    }
+
     plan match {
       // This logic is a special case of eliminating of unused columns.
       //
@@ -186,30 +198,20 @@ abstract class DeltaProviderBase extends DeltaIOProvider {
           inputList.exists(_.name == "_metadata") =>
         dvRoot.withNewChildren(Seq(
           dvFilter.withNewChildren(Seq(
-            dvFilterInput.copy(projectList = inputList.filterNot(_.name == "_metadata"))
-              .withNewChildren(Seq(
-                fsse.copy(
-                  originalOutput =
-                    fsse.originalOutput.filterNot(_.name == "_tmp_metadata_row_index"),
-                  requiredSchema = StructType(
-                    fsse.requiredSchema.filterNot(_.name == "_tmp_metadata_row_index")
-                  ))(fsse.rapidsConf)))))))
+            pruneMetadataProject(dvFilterInput, fsse)))))
       case dvRoot @ GpuProjectExec(outputList,
+      rowToCol @ RowToColumnarExec(
       dvFilter @ FilterExec(condition,
-      dvFilterInput @ GpuProjectExec(inputList, fsse: GpuFileSourceScanExec, _)), _)
+      colToRow @ ColumnarToRowExec(
+      dvFilterInput @ GpuProjectExec(inputList, fsse: GpuFileSourceScanExec, _)))), _)
         if condition.references.exists(_.name == IS_ROW_DELETED_COLUMN_NAME) &&
           !outputList.flatMap(_.references).exists(_.name == "_metadata") &&
           inputList.exists(_.name == "_metadata") =>
         dvRoot.withNewChildren(Seq(
-          dvFilter.withNewChildren(Seq(
-            dvFilterInput.copy(projectList = inputList.filterNot(_.name == "_metadata"))
-              .withNewChildren(Seq(
-                fsse.copy(
-                  originalOutput =
-                    fsse.originalOutput.filterNot(_.name == "_tmp_metadata_row_index"),
-                  requiredSchema = StructType(
-                    fsse.requiredSchema.filterNot(_.name == "_tmp_metadata_row_index")
-                  ))(fsse.rapidsConf)))))))
+          rowToCol.withNewChildren(Seq(
+            dvFilter.withNewChildren(Seq(
+              colToRow.withNewChildren(Seq(
+                pruneMetadataProject(dvFilterInput, fsse)))))))))
       case _ =>
         plan.withNewChildren(plan.children.map(pruneFileMetadata))
     }

--- a/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
+++ b/delta-lake/common/src/main/delta-33x-41x/scala/com/nvidia/spark/rapids/delta/common/DeltaProviderBase.scala
@@ -138,28 +138,32 @@ abstract class DeltaProviderBase extends DeltaIOProvider {
       InvalidateCacheShims.getInvalidateCache(cpuExec.invalidateCache))
   }
 
-  override def canPushDVPredicateDownToScan(conf: RapidsConf): Boolean = {
+  override def isPushDVPredicateDownEnabled(conf: RapidsConf): Boolean = {
     val dvConf = DeltaSQLConf.DELETION_VECTORS_USE_METADATA_ROW_INDEX
     val useMetadataRowIndex = conf.getStr(dvConf.key)
       .getOrElse(dvConf.defaultValueString).toBoolean
     useMetadataRowIndex && conf.isDeltaDeletionVectorPredicatePushdownEnabled
   }
 
-  override def pushDVPredicateDownToScan(plan: SparkPlan): SparkPlan = {
-    val pushed = DVPredicatePushdown.pushToScan(plan)
+  override def tryPushDVPredicateDownToScan(plan: SparkPlan): SparkPlan = {
+    if (DVPredicatePushdown.hasNativeDeletionVectorGpuScan(plan)) {
+      val pushed = DVPredicatePushdown.pushToScan(plan)
 
-    // Spark often generates a plan that looks like below for deletion vector scans:
-    // ...
-    // ProjectExec <- prune is_row_deleted
-    //   FilterExec <- condition on is_row_deleted
-    //     ProjectExec <- project is_row_deleted
-    //       FileSourceScanExec
-    //
-    // The FilterExec can be removed during the pushdown if the only remaining predicates
-    // are deletion vector predicates. If the FilterExec is removed, the `is_row_deleted`
-    // column is pruned from the subtree below the FilterExec. This can leave two consecutive
-    // identical ProjectExecs. We merge them here to simplify the plan.
-    DVPredicatePushdown.mergeIdenticalProjects(pushed)
+      // Spark often generates a plan that looks like below for deletion vector scans:
+      // ...
+      // ProjectExec <- prune is_row_deleted
+      //   FilterExec <- condition on is_row_deleted
+      //     ProjectExec <- project is_row_deleted
+      //       FileSourceScanExec
+      //
+      // The FilterExec can be removed during the pushdown if the only remaining predicates
+      // are deletion vector predicates. If the FilterExec is removed, the `is_row_deleted`
+      // column is pruned from the subtree below the FilterExec. This can leave two consecutive
+      // identical ProjectExecs. We merge them here to simplify the plan.
+      DVPredicatePushdown.mergeIdenticalProjects(pushed)
+    } else {
+      plan
+    }
   }
 
   override def pruneFileMetadata(plan: SparkPlan): SparkPlan = {
@@ -237,6 +241,14 @@ abstract class DeltaProviderBase extends DeltaIOProvider {
 
 object DVPredicatePushdown extends ShimPredicateHelper {
 
+  def hasNativeDeletionVectorGpuScan(plan: SparkPlan): Boolean = {
+    plan.exists {
+      case fsse: GpuFileSourceScanExec =>
+        fsse.relation.fileFormat.isInstanceOf[GpuDeltaParquetFileFormatBase2]
+      case _ => false
+    }
+  }
+
   /**
    * Pushes down deletion vector predicates to scan level by removing them from the FilterExec.
    * The deletion vector predicates will be processed in the scan instead.
@@ -295,14 +307,6 @@ object DVPredicatePushdown extends ShimPredicateHelper {
       }
     }
 
-    def hasNativeDeletionVectorGpuScan(plan: SparkPlan): Boolean = {
-      plan.exists {
-        case fsse: GpuFileSourceScanExec =>
-          fsse.relation.fileFormat.isInstanceOf[GpuDeltaParquetFileFormatBase2]
-        case _ => false
-      }
-    }
-
     def rewriteFilter(
         condition: Expression,
         child: SparkPlan,
@@ -321,8 +325,7 @@ object DVPredicatePushdown extends ShimPredicateHelper {
       }
 
       if (dvPredicate.nonEmpty &&
-          !otherPredicatesReadingIsRowDeleted &&
-          hasNativeDeletionVectorGpuScan(child)) {
+          !otherPredicatesReadingIsRowDeleted) {
         val newChild = pruneIsRowDeletedColumn(child)
         Some(if (otherPredicates.isEmpty) {
           newChild

--- a/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
+++ b/delta-lake/delta-33x/src/main/scala/com/nvidia/spark/rapids/delta/delta33x/Delta33xProvider.scala
@@ -75,7 +75,7 @@ object Delta33xProvider extends DeltaProviderBase with Logging {
 
   override protected def toGpuParquetFileFormat(conf: RapidsConf, fmt: DeltaParquetFileFormat)
   : FileFormat = {
-    if (canPushDVPredicateDownToScan(conf)) {
+    if (isPushDVPredicateDownEnabled(conf)) {
       // Pushing down deletion vector predicates is currently only supported
       // when the metadata row index is enabled.
       GpuDelta33xParquetFileFormat2(fmt.protocol, fmt.metadata, fmt.nullableRowTrackingFields,

--- a/delta-lake/delta-40x/src/main/scala/com/nvidia/spark/rapids/delta/delta40x/Delta40xProvider.scala
+++ b/delta-lake/delta-40x/src/main/scala/com/nvidia/spark/rapids/delta/delta40x/Delta40xProvider.scala
@@ -78,7 +78,7 @@ object Delta40xProvider extends DeltaProviderBase with Logging {
 
   override protected def toGpuParquetFileFormat(conf: RapidsConf, fmt: DeltaParquetFileFormat)
   : FileFormat = {
-    if (canPushDVPredicateDownToScan(conf)) {
+    if (isPushDVPredicateDownEnabled(conf)) {
       GpuDeltaParquetFileFormat2(
         protocol = fmt.protocol,
         metadata = fmt.metadata,

--- a/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/delta41x/Delta41xProvider.scala
+++ b/delta-lake/delta-41x/src/main/scala/com/nvidia/spark/rapids/delta/delta41x/Delta41xProvider.scala
@@ -78,7 +78,7 @@ object Delta41xProvider extends DeltaProviderBase with Logging {
 
   override protected def toGpuParquetFileFormat(conf: RapidsConf, fmt: DeltaParquetFileFormat)
   : FileFormat = {
-    if (canPushDVPredicateDownToScan(conf)) {
+    if (isPushDVPredicateDownEnabled(conf)) {
       GpuDeltaParquetFileFormat2(
         protocol = fmt.protocol,
         metadata = fmt.metadata,

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
@@ -53,7 +53,14 @@ import org.apache.spark.sql.catalyst.expressions.{
 }
 import org.apache.spark.sql.catalyst.plans.logical.TableSpec
 import org.apache.spark.sql.connector.write.V1Write
-import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.{
+  ColumnarToRowExec,
+  FileSourceScanExec,
+  FilterExec,
+  ProjectExec,
+  RowToColumnarExec,
+  SparkPlan
+}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.{

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
@@ -89,7 +89,7 @@ object DeltaSpark400DB173Provider extends DatabricksDeltaProviderBase {
   override def getReadFileFormat(
       relation: HadoopFsRelation, rapidsConf: RapidsConf): FileFormat = {
     val fmt = relation.fileFormat.asInstanceOf[DeltaParquetFileFormat]
-    if (canPushDVPredicateDownToScan(rapidsConf)) {
+    if (isPushDVPredicateDownEnabled(rapidsConf)) {
       GpuDeltaParquetFileFormatNativeDV(
         relation = relation,
         protocol = fmt.protocol,

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
@@ -122,6 +122,18 @@ object DeltaSpark400DB173Provider extends DatabricksDeltaProviderBase {
   }
 
   override def pruneFileMetadata(plan: SparkPlan): SparkPlan = {
+    def pruneMetadataProject(
+        project: GpuProjectExec,
+        scan: GpuFileSourceScanExec): SparkPlan = {
+      project.copy(projectList = project.projectList.filterNot(_.name == "_metadata"))
+        .withNewChildren(Seq(
+          scan.copy(
+            originalOutput = scan.originalOutput.filterNot(_.name == "_tmp_metadata_row_index"),
+            requiredSchema = StructType(
+              scan.requiredSchema.filterNot(_.name == "_tmp_metadata_row_index")
+            ))(scan.rapidsConf)))
+    }
+
     plan match {
       case dvRoot @ GpuProjectExec(outputList,
       dvFilter @ GpuFilterExec(condition,
@@ -131,14 +143,30 @@ object DeltaSpark400DB173Provider extends DatabricksDeltaProviderBase {
           inputList.exists(_.name == "_metadata") =>
         dvRoot.withNewChildren(Seq(
           dvFilter.withNewChildren(Seq(
-            dvFilterInput.copy(projectList = inputList.filterNot(_.name == "_metadata"))
-              .withNewChildren(Seq(
-                fsse.copy(
-                  originalOutput = fsse.originalOutput
-                    .filterNot(_.name == "_tmp_metadata_row_index"),
-                  requiredSchema = StructType(fsse.requiredSchema
-                    .filterNot(_.name == "_tmp_metadata_row_index"))
-                )(fsse.rapidsConf)))))))
+            pruneMetadataProject(dvFilterInput, fsse)))))
+      // Defensive match for a CPU FilterExec shape before GPU/CPU transitions are inserted.
+      case dvRoot @ GpuProjectExec(outputList,
+      dvFilter @ FilterExec(condition,
+      dvFilterInput @ GpuProjectExec(inputList, fsse: GpuFileSourceScanExec, _)), _)
+          if condition.references.exists(ref => isDeletionVectorSkipRowColumn(ref.name)) &&
+          !outputList.flatMap(_.references).exists(_.name == "_metadata") &&
+          inputList.exists(_.name == "_metadata") =>
+        dvRoot.withNewChildren(Seq(
+          dvFilter.withNewChildren(Seq(
+            pruneMetadataProject(dvFilterInput, fsse)))))
+      case dvRoot @ GpuProjectExec(outputList,
+      rowToCol @ RowToColumnarExec(
+      dvFilter @ FilterExec(condition,
+      colToRow @ ColumnarToRowExec(
+      dvFilterInput @ GpuProjectExec(inputList, fsse: GpuFileSourceScanExec, _)))), _)
+          if condition.references.exists(ref => isDeletionVectorSkipRowColumn(ref.name)) &&
+          !outputList.flatMap(_.references).exists(_.name == "_metadata") &&
+          inputList.exists(_.name == "_metadata") =>
+        dvRoot.withNewChildren(Seq(
+          rowToCol.withNewChildren(Seq(
+            dvFilter.withNewChildren(Seq(
+              colToRow.withNewChildren(Seq(
+                pruneMetadataProject(dvFilterInput, fsse)))))))))
       case _ =>
         plan.withNewChildren(plan.children.map(pruneFileMetadata))
     }

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/DeltaSpark400DB173Provider.scala
@@ -106,7 +106,7 @@ object DeltaSpark400DB173Provider extends DatabricksDeltaProviderBase {
     }
   }
 
-  override def canPushDVPredicateDownToScan(conf: RapidsConf): Boolean = {
+  override def isPushDVPredicateDownEnabled(conf: RapidsConf): Boolean = {
     val dvConf = DeltaSQLConf.DELETION_VECTORS_USE_METADATA_ROW_INDEX
     val useMetadataRowIndex = conf.getStr(dvConf.key)
       .getOrElse(dvConf.defaultValueString).toBoolean
@@ -116,7 +116,7 @@ object DeltaSpark400DB173Provider extends DatabricksDeltaProviderBase {
     useMetadataRowIndex && conf.isDeltaDeletionVectorPredicatePushdownEnabled
   }
 
-  override def pushDVPredicateDownToScan(plan: SparkPlan): SparkPlan = {
+  override def tryPushDVPredicateDownToScan(plan: SparkPlan): SparkPlan = {
     val pushed = DB173DVPredicatePushdown.pushToScan(plan)
     DB173DVPredicatePushdown.mergeIdenticalProjects(pushed)
   }

--- a/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
+++ b/delta-lake/delta-spark400db173/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaParquetFileFormat.scala
@@ -226,7 +226,7 @@ object GpuDeltaParquetFileFormat {
         meta.willNotWorkOnGpu(
           "CDC reads with deletion vectors are not yet supported on GPU for DB-17.3")
       }
-      if (!DeltaSpark400DB173Provider.canPushDVPredicateDownToScan(meta.conf)) {
+      if (!DeltaSpark400DB173Provider.isPushDVPredicateDownEnabled(meta.conf)) {
         meta.willNotWorkOnGpu(
           "DB-17.3 deletion vector reads on GPU require native cuDF deletion-vector " +
             "support with spark.databricks.delta.deletionVectors.useMetadataRowIndex " +

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -908,19 +908,20 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
         "spark.rapids.sql.reader.chunked": "true"
     }
 
-    col_a_gen = IntegerGen(min_val=0, max_val=100, nullable=False, special_cases=[])
-    col_b_gen = IntegerGen(min_val=0, max_val=5, nullable=False, special_cases=[0, 1, 2, 3])
-
     def create_delta(spark):
-        two_col_df(spark, col_a_gen, col_b_gen, length=4000).coalesce(1).write.format("delta") \
+        spark.range(2000).selectExpr(
+            "CAST(id AS INT) AS id",
+            "CAST(id % 7 AS INT) AS b",
+            "CONCAT('p', CAST(id % 4 AS INT)) AS part"
+        ).write.format("delta") \
             .option("delta.enableDeletionVectors", "true") \
-            .partitionBy("a").save(data_path)
+            .partitionBy("part").save(data_path)
 
-        count = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE b = 0").collect()[0][0]
+        count = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE id % 5 = 0").collect()[0][0]
         assert count > 100, "Expected enough rows to be deleted to create deletion vectors"
 
     def read_table(spark):
-        df = spark.sql(f"SELECT a, b FROM delta.`{data_path}` WHERE b IN (1, 2, 3)")
+        df = spark.sql(f"SELECT id, b FROM delta.`{data_path}` WHERE b IN (1, 2, 3)")
         is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
         if is_gpu:
             _assert_db173_gpu_delta_scan_if_enabled(spark, df)
@@ -931,6 +932,7 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
                 assert callback.contains(plan, "GpuFileGpuScan"), explain_str
                 assert "_databricks_internal_edge_computed_column_skip_row" not in explain_str
                 assert "__delta_internal_is_row_deleted" not in explain_str
+                assert "_metadata" not in explain_str
             else:
                 assert callback.contains(plan, "GpuFileSourceScanExec"), explain_str
                 assert "__delta_internal_is_row_deleted" not in explain_str

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -939,19 +939,18 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
 @allow_non_gpu("FilterExec", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.skipif(is_databricks_runtime(),
-                    reason="This regression targets the open-source Delta provider")
 @pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
                     reason="Delta Lake deletion vector support is required")
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
-def test_delta_dv_cpu_filter_after_native_scan_oss(spark_tmp_path):
+def test_delta_dv_cpu_filter_after_gpu_scan(spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     conf = {
         "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
         "spark.databricks.delta.delete.deletionVectors.persistent": "true",
         "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true",
         "spark.sql.adaptive.enabled": "false",
+        # Disable IN and INSET to force the FilterExec on CPU.
         "spark.rapids.sql.expression.In": "false",
         "spark.rapids.sql.expression.InSet": "false"
     }
@@ -979,6 +978,7 @@ def test_delta_dv_cpu_filter_after_native_scan_oss(spark_tmp_path):
             assert callback.contains(plan, "org.apache.spark.sql.execution.FilterExec"), \
                 explain_str
             assert "__delta_internal_is_row_deleted" not in explain_str
+            assert "_metadata" not in explain_str
         return df
 
     with_cpu_session(create_delta, conf=conf)

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -936,6 +936,55 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
     assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
 
 
+@allow_non_gpu("FilterExec", "ColumnarToRowExec", *delta_meta_allow)
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="This regression targets the open-source Delta provider")
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
+                    reason="Delta Lake deletion vector support is required")
+@pytest.mark.skipif(is_before_spark_353(),
+                    reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
+def test_delta_dv_cpu_filter_after_native_scan_oss(spark_tmp_path):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    conf = {
+        "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
+        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
+        "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true",
+        "spark.sql.adaptive.enabled": "false",
+        "spark.rapids.sql.expression.In": "false",
+        "spark.rapids.sql.expression.InSet": "false"
+    }
+
+    def create_delta(spark):
+        spark.range(2000).selectExpr(
+            "CAST(id AS INT) AS id",
+            "CAST(id % 7 AS INT) AS b",
+            "CONCAT('p', CAST(id % 4 AS INT)) AS part"
+        ).write.format("delta") \
+            .option("delta.enableDeletionVectors", "true") \
+            .partitionBy("part").save(data_path)
+
+        count = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE id % 5 = 0").collect()[0][0]
+        assert count > 100, "Expected enough rows to be deleted to create deletion vectors"
+
+    def read_table(spark):
+        df = spark.sql(f"SELECT id, b FROM delta.`{data_path}` WHERE b IN (1, 2, 3)")
+        is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
+        if is_gpu:
+            plan = df._jdf.queryExecution().executedPlan()
+            explain_str = str(plan)
+            callback = spark._sc._jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
+            assert callback.contains(plan, "GpuFileSourceScanExec"), explain_str
+            assert callback.contains(plan, "org.apache.spark.sql.execution.FilterExec"), \
+                explain_str
+            assert "__delta_internal_is_row_deleted" not in explain_str
+        return df
+
+    with_cpu_session(create_delta, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
+
+
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -888,11 +888,13 @@ def test_delta_filter_out_metadata_col(spark_tmp_path, dv_predicate_pushdown):
         assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
 
 
-@allow_non_gpu("FilterExec", *delta_meta_allow)
+@allow_non_gpu("FilterExec", "ColumnarToRowExec", *delta_meta_allow)
 @delta_lake
 @ignore_order(local=True)
-@pytest.mark.skipif(not is_databricks173_or_later(),
-                    reason="This regression is specific to DBR 17.3 native DV reads")
+@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
+                    reason="Delta Lake deletion vector support is required")
+@pytest.mark.skipif(is_databricks_runtime() and not is_databricks173_or_later(),
+                    reason="Deletion vector scan is not supported on Databricks before 17.3")
 @pytest.mark.skipif(is_before_spark_353(),
                     reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
 def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
@@ -903,7 +905,6 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
         "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true",
         "spark.rapids.sql.expression.In": "false",
         "spark.rapids.sql.expression.InSet": "false",
-        "spark.rapids.sql.format.parquet.reader.type": "MULTITHREADED",
         "spark.rapids.sql.reader.chunked": "true"
     }
 
@@ -926,59 +927,16 @@ def test_delta_dv_cpu_filter_after_native_scan(spark_tmp_path):
             plan = df._jdf.queryExecution().executedPlan()
             explain_str = str(plan)
             callback = spark._sc._jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
-            assert callback.contains(plan, "GpuFileGpuScan"), explain_str
+            if is_databricks173_or_later():
+                assert callback.contains(plan, "GpuFileGpuScan"), explain_str
+                assert "_databricks_internal_edge_computed_column_skip_row" not in explain_str
+                assert "__delta_internal_is_row_deleted" not in explain_str
+            else:
+                assert callback.contains(plan, "GpuFileSourceScanExec"), explain_str
+                assert "__delta_internal_is_row_deleted" not in explain_str
+                assert "_metadata" not in explain_str
             assert callback.contains(plan, "org.apache.spark.sql.execution.FilterExec"), \
                 explain_str
-            assert "_databricks_internal_edge_computed_column_skip_row" not in explain_str
-        return df
-
-    with_cpu_session(create_delta, conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(read_table, conf=conf)
-
-
-@allow_non_gpu("FilterExec", "ColumnarToRowExec", *delta_meta_allow)
-@delta_lake
-@ignore_order(local=True)
-@pytest.mark.skipif(not supports_delta_lake_deletion_vectors(),
-                    reason="Delta Lake deletion vector support is required")
-@pytest.mark.skipif(is_before_spark_353(),
-                    reason="Spark-RAPIDS supports scan with deletion vectors starting in Spark 3.5.3")
-def test_delta_dv_cpu_filter_after_gpu_scan(spark_tmp_path):
-    data_path = spark_tmp_path + "/DELTA_DATA"
-    conf = {
-        "spark.rapids.sql.delta.deletionVectors.predicatePushdown.enabled": "true",
-        "spark.databricks.delta.delete.deletionVectors.persistent": "true",
-        "spark.databricks.delta.deletionVectors.useMetadataRowIndex": "true",
-        "spark.sql.adaptive.enabled": "false",
-        # Disable IN and INSET to force the FilterExec on CPU.
-        "spark.rapids.sql.expression.In": "false",
-        "spark.rapids.sql.expression.InSet": "false"
-    }
-
-    def create_delta(spark):
-        spark.range(2000).selectExpr(
-            "CAST(id AS INT) AS id",
-            "CAST(id % 7 AS INT) AS b",
-            "CONCAT('p', CAST(id % 4 AS INT)) AS part"
-        ).write.format("delta") \
-            .option("delta.enableDeletionVectors", "true") \
-            .partitionBy("part").save(data_path)
-
-        count = spark.sql(f"DELETE FROM delta.`{data_path}` WHERE id % 5 = 0").collect()[0][0]
-        assert count > 100, "Expected enough rows to be deleted to create deletion vectors"
-
-    def read_table(spark):
-        df = spark.sql(f"SELECT id, b FROM delta.`{data_path}` WHERE b IN (1, 2, 3)")
-        is_gpu = str(spark.conf.get("spark.rapids.sql.enabled", "false")).lower() == "true"
-        if is_gpu:
-            plan = df._jdf.queryExecution().executedPlan()
-            explain_str = str(plan)
-            callback = spark._sc._jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
-            assert callback.contains(plan, "GpuFileSourceScanExec"), explain_str
-            assert callback.contains(plan, "org.apache.spark.sql.execution.FilterExec"), \
-                explain_str
-            assert "__delta_internal_is_row_deleted" not in explain_str
-            assert "_metadata" not in explain_str
         return df
 
     with_cpu_session(create_delta, conf=conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -810,8 +810,8 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       GpuOverrides.logDuration(rapidsConf.shouldExplain,
         t => f"GPU plan transition optimization took $t%.2f ms") {
         var updatedPlan = DeltaProvider().pruneFileMetadata(plan)
-        if (DeltaProvider().canPushDVPredicateDownToScan(rapidsConf)) {
-          updatedPlan = DeltaProvider().pushDVPredicateDownToScan(updatedPlan)
+        if (DeltaProvider().isPushDVPredicateDownEnabled(rapidsConf)) {
+          updatedPlan = DeltaProvider().tryPushDVPredicateDownToScan(updatedPlan)
         }
         updatedPlan = insertHashOptimizeSorts(updatedPlan)
         updatedPlan = updateScansForInputAndOrder(updatedPlan)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
@@ -95,14 +95,14 @@ trait DeltaProvider {
       meta: OverwriteByExpressionExecV1Meta): GpuExec
 
   /**
-   * Returns true if deletion vector predicates can be pushed down to the scan.
+   * Returns true if deletion vector predicate pushdown is enabled via configuration.
    */
-  def canPushDVPredicateDownToScan(conf: RapidsConf): Boolean = false
+  def isPushDVPredicateDownEnabled(conf: RapidsConf): Boolean = false
 
   /**
-   * Pushes down deletion vector predicates to the scan if possible
+   * Tries to push down deletion vector predicates to the scan.
    */
-  def pushDVPredicateDownToScan(plan: SparkPlan): SparkPlan = plan
+  def tryPushDVPredicateDownToScan(plan: SparkPlan): SparkPlan = plan
 
   def pruneFileMetadata(plan: SparkPlan): SparkPlan = plan
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14976.

### Description

  Delta deletion-vector predicate pushdown can fail during GPU planning when the filter containing the deletion-vector predicate remains a CPU `FilterExec` instead of being converted to `GpuFilterExec`.

  This can happen when the user query contains expressions that are not supported on GPU. In that case, Spark can still use a native GPU deletion-vector scan, but the filter above it remains on CPU. The previous pushdown path assumed the deletion-vector predicate filter was always a `GpuFilterExec`, so planning could fail instead of completing the query.

  This PR fixes the planning path so deletion-vector predicate pushdown works when the filter remains a CPU `FilterExec`. It also ensures the deletion-vector predicate is only removed when the scan below that filter can handle native deletion-vector filtering. After the DV predicate is pushed into the native GPU scan, the plan prunes the temporary DV-related columns that are no longer needed above the scan.

  The existing deletion-vector CPU-filter regression test is updated to cover both OSS Delta and DBR 17.3 native deletion-vector scan paths.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
