### PR TITLE
Support configurable parent POM deployment [skip ci]

### DIFF
--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -110,12 +110,10 @@ echo "Deploy CMD: $DEPLOY_CMD"
 
 ###### Deploy the parent pom file(s) ######
 PARENT_POM=${PARENT_POM:-"./pom.xml"}
-if [[ -n "$PARENT_POM" ]]; then
-    IFS=',' read -ra parent_arr <<< "$PARENT_POM"
-    for parent in "${parent_arr[@]}"; do
-        $DEPLOY_CMD -Dfile="$parent" -DpomFile="$parent"
-    done
-fi
+IFS=',' read -ra parent_arr <<< "$PARENT_POM"
+for parent in "${parent_arr[@]}"; do
+    $DEPLOY_CMD -Dfile="$parent" -DpomFile="$parent"
+done
 
 ###### Deploy the artifact jar(s) ######
 $DEPLOY_CMD -DpomFile=$POM_FILE \

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -27,6 +27,7 @@
 #   SIGN_TOOL:      Tool to sign files, e.g., gpg, nvsec, only required when $1 is 'true'
 #   GPG_PASSPHRASE: gpg passphrase to sign artifacts, only required when <SIGN_TOOL> is gpg
 #   MVN_SETTINGS:   Maven configuration file
+#   PARENT_POM:     Comma-separated parent pom files to be deployed
 #   POM_FILE:       Project pom file to be deployed
 #   OUT_PATH:       The path where jar files are
 #   CUDA_CLASSIFIERS:    Comma separated classifiers, e.g., "cuda12"
@@ -107,8 +108,14 @@ fi
 DEPLOY_CMD="$DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID"
 echo "Deploy CMD: $DEPLOY_CMD"
 
-###### Deploy the parent pom file ######
-$DEPLOY_CMD -Dfile=./pom.xml -DpomFile=./pom.xml
+###### Deploy the parent pom file(s) ######
+PARENT_POM=${PARENT_POM:-"./pom.xml"}
+if [[ -n "$PARENT_POM" ]]; then
+    IFS=',' read -ra parent_arr <<< "$PARENT_POM"
+    for parent in "${parent_arr[@]}"; do
+        $DEPLOY_CMD -Dfile="$parent" -DpomFile="$parent"
+    done
+fi
 
 ###### Deploy the artifact jar(s) ######
 $DEPLOY_CMD -DpomFile=$POM_FILE \


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids/issues/15000

Allow jenkins/deploy.sh to deploy one or more parent POM files <e.g., rapids-4-spark-parent_2.12,rapids-4-spark-jdk-profiles_2.12> from the PARENT_POM environment variable, defaulting to ./pom.xml for existing callers.

This is needed by the CUDF artifact deployment path, which rewrites Maven coordinates into temporary POM files and stages the rewritten parent as parent-pom.xml.

Without this, spark-rapids deploys the original ./pom.xml parent while the child POM points at cudf-spark-parent_*, causing parent resolution/deployment mismatches.



Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
