### PR TITLE
Run nightly integration tests with Spark testing mode enabled

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -340,7 +340,16 @@ else
     # we enable the java property in the driver and executor, in case the tests are running in 
     # local mode or in standalone mode.
     ENABLE_TEST_FEATURES="-Dcom.nvidia.spark.rapids.runningTests=true"
-    DRIVER_EXTRA_JAVA_OPTIONS="-ea -Duser.timezone=$TZ -Ddelta.log.cacheSize=$deltaCacheSize"
+    # Opt-in Spark testing mode (driver only). With -Dspark.testing=true Spark's Utils.isTesting
+    # turns on internal-contract guards that are silent in production, e.g. the DSv2
+    # computeStats-before-pushdown check. See NVIDIA/spark-rapids#14950 and #14927. Driver-only is
+    # enough for the planning/optimizer guards and keeps the blast radius off the executors.
+    SPARK_TESTING_OPTS=""
+    if [[ "${SPARK_TESTING_ENABLED:-0}" == "1" ]]; then
+        SPARK_TESTING_OPTS="-Dspark.testing=true"
+        [[ -n "${SPARK_HOME:-}" ]] && SPARK_TESTING_OPTS="$SPARK_TESTING_OPTS -Dspark.test.home=$SPARK_HOME"
+    fi
+    DRIVER_EXTRA_JAVA_OPTIONS="-ea -Duser.timezone=$TZ -Ddelta.log.cacheSize=$deltaCacheSize $SPARK_TESTING_OPTS"
     export PYSP_TEST_spark_driver_extraJavaOptions="$DRIVER_EXTRA_JAVA_OPTIONS $COVERAGE_SUBMIT_FLAGS $ENABLE_TEST_FEATURES"
     export PYSP_TEST_spark_executor_extraJavaOptions="-ea -Duser.timezone=$TZ $ENABLE_TEST_FEATURES"
 

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -157,6 +157,11 @@ export PYSP_TEST_spark_driver_extraJavaOptions=-Duser.timezone=UTC
 export PYSP_TEST_spark_executor_extraJavaOptions=-Duser.timezone=UTC
 export PYSP_TEST_spark_sql_session_timeZone=UTC
 
+# Run the nightly integration tests with Spark testing mode so that Spark enforces its internal
+# contract guards (e.g. DSv2 computeStats-before-pushdown) that are silent in production.
+# See NVIDIA/spark-rapids#14950. Export SPARK_TESTING_ENABLED=0 on a job to opt out.
+export SPARK_TESTING_ENABLED=${SPARK_TESTING_ENABLED:-1}
+
 # PARALLEL or non-PARALLEL specific configs
 if [[ $PARALLEL_TEST == "true" ]]; then
   export PYSP_TEST_spark_cores_max=1


### PR DESCRIPTION
Closes #14950

Adds an opt-in `SPARK_TESTING_ENABLED` toggle to `run_pyspark_from_build.sh` that injects `-Dspark.testing=true` (plus `-Dspark.test.home=$SPARK_HOME` when set) into the **driver** JVM options. With Spark testing mode on, `Utils.isTesting` turns on Spark's internal-contract guards that are silent in production — e.g. the `DataSourceV2Relation` computeStats-before-pushdown check that surfaced the join-reorder bug in #14927. Driver-only is sufficient for the planning/optimizer guards and keeps the blast radius off the executors.

The toggle defaults **off**, so no existing caller changes behavior. `jenkins/spark-tests.sh` (nightly integration tests) enables it by default; a job can opt out with `SPARK_TESTING_ENABLED=0`.

Scope note for the reviewer: the public plugin jar does not contain `JoinReorderRule` (it lives in spark-rapids-private), so this will not reproduce #14927 in public premerge — the value there is hardening against the broad class of internal-contract violations. The internal nightly, which loads the private plugin and reuses these scripts, inherits the toggle and is where the #14927 class actually gets caught. Worth timing the rollout with the pending spark-rapids-private fix for #14927 so the nightly is not reddened by the known-unfixed rule; export `SPARK_TESTING_ENABLED=0` on the nightly job to hold it off until then.

Local validation: `bash -n` on both scripts plus a deterministic check that the toggle injects the flag only when enabled (and omits an empty `spark.test.home` when `SPARK_HOME` is unset). I did not run the full nightly integration-test suite under `spark.testing` locally — that is exercised in CI.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
