### PR TITLE
Fix parquet partition verification on GCS paths

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -990,21 +990,28 @@ def test_parquet_interleaved_file_splits_partition_value_alignment(
 
     with_cpu_session(setup_table, conf=write_conf)
 
-    parquet_files_by_part = {}
-    for root, _, files in os.walk(data_path):
-        parquet_files = [os.path.join(root, f) for f in files if f.endswith(".parquet")]
-        if parquet_files:
-            parquet_files_by_part[os.path.basename(root)] = parquet_files
+    def parquet_file_info_by_part(spark):
+        rows = spark.read.parquet(data_path).selectExpr(
+            "p",
+            "named_struct('file_path', _metadata.file_path, "
+            "'file_size', _metadata.file_size) AS file_info") \
+            .groupBy("p") \
+            .agg(collect_set("file_info").alias("files")) \
+            .collect()
+        return {
+            f"p={row['p']}": [(file["file_path"], file["file_size"]) for file in row["files"]]
+            for row in rows
+        }
+
+    parquet_files_by_part = with_cpu_session(parquet_file_info_by_part)
 
     assert sorted(parquet_files_by_part.keys()) == ["p=1", "p=2"], \
         f"Expected parquet files under p=1 and p=2, got {parquet_files_by_part}"
     assert len(parquet_files_by_part["p=1"]) == 1, parquet_files_by_part["p=1"]
     assert len(parquet_files_by_part["p=2"]) == 1, parquet_files_by_part["p=2"]
 
-    a_path = parquet_files_by_part["p=1"][0]
-    b_path = parquet_files_by_part["p=2"][0]
-    a_size = os.path.getsize(a_path)
-    b_size = os.path.getsize(b_path)
+    a_path, a_size = parquet_files_by_part["p=1"][0]
+    b_path, b_size = parquet_files_by_part["p=2"][0]
     a_tail = a_size % max_split
     assert a_size > max_split, \
         f"File A ({a_size}) must exceed max_split ({max_split}) to split"

--- a/integration_tests/src/main/python/parquet_test_utils.py
+++ b/integration_tests/src/main/python/parquet_test_utils.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from urllib.parse import urlparse
+
 import pyarrow.fs as pa_fs
 import pyarrow.parquet as pa_pq
 
 
 def parquet_row_group_midpoints(path):
     """Returns an approximate byte midpoint for each Parquet row group."""
-    if "://" in path:
+    if urlparse(path).scheme:
         filesystem, path = pa_fs.FileSystem.from_uri(path)
         meta = pa_pq.read_metadata(path, filesystem=filesystem)
     else:

--- a/integration_tests/src/main/python/parquet_test_utils.py
+++ b/integration_tests/src/main/python/parquet_test_utils.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pyarrow.fs as pa_fs
 import pyarrow.parquet as pa_pq
 
 
 def parquet_row_group_midpoints(path):
     """Returns an approximate byte midpoint for each Parquet row group."""
-    meta = pa_pq.read_metadata(path)
+    if "://" in path:
+        filesystem, path = pa_fs.FileSystem.from_uri(path)
+        meta = pa_pq.read_metadata(path, filesystem=filesystem)
+    else:
+        meta = pa_pq.read_metadata(path)
     midpoints = []
     for rg_index in range(meta.num_row_groups):
         row_group = meta.row_group(rg_index)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/14864.

### Description

  This fixes `test_parquet_interleaved_file_splits_partition_value_alignment` when the test temporary path is backed by GCS.

  The test previously used Python local filesystem APIs to discover generated Parquet files and read their sizes. That fails when `spark_tmp_path` is a `gs://` path because Python `os.walk` / `os.path.getsize` do not see Spark-created GCS files.

  The test now uses Spark hidden metadata columns to discover the generated Parquet file paths and sizes:

  - `_metadata.file_path`
  - `_metadata.file_size`

The existing `parquet_row_group_midpoints` helper now opens URI-backed paths through `pyarrow.fs.FileSystem.from_uri`, allowing PyArrow to read Parquet footers from `gs://` paths while keeping the same midpoint calculation.

Confirmed the test passes with a GCS temp directory with: 

```
  /usr/bin/env \
    PYSP_TEST_spark_hadoop_fs_defaultFS=gs://my/gcs/path \
    PYSP_TEST_spark_driver_extraClassPath=spark-rapids-gcs/gcs-connector-hadoop3-2.2.33-shaded.jar \
    PYSP_TEST_spark_executor_extraClassPath=spark-rapids-gcs/gcs-connector-hadoop3-2.2.33-shaded.jar \
    integration_tests/run_pyspark_from_build.sh \
      -k "test_parquet_interleaved_file_splits_partition_value_alignment" \
      --tmp_path "gs://my/gcs/tmp/path" \
      --debug_tmp_path
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
