### PR TITLE
Avoid Maven when generating Scala 2.13 POMs

### DIFF
--- a/build/make-scala-version-build-files.sh
+++ b/build/make-scala-version-build-files.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -106,6 +106,16 @@ sed_i '/<spark\-rapids\-jni\.version>/,/<scala\.binary\.version>[0-9]*\.[0-9]*</
 
 # Update <scala.version> in parent POM
 # Match any scala version to ensure idempotency
-SCALA_VERSION=$(mvn help:evaluate -Pscala-${TO_VERSION} -Dexpression=scala.version -q -DforceStdout)
+SCALA_VERSION=$(awk -v profile="scala-${TO_VERSION}" '
+  /<profile>/ { in_profile = 1; found = 0 }
+  in_profile && $0 ~ "<id>" profile "</id>" { found = 1 }
+  found && /<scala[.]version>/ {
+    gsub(/.*<scala[.]version>|<\/scala[.]version>.*/, "")
+    print
+    exit
+  }
+  /<\/profile>/ { in_profile = 0; found = 0 }
+' "$BASEDIR/pom.xml")
+
 sed_i '/<spark\-rapids\-jni\.version>/,/<scala.version>[0-9]*\.[0-9]*\.[0-9]*</s/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</<scala.version>'$SCALA_VERSION'</' \
   "$TO_DIR/pom.xml"

--- a/build/make-scala-version-build-files.sh
+++ b/build/make-scala-version-build-files.sh
@@ -108,7 +108,7 @@ sed_i '/<spark\-rapids\-jni\.version>/,/<scala\.binary\.version>[0-9]*\.[0-9]*</
 # Match any scala version to ensure idempotency
 SCALA_VERSION=$(awk -v profile="scala-${TO_VERSION}" '
   /<profile>/ { in_profile = 1; found = 0 }
-  in_profile && $0 ~ "<id>" profile "</id>" { found = 1 }
+  in_profile && index($0, "<id>" profile "</id>") { found = 1 }
   found && /<scala[.]version>/ {
     gsub(/.*<scala[.]version>|<\/scala[.]version>.*/, "")
     print
@@ -116,6 +116,10 @@ SCALA_VERSION=$(awk -v profile="scala-${TO_VERSION}" '
   }
   /<\/profile>/ { in_profile = 0; found = 0 }
 ' "$BASEDIR/pom.xml")
+if [[ -z "$SCALA_VERSION" ]]; then
+  echo "Could not find scala.version for profile scala-${TO_VERSION}" >&2
+  exit 1
+fi
 
 sed_i '/<spark\-rapids\-jni\.version>/,/<scala.version>[0-9]*\.[0-9]*\.[0-9]*</s/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</<scala.version>'$SCALA_VERSION'</' \
   "$TO_DIR/pom.xml"


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids/issues/15020

Read the Scala version directly from the matching profile in pom.xml instead of invoking

Maven during Scala POM generation. This keeps the helper independent of network access,

repository settings, credentials, and Maven plugin resolution.



Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
