### PR TITLE
Add the missing case for GpuShuffleCoalesceExec for the broadcast hash join on DBR 14.3 [Databricks]

### DIFF
--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -20,7 +20,7 @@ from conftest import is_databricks_runtime, is_not_utc
 from data_gen import *
 from spark_session import is_spark_400_or_later
 from marks import ignore_order, allow_non_gpu
-from spark_session import with_cpu_session, is_databricks113_or_later, is_before_spark_330, is_databricks_version_or_later
+from spark_session import with_cpu_session, is_databricks113_or_later, is_before_spark_330, is_databricks_version, is_databricks_version_or_later
 
 # allow non gpu when time zone is non-UTC because of https://github.com/NVIDIA/spark-rapids/issues/9653'
 not_utc_aqe_allow=['ShuffleExchangeExec', 'HashAggregateExec'] if is_not_utc() else []
@@ -393,9 +393,13 @@ def test_aqe_bhj_executor_broadcast_shuffle_coalesce_with_residual_condition(spa
             WHERE ABS(IFNULL(C_TABLE.id, 10) - IFNULL(G_TABLE.id, 10)) > 1e-09
         """)
 
+    exist_classes = "GpuBroadcastHashJoinExec"
+    if is_databricks_version(14, 3):
+        exist_classes += ",GpuShuffleCoalesceExec"
+
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         do_it,
-        exist_classes="GpuBroadcastHashJoinExec,GpuShuffleCoalesceExec",
+        exist_classes=exist_classes,
         non_exist_classes="GpuBroadcastExchangeExec",
         conf=conf,
         require_non_empty=True)

--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -336,6 +336,69 @@ def test_aqe_join_executor_broadcast_enforce_single_batch():
         exist_classes="GpuShuffleExchangeExec,GpuBroadcastHashJoinExec",
         non_exist_classes="GpuBroadcastExchangeExec",
         conf=conf)
+
+
+@ignore_order(local=True)
+@pytest.mark.skipif(not is_databricks_runtime(),
+    reason="Executor side broadcast only supported on Databricks")
+def test_aqe_bhj_executor_broadcast_shuffle_coalesce_with_residual_condition(spark_tmp_path):
+    from datetime import datetime
+    from decimal import Decimal
+
+    conf = copy_and_update(_adaptive_conf, {
+        "spark.rapids.sql.exec.BroadcastHashJoinExec": "true",
+        "spark.sql.shuffle.partitions": "32",
+        "spark.sql.autoBroadcastJoinThreshold": str(10 * 1024 * 1024),
+        "spark.sql.adaptive.autoBroadcastJoinThreshold": str(10 * 1024 * 1024),
+    })
+    left_path = spark_tmp_path + '/left'
+    right_path = spark_tmp_path + '/right'
+
+    # Keep each composite join key duplicated with different ids. Self-matches
+    # are removed by the residual id predicate, while cross-pair matches remain.
+    rows = [
+        (1, True, 99.99, Decimal("150.50"), datetime(2024, 1, 15, 10, 30, 0)),
+        (2, True, 99.99, Decimal("150.50"), datetime(2024, 1, 15, 10, 30, 0)),
+        (3, False, 199.99, Decimal("250.75"), datetime(2024, 2, 20, 14, 45, 30)),
+        (5, False, 199.99, Decimal("250.75"), datetime(2024, 2, 20, 14, 45, 30)),
+        (8, True, 299.99, Decimal("350.25"), datetime(2024, 3, 10, 9, 15, 45)),
+        (13, True, 299.99, Decimal("350.25"), datetime(2024, 3, 10, 9, 15, 45)),
+    ]
+    schema = StructType([
+        StructField("id", IntegerType(), True),
+        StructField("is_active", BooleanType(), True),
+        StructField("price", DoubleType(), True),
+        StructField("amount", DecimalType(10, 2), True),
+        StructField("created_at", TimestampType(), True),
+    ])
+
+    def prep(spark):
+        df = spark.createDataFrame(rows, schema)
+        df.write.mode("overwrite").parquet(left_path)
+        df.write.mode("overwrite").parquet(right_path)
+
+    with_cpu_session(prep)
+
+    def do_it(spark):
+        spark.read.parquet(left_path).createOrReplaceTempView("C_TABLE")
+        spark.read.parquet(right_path).createOrReplaceTempView("G_TABLE")
+        return spark.sql("""
+            SELECT C_TABLE.*, G_TABLE.*
+            FROM C_TABLE
+            INNER JOIN G_TABLE
+              ON C_TABLE.is_active  = G_TABLE.is_active
+             AND C_TABLE.price      = G_TABLE.price
+             AND C_TABLE.amount     = G_TABLE.amount
+             AND C_TABLE.created_at = G_TABLE.created_at
+            WHERE ABS(IFNULL(C_TABLE.id, 10) - IFNULL(G_TABLE.id, 10)) > 1e-09
+        """)
+
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        do_it,
+        exist_classes="GpuBroadcastHashJoinExec,GpuShuffleCoalesceExec",
+        non_exist_classes="GpuBroadcastExchangeExec",
+        conf=conf,
+        require_non_empty=True)
 
 # This test relies on the join not being on the GPU because a join on an array is not
 # currently supported. This causes the join to fall back to the CPU, and with AQE the

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -502,7 +502,8 @@ def assert_gpu_fallback_write_sql(write_func,
 def assert_cpu_and_gpu_are_equal_collect_with_capture(func,
         exist_classes='',
         non_exist_classes='',
-        conf={}):
+        conf={},
+        require_non_empty=False):
     (bring_back, collect_type) = _prep_func_for_compare(func, 'COLLECT_WITH_DATAFRAME')
 
     conf = _prep_incompat_conf(conf)
@@ -511,6 +512,8 @@ def assert_cpu_and_gpu_are_equal_collect_with_capture(func,
     cpu_start = time.time()
     from_cpu, cpu_df = with_cpu_session(bring_back, conf=conf)
     cpu_end = time.time()
+    if require_non_empty:
+        assert len(from_cpu) > 0, "Expected non-empty result"
     print('### GPU RUN ###')
     gpu_start = time.time()
     from_gpu, gpu_df = with_gpu_session(bring_back, conf=conf)

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -129,6 +129,8 @@ case class GpuBroadcastHashJoinExec(
         from(sqse)
       case GpuShuffleCoalesceExec(sqse: ShuffleQueryStageExec, _) => from(sqse)
       case GpuCustomShuffleReaderExec(sqse: ShuffleQueryStageExec, _) => from(sqse)
+      case other => throw new IllegalStateException(
+        s"cannot locate GPU shuffle exchange in build plan: $other")
     }
   }
 

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -127,6 +127,7 @@ case class GpuBroadcastHashJoinExec(
       case reused: ReusedExchangeExec => reused.child.asInstanceOf[GpuShuffleExchangeExec]
       case GpuShuffleCoalesceExec(GpuCustomShuffleReaderExec(sqse: ShuffleQueryStageExec, _), _) =>
         from(sqse)
+      case GpuShuffleCoalesceExec(sqse: ShuffleQueryStageExec, _) => from(sqse)
       case GpuCustomShuffleReaderExec(sqse: ShuffleQueryStageExec, _) => from(sqse)
     }
   }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14997.

### Description

  Issue #14997 reports a DBR 14.3 executor-broadcast GPU broadcast hash join failure where AQE can produce a build side shaped as `GpuShuffleCoalesceExec(ShuffleQueryStageExec, _)`, causing `GpuBroadcastHashJoinExec.shuffleExchange` to throw a `scala.MatchError`.

  This PR fixes the Databricks BHJ shim by adding the missing `GpuShuffleCoalesceExec(sqse: ShuffleQueryStageExec, _)` match arm in `GpuBroadcastHashJoinExec.shuffleExchange`. The new case unwraps the query stage through the existing `from(sqse)` helper, matching the behavior already present in the Databricks broadcast nested loop join path.

  This PR also adds coverage for the regression:
  - Adds a Databricks-only AQE integration test for executor-broadcast GPU BHJ with a residual join predicate.
  - Crafts duplicate composite join keys with different `id`s so the residual predicate keeps non-self matches.
  - Verifies CPU/GPU results are equal and non-empty.
  - Verifies the GPU plan contains `GpuBroadcastHashJoinExec` and `GpuShuffleCoalesceExec`, and does not contain `GpuBroadcastExchangeExec`.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
