### PR TITLE
Fix flaky iceberg test_v2_write_sql_ui_shows_gpu_child_operators by scoping to its own write execution [skip ci]

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -88,7 +88,10 @@ def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
                 names = node_names(exec_id)
                 if any(_is_write_node(n) for n in names):
                     write_execs.append((exec_id, names))
-        return min(write_execs)[1] if write_execs else []
+        assert write_execs, \
+            f"No write execution found after baseline_exec_id={baseline_exec_id}; " \
+            f"the INSERT may not have registered with the SQL status store."
+        return min(write_execs)[1]
 
     names = with_gpu_session(run, conf=iceberg_write_enabled_conf)
 

--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -70,6 +70,11 @@ def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
         # first write execution" globally can otherwise latch onto an unrelated CPU
         # write from a prior test and spuriously fail. Record a baseline (this also
         # excludes the CREATE TABLE above) so we only look at higher execution ids.
+        # Drain the listener bus first: the status store can lag the shared Spark
+        # session, so a prior-test CPU write whose execution event has not yet
+        # reached the store would make the baseline too low and could then be picked
+        # up (with id > baseline) by the post-INSERT scan below.
+        spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty(30000)
         baseline_exec_id = max_execution_id()
         # GROUP BY -> shuffle -> AQE re-plans; the INSERT is the V2 write execution.
         spark.sql(f"INSERT INTO {table_name} "

--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -45,13 +45,6 @@ def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
     table_name = get_full_table_name(spark_tmp_table_factory)
 
     def run(spark):
-        spark.sql(f"CREATE TABLE {table_name} (grp BIGINT, cnt BIGINT) "
-                  f"USING ICEBERG {_BASE_TBLPROPS_SQL}")
-        # GROUP BY -> shuffle -> AQE re-plans; the INSERT is the V2 write execution.
-        spark.sql(f"INSERT INTO {table_name} "
-                  f"SELECT id % 8 AS grp, count(*) AS cnt FROM range(0, 100000) GROUP BY id % 8")
-        # Make sure the listener bus has drained the posted plan-update events.
-        spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty(30000)
         sql_store = spark._jsparkSession.sharedState().statusStore()
 
         def node_names(exec_id):
@@ -61,17 +54,41 @@ def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
                 names.append(it.next().name())
             return names
 
-        # Pick the write execution by plan content rather than list position:
-        # executionsList() ordering is implementation-defined and varies across Spark
-        # releases, and the CREATE TABLE above is its own SQL execution. The write
-        # execution is the one whose plan graph is rooted at / contains a write node.
-        execs = sql_store.executionsList()
-        it = execs.iterator()
+        def max_execution_id():
+            mx = -1
+            it = sql_store.executionsList().iterator()
+            while it.hasNext():
+                mx = max(mx, it.next().executionId())
+            return mx
+
+        spark.sql(f"CREATE TABLE {table_name} (grp BIGINT, cnt BIGINT) "
+                  f"USING ICEBERG {_BASE_TBLPROPS_SQL}")
+        # The integration-test Spark session is shared across tests, so the SQL status
+        # store accumulates executions from earlier tests -- including CPU V2 writes
+        # (e.g. a VALUES-based AppendData over a LocalTableScan / Scan ExistingRDD). We
+        # must inspect only the execution created by *our* INSERT below; selecting "the
+        # first write execution" globally can otherwise latch onto an unrelated CPU
+        # write from a prior test and spuriously fail. Record a baseline (this also
+        # excludes the CREATE TABLE above) so we only look at higher execution ids.
+        baseline_exec_id = max_execution_id()
+        # GROUP BY -> shuffle -> AQE re-plans; the INSERT is the V2 write execution.
+        spark.sql(f"INSERT INTO {table_name} "
+                  f"SELECT id % 8 AS grp, count(*) AS cnt FROM range(0, 100000) GROUP BY id % 8")
+        # Make sure the listener bus has drained the posted plan-update events.
+        spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty(30000)
+
+        # Among the executions our INSERT created (id > baseline), the V2 write
+        # execution is the lowest-id one whose plan graph contains a write node (the
+        # top-level INSERT runs before any execution it nests).
+        write_execs = []
+        it = sql_store.executionsList().iterator()
         while it.hasNext():
-            names = node_names(it.next().executionId())
-            if any(_is_write_node(n) for n in names):
-                return names
-        return []
+            exec_id = it.next().executionId()
+            if exec_id > baseline_exec_id:
+                names = node_names(exec_id)
+                if any(_is_write_node(n) for n in names):
+                    write_execs.append((exec_id, names))
+        return min(write_execs)[1] if write_execs else []
 
     names = with_gpu_session(run, conf=iceberg_write_enabled_conf)
 


### PR DESCRIPTION
Fixes #15010.

### Description

The Iceberg IT `test_v2_write_sql_ui_shows_gpu_child_operators` (added in #14975)
is flaky in CI: it intermittently fails with the captured plan
`['AppendData', 'Scan ExistingRDD', 'WholeStageCodegen (1)']` (a CPU write, no
`Gpu*` nodes), even though the underlying feature works correctly.

**Root cause (not a production bug).** The RAPIDS integration-test Spark session
is shared across tests, so the SQL status store's `executionsList()` accumulates
write executions from *earlier* tests — including CPU V2 writes such as a
VALUES-based `AppendData` over a `LocalTableScan` / `Scan ExistingRDD` (e.g. the
`test_insert_into_unpartitioned_table_values` cases, which legitimately run the
write on CPU and carry `ALLOW_NON_GPU(AppendDataExec)`). The test selected "the
first execution whose plan graph contains a write node", and `executionsList()`
ordering is implementation-defined, so in CI it latched onto a prior test's CPU
write instead of its own GPU `INSERT` and failed the GPU-child assertion. It
passes locally only because a fresh session contains just this test's execution.

**Fix (test-only).** Record a baseline execution id right before the `INSERT`
(this also excludes the `CREATE TABLE`), then inspect only executions created by
the `INSERT` (`id > baseline`) and select the lowest-id write execution — i.e.
this test's own top-level V2 write. No production code changes; the #14975
feature (`GpuV2TableWriteExec.postFinalPlanUpdateToSqlUi`) is unchanged and
correct.

**How it was verified.** Reproduced and validated locally on Spark 3.5.3 + Scala
2.13 + Iceberg 1.6.1 on the GPU (the failing CI env). Seeding a stale CPU iceberg
write into a shared session and then running the verbatim old vs new test code:
- old code selects `['AppendData', 'LocalTableScan']` → fails (matches CI);
- new code selects `['GpuAppendData', 'GpuHashAggregate', 'GpuShuffleCoalesce',
  'GpuCustomShuffleReader', 'GpuColumnarExchange', 'GpuHashAggregate',
  'GpuProject', 'GpuRange']` → passes.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [x] Covered by existing tests
      (test_v2_write_sql_ui_shows_gpu_child_operators)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
