### PR TITLE
Use current repository name in GitHub workflows [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ jobs:
     uses: NVIDIA/spark-rapids-common/.github/workflows/auto-merge.yml@main
     with:
       owner: ${{ github.repository_owner }}
-      repo: spark-rapids
+      repo: ${{ github.event.repository.name }}
       branch: ${{ github.event.pull_request.base.ref }}
     secrets:
       token: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,6 @@ jobs:
         uses: NVIDIA/spark-rapids-common/signoff-check@main
         with:
           owner: ${{ github.repository_owner }}
-          repo: spark-rapids
+          repo: ${{ github.event.repository.name }}
           pull_number: ${{ github.event.number }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replacing hardcoded repo: spark-rapids* with `repo: ${{ github.event.repository.name }}`

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [X] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [X] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [X] Not required
