### PR TITLE
Fall back when Iceberg S3 PerfIO is unsupported

### DIFF
--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
@@ -26,6 +26,7 @@ import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import com.nvidia.spark.rapids.jni.fileio.SeekableInputStream;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
+import org.apache.spark.sql.rapids.GpuTaskMetrics$;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +73,7 @@ public final class IcebergS3InputFile implements RapidsInputFile {
         fileIO.properties(),
         ShimUtils.storageCredentialOverlays(fileIO));
     if (icebergS3Client == null) {
+      GpuTaskMetrics$.MODULE$.get().recordPerfioS3IcebergFallback();
       LOG.debug("IcebergS3RangeCopier path disabled for {}", s3Uri);
       return new IcebergInputFile(inputFile);
     }

--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
@@ -71,6 +71,10 @@ public final class IcebergS3InputFile implements RapidsInputFile {
         s3Uri.toString(),
         fileIO.properties(),
         ShimUtils.storageCredentialOverlays(fileIO));
+    if (icebergS3Client == null) {
+      LOG.debug("IcebergS3RangeCopier path disabled for {}", s3Uri);
+      return new IcebergInputFile(inputFile);
+    }
     LOG.debug("IcebergS3RangeCopier path active for {}", s3Uri);
     return new IcebergS3InputFile(new IcebergInputFile(inputFile), s3Uri, icebergS3Client);
   }

--- a/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
+++ b/iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java
@@ -26,6 +26,7 @@ import com.nvidia.spark.rapids.jni.fileio.RapidsInputFile;
 import com.nvidia.spark.rapids.jni.fileio.SeekableInputStream;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
+import org.apache.spark.TaskContext;
 import org.apache.spark.sql.rapids.GpuTaskMetrics$;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,12 +60,13 @@ public final class IcebergS3InputFile implements RapidsInputFile {
   public static RapidsInputFile maybeCreate(InputFile inputFile, FileIO fileIO) {
     // When the gating conf is off (or the file is not an S3 file), return the
     // default IcebergInputFile so the standard Iceberg SeekableInputStream path is used.
+    IcebergInputFile delegate = new IcebergInputFile(inputFile);
     if (!RapidsInputFiles.isS3PerfEnabled()) {
-      return new IcebergInputFile(inputFile);
+      return delegate;
     }
     URI s3Uri = IcebergS3InputFileAccess.s3Uri(inputFile);
     if (s3Uri == null) {
-      return new IcebergInputFile(inputFile);
+      return delegate;
     }
     // Iceberg < 1.7 does not have SupportsStorageCredentials; ShimUtils returns
     // the per-prefix credential overlays (or an empty map on 1.6).
@@ -73,12 +75,14 @@ public final class IcebergS3InputFile implements RapidsInputFile {
         fileIO.properties(),
         ShimUtils.storageCredentialOverlays(fileIO));
     if (icebergS3Client == null) {
-      GpuTaskMetrics$.MODULE$.get().recordPerfioS3IcebergFallback();
+      if (TaskContext.get() != null) {
+        GpuTaskMetrics$.MODULE$.get().recordPerfioS3IcebergFallback();
+      }
       LOG.debug("IcebergS3RangeCopier path disabled for {}", s3Uri);
-      return new IcebergInputFile(inputFile);
+      return delegate;
     }
     LOG.debug("IcebergS3RangeCopier path active for {}", s3Uri);
-    return new IcebergS3InputFile(new IcebergInputFile(inputFile), s3Uri, icebergS3Client);
+    return new IcebergS3InputFile(delegate, s3Uri, icebergS3Client);
   }
 
   @Override

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -286,6 +286,7 @@ class GpuTaskMetrics extends Serializable with Logging {
   private val perfioS3NettyExecutors = new LongAccumulator
   private val perfioS3CrtExecutors = new LongAccumulator
   private val perfioS3S3aExecutors = new LongAccumulator
+  private val perfioS3IcebergFallbacks = new LongAccumulator
 
   private var maxHostBytesAllocated: Long = 0
   private var maxPageableBytesAllocated: Long = 0
@@ -352,7 +353,8 @@ class GpuTaskMetrics extends Serializable with Logging {
     "gpuDiskWriteSavedBytes" -> diskWriteSavedBytes,
     "perfio.s3.netty.executors" -> perfioS3NettyExecutors,
     "perfio.s3.crt.executors" -> perfioS3CrtExecutors,
-    "perfio.s3.s3a.executors" -> perfioS3S3aExecutors
+    "perfio.s3.s3a.executors" -> perfioS3S3aExecutors,
+    "perfio.s3.iceberg.fallbacks" -> perfioS3IcebergFallbacks
   )
 
   def register(sc: SparkContext): Unit = {
@@ -522,6 +524,14 @@ class GpuTaskMetrics extends Serializable with Logging {
       if (PerfIO.reportedBackendAccIds.add(acc.id)) {
         acc.add(1L)
       }
+    } catch {
+      case _: IllegalArgumentException => // accumulator not yet registered; no-op
+    }
+  }
+
+  def recordPerfioS3IcebergFallback(): Unit = {
+    try {
+      perfioS3IcebergFallbacks.add(1L)
     } catch {
       case _: IllegalArgumentException => // accumulator not yet registered; no-op
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -530,11 +530,7 @@ class GpuTaskMetrics extends Serializable with Logging {
   }
 
   def recordPerfioS3IcebergFallback(): Unit = {
-    try {
-      perfioS3IcebergFallbacks.add(1L)
-    } catch {
-      case _: IllegalArgumentException => // accumulator not yet registered; no-op
-    }
+    perfioS3IcebergFallbacks.add(1L)
   }
 }
 


### PR DESCRIPTION
## Summary

This public companion change makes the Iceberg S3 PerfIO integration treat a `null` private client as an unsupported fast-path configuration and fall back to Iceberg's normal `InputFile` path.

It also adds a task metric, `perfio.s3.iceberg.fallbacks`, so runs with PerfIO enabled can report when Iceberg S3 reads had to leave the PerfIO path because the private S3 client factory declined the catalog/table configuration.

## Why

The private change in nvspark/spark-rapids-private!369 intentionally returns `null` from `IcebergS3RangeCopier.resolveClient(...)` for Iceberg S3 settings that the PerfIO client path should not attempt to partially emulate. That lets the normal Iceberg reader preserve behavior for configurations such as Access Grants and other client plugins, while still allowing supported S3 settings to use PerfIO.

## Changes

- `IcebergS3InputFile.maybeCreate(...)` now records `perfio.s3.iceberg.fallbacks` and returns the normal Iceberg input file when the private resolver returns `null`.
- `GpuTaskMetrics` registers and exposes `perfio.s3.iceberg.fallbacks`.

## Companion Change

- Private MR: https://gitlab-master.nvidia.com/nvspark/spark-rapids-private/-/merge_requests/369
- Tested with private revision `98d8da84a`.

## Validation

- `mvn -pl iceberg/iceberg-1-10-x -am -Dbuildver=355 -DskipTests -Dmaven.scaladoc.skip=true -Dmaven.scalastyle.skip=true package`
- `git diff --check -- iceberg/common/src/main/java/org/apache/iceberg/aws/s3/IcebergS3InputFile.java sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala`
- EMR benchmark smoke/runtime checks with the private companion:
  - Netty run observed `perfio.s3.netty.executors = 2`
  - CRT one-job run completed successfully and observed `perfio.s3.crt.executors = 2`
