### PR TITLE
Allow CPU CreateTableExec in iceberg SQL UI write test [skip ci]

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -14,7 +14,7 @@
 
 from iceberg import get_full_table_name, iceberg_write_enabled_conf, \
     iceberg_unsupported_mark, _BASE_TBLPROPS_SQL
-from marks import iceberg
+from marks import allow_non_gpu, iceberg
 from spark_session import with_gpu_session
 
 pytestmark = iceberg_unsupported_mark
@@ -28,6 +28,11 @@ def _is_write_node(name):
     return any(m in name for m in _WRITE_MARKERS)
 
 
+# CREATE TABLE ... USING ICEBERG is a CPU-only catalog op (CreateTableExec) that is
+# not (and need not be) on the GPU. In GPU test mode the plugin asserts the full plan
+# is columnar unless the CPU node is allowed, so allow it here; the INSERT below is the
+# write execution we actually assert on.
+@allow_non_gpu('CreateTableExec')
 @iceberg
 def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
     """Regression test: the SQL UI / History Server must show the GPU child


### PR DESCRIPTION
Fixes #14999.

### Description

`test_v2_write_sql_ui_shows_gpu_child_operators` (added in #14975) had a
test-side mistake made by AI: its setup `CREATE TABLE ... USING ICEBERG` is a
CPU-only catalog op (`CreateTableExec`), which trips the strict "whole plan must
be columnar" assertion in GPU test mode, so the test failed at setup with
`Part of the plan is not columnar ... CreateTableExec` before reaching its
INSERT / SQL-UI assertions.

Fix: add `@allow_non_gpu('CreateTableExec')`. This only impacts the test case;
no production code is affected, and the underlying feature from #14975 is correct.

Verified the test passes end-to-end on Spark 3.5.0 + Iceberg 1.6.1 (the failing
env) and Spark 3.5.6 + Iceberg 1.10.1.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (test_v2_write_sql_ui_shows_gpu_child_operators)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
