### PR TITLE
[BUG] Keep DBR 14.3 local union source on CPU [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_merge_test.py
+++ b/integration_tests/src/main/python/delta_lake_merge_test.py
@@ -18,7 +18,11 @@ import pytest
 from delta_lake_merge_common import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import is_before_spark_320, is_databricks_runtime, spark_version, supports_delta_lake_deletion_vectors, is_before_spark_353, is_spark_400_or_later, is_databricks173_or_later
+from spark_session import (is_before_spark_320, is_databricks_runtime, spark_version,
+                           supports_delta_lake_deletion_vectors, is_before_spark_353,
+                           is_spark_400_or_later, is_databricks143,
+                           is_databricks143_or_later,
+                           is_databricks173_or_later)
 
 delta_merge_enabled_conf = copy_and_update(delta_writes_enabled_conf,
                                            {"spark.rapids.sql.command.MergeIntoCommand": "true",
@@ -102,6 +106,86 @@ def test_delta_merge_not_matched_by_source_fallback(spark_tmp_path, spark_tmp_ta
                          use_cdf=False, enable_deletion_vectors=enable_deletion_vectors,
                          src_table_func=lambda spark: binary_op_df(spark, SetValuesGen(IntegerType(), range(10))),
                          dest_table_func=lambda spark: binary_op_df(spark, SetValuesGen(IntegerType(), range(20, 30))),
+                         merge_sql=merge_sql,
+                         check_func=checker)
+
+@allow_non_gpu("ExecutedCommandExec,BroadcastHashJoinExec,ColumnarToRowExec,"
+               "BroadcastExchangeExec,DataWritingCommandExec,UnionExec,UnionWithLocalDataExec,"
+               "RangeExec",
+               delta_write_fallback_allow, *delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(not is_databricks143(),
+                    reason="DBR 14.3 local-source union materialization is required")
+def test_delta_merge_not_matched_by_source_union_source_fallback(
+        spark_tmp_path, spark_tmp_table_factory):
+    materialize_conf = copy_and_update(delta_merge_enabled_conf, {
+        "spark.databricks.delta.merge.materializeSource": "all"})
+
+    def checker(data_path, do_merge):
+        assert_gpu_fallback_write(do_merge, read_delta_path, data_path, "ExecutedCommandExec",
+                                  conf=materialize_conf)
+
+    def create_test_data(spark, num=120):
+        from datetime import datetime, timedelta, timezone
+        import pandas as pd
+
+        start = datetime(2022, 1, 1, tzinfo=timezone.utc)
+        categories = ["electronics", "books", "home_garden", "toys"]
+        rows = {
+            "product_id": [],
+            "sale_datetime": [],
+            "sale_date": [],
+            "product_category": [],
+            "sales_amount": [],
+            "quantity": []
+        }
+        for i in range(num):
+            if i % 10 == 0:
+                rows["sale_datetime"].append(None)
+                rows["sale_date"].append(None)
+            else:
+                dt = start + timedelta(days=i * 3)
+                rows["sale_datetime"].append(dt)
+                rows["sale_date"].append(dt.date())
+            rows["product_id"].append(i)
+            rows["product_category"].append(categories[i % len(categories)])
+            rows["sales_amount"].append(float(100 + i))
+            rows["quantity"].append((i % 10) + 1)
+
+        df = spark.createDataFrame(pd.DataFrame(rows))
+        return df.withColumn("year", f.year("sale_datetime"))
+
+    def extra_source_df(spark, start, end):
+        return spark.range(start, end).select(
+            f.col("id").alias("product_id"),
+            f.lit(None).cast(TimestampType()).alias("sale_datetime"),
+            f.lit(None).cast(DateType()).alias("sale_date"),
+            f.lit("books").alias("product_category"),
+            (f.col("id").cast(DoubleType()) * 10.0).alias("sales_amount"),
+            f.lit(1).cast(LongType()).alias("quantity"),
+            f.lit(2025).cast(IntegerType()).alias("year"))
+
+    def source_df(spark):
+        target_df = create_test_data(spark, num=120)
+        matched = target_df.filter(f.col("product_id") < 60)
+        inserted = extra_source_df(spark, 200, 260)
+        return matched.unionByName(inserted)
+
+    merge_sql = "MERGE INTO {dest_table} " \
+                "USING {src_table} " \
+                "ON {src_table}.product_id == {dest_table}.product_id " \
+                "WHEN MATCHED THEN " \
+                "  UPDATE SET {dest_table}.sales_amount = {src_table}.sales_amount " \
+                "WHEN NOT MATCHED THEN " \
+                "  INSERT * " \
+                "WHEN NOT MATCHED BY SOURCE THEN " \
+                "  DELETE"
+    delta_sql_merge_test(spark_tmp_path, spark_tmp_table_factory,
+                         use_cdf=False,
+                         enable_deletion_vectors=False,
+                         src_table_func=source_df,
+                         dest_table_func=lambda spark: create_test_data(spark, num=120),
                          merge_sql=merge_sql,
                          check_func=checker)
 

--- a/integration_tests/src/main/python/delta_lake_merge_test.py
+++ b/integration_tests/src/main/python/delta_lake_merge_test.py
@@ -21,7 +21,6 @@ from pyspark.sql.types import *
 from spark_session import (is_before_spark_320, is_databricks_runtime, spark_version,
                            supports_delta_lake_deletion_vectors, is_before_spark_353,
                            is_spark_400_or_later, is_databricks143,
-                           is_databricks143_or_later,
                            is_databricks173_or_later)
 
 delta_merge_enabled_conf = copy_and_update(delta_writes_enabled_conf,
@@ -109,21 +108,21 @@ def test_delta_merge_not_matched_by_source_fallback(spark_tmp_path, spark_tmp_ta
                          merge_sql=merge_sql,
                          check_func=checker)
 
-@allow_non_gpu("ExecutedCommandExec,BroadcastHashJoinExec,ColumnarToRowExec,"
-               "BroadcastExchangeExec,DataWritingCommandExec,UnionExec,UnionWithLocalDataExec,"
-               "RangeExec",
+@allow_non_gpu("BroadcastHashJoinExec,ColumnarToRowExec,BroadcastExchangeExec,"
+               "UnionExec,UnionWithLocalDataExec,RangeExec",
                delta_write_fallback_allow, *delta_meta_allow)
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(not is_databricks143(),
-                    reason="DBR 14.3 local-source union materialization is required")
+                    reason="The shimmed UnionWithLocalDataExec fallback is DBR 14.3-specific")
 def test_delta_merge_not_matched_by_source_union_source_fallback(
         spark_tmp_path, spark_tmp_table_factory):
     materialize_conf = copy_and_update(delta_merge_enabled_conf, {
         "spark.databricks.delta.merge.materializeSource": "all"})
 
     def checker(data_path, do_merge):
-        assert_gpu_fallback_write(do_merge, read_delta_path, data_path, "ExecutedCommandExec",
+        assert_gpu_fallback_write(do_merge, read_delta_path, data_path,
+                                  ["ExecutedCommandExec", "UnionExec"],
                                   conf=materialize_conf)
 
     def create_test_data(spark, num=120):

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -316,6 +316,9 @@ def is_databricks133_or_later():
 def is_databricks133():
     return is_databricks_version(13, 3)
 
+def is_databricks143():
+    return is_databricks_version(14, 3)
+
 def is_databricks143_or_later():
     return is_databricks_version_or_later(14, 3)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4552,6 +4552,28 @@ object GpuOverrides extends Logging {
           "unionByName will not optionally impute nulls for missing struct fields " +
           "when the column is a struct and there are non-overlapping fields"), TypeSig.all),
       (union, conf, p, r) => new SparkPlanMeta[UnionExec](union, conf, p, r) {
+        // DBR 14.3's UnionWithLocalDataExec is a Databricks-private class, so identify it by
+        // simple class name to keep non-Databricks builds from depending on that class.
+        private def isUnderUnionWithLocalDataExec: Boolean =
+          p.exists(_.wrapped.getClass.getSimpleName == "UnionWithLocalDataExec")
+
+        override def tagPlanForGpu(): Unit = {
+          // This DBR 14.3 local-source union path executes its children through the row path.
+          if (isUnderUnionWithLocalDataExec) {
+            willNotWorkOnGpu("UnionWithLocalDataExec requires row-based UnionExec children")
+          }
+        }
+
+        override def convertToCpu(): SparkPlan = {
+          if (isUnderUnionWithLocalDataExec) {
+            // Keep the original CPU UnionExec subtree; transition insertion is not guaranteed on
+            // this Databricks-local row execution path.
+            union
+          } else {
+            super.convertToCpu()
+          }
+        }
+
         override def convertToGpu(): GpuExec =
           GpuUnionExec(childPlans.map(_.convertIfNeeded()))
       }),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4552,28 +4552,6 @@ object GpuOverrides extends Logging {
           "unionByName will not optionally impute nulls for missing struct fields " +
           "when the column is a struct and there are non-overlapping fields"), TypeSig.all),
       (union, conf, p, r) => new SparkPlanMeta[UnionExec](union, conf, p, r) {
-        // DBR 14.3's UnionWithLocalDataExec is a Databricks-private class, so identify it by
-        // simple class name to keep non-Databricks builds from depending on that class.
-        private def isUnderUnionWithLocalDataExec: Boolean =
-          p.exists(_.wrapped.getClass.getSimpleName == "UnionWithLocalDataExec")
-
-        override def tagPlanForGpu(): Unit = {
-          // This DBR 14.3 local-source union path executes its children through the row path.
-          if (isUnderUnionWithLocalDataExec) {
-            willNotWorkOnGpu("UnionWithLocalDataExec requires row-based UnionExec children")
-          }
-        }
-
-        override def convertToCpu(): SparkPlan = {
-          if (isUnderUnionWithLocalDataExec) {
-            // Keep the original CPU UnionExec subtree; transition insertion is not guaranteed on
-            // this Databricks-local row execution path.
-            union
-          } else {
-            super.convertToCpu()
-          }
-        }
-
         override def convertToGpu(): GpuExec =
           GpuUnionExec(childPlans.map(_.convertIfNeeded()))
       }),

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/Spark350db143Shims.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/Spark350db143Shims.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350db143"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.databricks.sql.execution.UnionWithLocalDataExec
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.execution.{SparkPlan, UnionExec}
+
+trait Spark350db143Shims extends Spark341PlusDBShims {
+  private val shimExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Seq(
+    GpuOverrides.exec[UnionExec](
+      "The backend for the union operator",
+      ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
+          TypeSig.MAP + TypeSig.ARRAY + TypeSig.STRUCT).nested()
+        .withPsNote(TypeEnum.STRUCT,
+          "unionByName will not optionally impute nulls for missing struct fields " +
+          "when the column is a struct and there are non-overlapping fields"), TypeSig.all),
+      (union, conf, p, r) => new SparkPlanMeta[UnionExec](union, conf, p, r) {
+        private def hasUnionWithLocalDataExecParent: Boolean =
+          p.exists(_.wrapped.isInstanceOf[UnionWithLocalDataExec])
+
+        override def tagPlanForGpu(): Unit = {
+          // DBR 14.3's local-source union path executes direct UnionExec children as rows.
+          if (hasUnionWithLocalDataExecParent) {
+            willNotWorkOnGpu("UnionWithLocalDataExec requires row-based UnionExec children")
+          }
+        }
+
+        override def convertToCpu(): SparkPlan = {
+          if (hasUnionWithLocalDataExecParent) {
+            // Keep the original CPU UnionExec subtree; transition insertion is not guaranteed on
+            // this Databricks-local row execution path.
+            union
+          } else {
+            super.convertToCpu()
+          }
+        }
+
+        override def convertToGpu(): GpuExec =
+          GpuUnionExec(childPlans.map(_.convertIfNeeded()))
+      })
+  ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
+
+  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
+    super.getExecs ++ shimExecs
+}

--- a/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark350db143/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "341db"}
+{"spark": "350db143"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-object SparkShimImpl extends Spark341PlusDBShims
+object SparkShimImpl extends Spark350db143Shims


### PR DESCRIPTION
Contributes to #14981.

### Description

- Prevent `UnionExec` directly under DBR 14.3 `UnionWithLocalDataExec` from being replaced with `GpuUnionExec`, because that Databricks-local materialization path executes through row-based `execute()` and can otherwise hit `GpuUnionExec.doExecute()`.
- It is unclear why this DBR 14.3-specific `UnionWithLocalDataExec` path bypasses the normal plan-tree transition insertion, so this manually falls back the child `UnionExec` to keep the local-source union subtree row-based.
- This appears to be a corner case that only happens on DBR 14.3 when scanning non-Spark DataFrames, such as DataFrames generated from pandas, so this targeted fix is good enough for the release branch.
- Keep the original CPU `UnionExec` subtree for this DBR 14.3-only path so its children do not remain as GPU operators under the row-based local union execution path.
- Add an issue-specific Delta MERGE regression test for DBR 14.3 using `WHEN NOT MATCHED BY SOURCE`, forced source materialization, and a pandas-created target-derived source branch unioned with a range source branch.
- Validation: DBR 14.3 cluster validation where the issue-specific test reproduced before the fix and passed after rebuilding with the fix.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
