### PR TITLE
Render GPU operator metrics for V2 table writes in the SQL UI

### DIFF
--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -37,11 +37,11 @@ def _is_write_node(name):
 def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
     """Regression test: the SQL UI / History Server must show the GPU child
     operators under a DataSource V2 table write (GpuV2TableWriteExec), not just
-    the write node. GpuV2TableWriteExec wraps its query in an AdaptiveSparkPlanExec
-    whose own final-plan update only refreshes its subtree, so without re-posting
-    the final plan the write execution's plan graph only contains the write node
-    and the GPU operators under it are missing. See GpuV2TableWriteExec
-    .postFinalPlanUpdateToSqlUi."""
+    the write node. GpuV2TableWriteExec wraps its query in an AdaptiveSparkPlanExec;
+    it must execute that original AQE (via finalPhysicalPlan) so Spark's own
+    per-query-stage plan updates post the GPU plan to the SQL UI. Otherwise the
+    write execution's plan graph contains only the write node and the GPU operators
+    under it are missing. See GpuV2TableWriteExec.finalQuery."""
     table_name = get_full_table_name(spark_tmp_table_factory)
 
     def run(spark):
@@ -108,3 +108,83 @@ def test_v2_write_sql_ui_shows_gpu_child_operators(spark_tmp_table_factory):
     assert gpu_children, \
         f"SQL UI plan graph for the V2 write is missing GPU child operators " \
         f"(only the write node is shown): {names}"
+
+
+@allow_non_gpu('CreateTableExec')
+@iceberg
+def test_v2_write_sql_ui_gpu_child_operator_metrics_are_visible(spark_tmp_table_factory):
+    """Regression test: the SQL UI / History Server must show metric values (op
+    times) on the GPU child operators of a DataSource V2 table write, not just
+    their names. GpuV2TableWriteExec executes the query's AdaptiveSparkPlanExec;
+    the GPU operators' SQLMetric accumulator ids must reach Spark's SQL listener
+    (via AQE's per-query-stage plan updates) BEFORE each stage's job starts. If
+    they do not, the listener never registers those ids and drops every matching
+    task accumulator update, leaving op times blank on the plan nodes. Here we
+    assert the GPU child 'op time' metric ids are present in the execution's
+    metric-value map (i.e. their task updates were joined back to the plan)."""
+    table_name = get_full_table_name(spark_tmp_table_factory)
+
+    def run(spark):
+        sql_store = spark._jsparkSession.sharedState().statusStore()
+
+        def nodes_of(exec_id):
+            ns = []
+            it = sql_store.planGraph(exec_id).allNodes().iterator()
+            while it.hasNext():
+                ns.append(it.next())
+            return ns
+
+        def max_execution_id():
+            mx = -1
+            it = sql_store.executionsList().iterator()
+            while it.hasNext():
+                mx = max(mx, it.next().executionId())
+            return mx
+
+        spark.sql(f"CREATE TABLE {table_name} (grp BIGINT, cnt BIGINT) "
+                  f"USING ICEBERG {_BASE_TBLPROPS_SQL}")
+        # See test_v2_write_sql_ui_shows_gpu_child_operators: drain the listener bus
+        # and scope to executions created by our own INSERT (the IT Spark session is
+        # shared, so the status store accumulates executions from earlier tests).
+        spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty(30000)
+        baseline_exec_id = max_execution_id()
+        # GROUP BY -> shuffle -> AQE re-plans; the INSERT is the V2 write execution.
+        spark.sql(f"INSERT INTO {table_name} "
+                  f"SELECT id % 8 AS grp, count(*) AS cnt FROM range(0, 100000) GROUP BY id % 8")
+        spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty(30000)
+
+        write_exec_ids = []
+        it = sql_store.executionsList().iterator()
+        while it.hasNext():
+            exec_id = it.next().executionId()
+            if exec_id > baseline_exec_id and \
+                    any(_is_write_node(n.name()) for n in nodes_of(exec_id)):
+                write_exec_ids.append(exec_id)
+        assert write_exec_ids, \
+            f"No V2 write execution found after baseline_exec_id={baseline_exec_id}."
+        write_exec_id = min(write_exec_ids)
+
+        # accumulator-id -> rendered metric value, for this execution.
+        metric_values = sql_store.executionMetrics(write_exec_id)
+        gpu_op_time = []  # (node_name, present_in_metric_values)
+        for node in nodes_of(write_exec_id):
+            if not node.name().startswith("Gpu") or _is_write_node(node.name()):
+                continue
+            mit = node.metrics().iterator()
+            while mit.hasNext():
+                metric = mit.next()
+                if metric.name().startswith("op time"):
+                    gpu_op_time.append(
+                        (node.name(), metric_values.contains(metric.accumulatorId())))
+        return gpu_op_time
+
+    gpu_op_time = with_gpu_session(run, conf=iceberg_write_enabled_conf)
+    assert gpu_op_time, \
+        "No GPU child 'op time' metrics found under the V2 write."
+    present = [n for (n, ok) in gpu_op_time if ok]
+    # With the bug the SQL listener drops every GPU task accumulator update, so none
+    # of the GPU child op-time ids appear in the metric-value map.
+    assert present, \
+        f"SQL UI shows no op-time values on the V2 write's GPU child operators " \
+        f"(task accumulator updates were not joined to the plan); GPU op-time " \
+        f"metrics seen on: {[n for (n, _) in gpu_op_time]}"

--- a/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
+++ b/integration_tests/src/main/python/iceberg/iceberg_write_sql_ui_test.py
@@ -181,10 +181,10 @@ def test_v2_write_sql_ui_gpu_child_operator_metrics_are_visible(spark_tmp_table_
     gpu_op_time = with_gpu_session(run, conf=iceberg_write_enabled_conf)
     assert gpu_op_time, \
         "No GPU child 'op time' metrics found under the V2 write."
-    present = [n for (n, ok) in gpu_op_time if ok]
+    missing = [n for (n, ok) in gpu_op_time if not ok]
     # With the bug the SQL listener drops every GPU task accumulator update, so none
     # of the GPU child op-time ids appear in the metric-value map.
-    assert present, \
-        f"SQL UI shows no op-time values on the V2 write's GPU child operators " \
-        f"(task accumulator updates were not joined to the plan); GPU op-time " \
-        f"metrics seen on: {[n for (n, _) in gpu_op_time]}"
+    assert not missing, \
+        f"SQL UI shows blank op-time values on some of the V2 write's GPU child " \
+        f"operators (task accumulator updates were not joined to the plan for): " \
+        f"{missing}; all GPU op-time metrics: {[n for (n, _) in gpu_op_time]}"

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -32,8 +32,6 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2
 
-import scala.util.control.NonFatal
-
 import ai.rapids.cudf.{ColumnVector => CudfColumnVector, Scalar => CudfScalar}
 import com.nvidia.spark.rapids.{GpuColumnarToRowExec, GpuColumnVector, GpuDeltaWrite, GpuExec, GpuMetric, GpuWrite}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
@@ -49,12 +47,10 @@ import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{DELETE_OPERATION, UPDAT
 import org.apache.spark.sql.catalyst.util.WriteDeltaProjections
 import org.apache.spark.sql.connector.write.{BatchWrite, DataWriter, DataWriterFactory, DeltaWriter, PhysicalWriteInfoImpl, Write, WriterCommitMessage}
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.{SparkPlan, SparkPlanInfo, SQLExecution, UnaryExecNode}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources.v2.GpuDelteWritingSparkTask.filterByOperation
 import org.apache.spark.sql.execution.metric.{CustomMetrics, SQLMetric, SQLMetrics}
-import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
-import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{LongAccumulator, Utils}
 
@@ -93,54 +89,34 @@ trait GpuV2TableWriteExec extends V2CommandExec with UnaryExecNode with GpuExec 
   override def child: SparkPlan = query
   override def output: Seq[Attribute] = Seq.empty
 
+  // Root cause of "SQL op times / task metrics missing on GPU plan nodes in the SQL UI /
+  // History Server" for V2 writes under AQE:
+  //
+  // The previous code executed a *detached copy* of the query's AQE
+  // (`aqe.copy(supportsColumnar = true)`). Spark's AQE posts its per-query-stage UI updates by
+  // serializing `context.qe.executedPlan`, which (for this write command) walks `query` — the
+  // ORIGINAL, never-executed AQE, frozen at its pre-GPU (CPU) plan. The GPU operators the tasks
+  // actually update live in the *copy*, with different metric IDs, so Spark's SQL listener
+  // filters out every task accumulator update and op times render blank on every node.
+  //
+  // Fix: execute the ORIGINAL `query` AQE itself (the instance `context.qe.executedPlan`
+  // references) via `finalPhysicalPlan`, which materializes its query stages and drives Spark's
+  // own per-stage `onUpdatePlan` — so the SQL UI sees the GPU plan (node names AND the GPU
+  // metric IDs) before each stage's job starts, exactly as it already does for pure reads. The
+  // GPU writer consumes `ColumnarBatch`es, so we then feed it the columnar source beneath the
+  // AQE's row-output transition (the AQE wrapper is `supportsColumnar = false`, so its settled
+  // plan tops out in a `GpuColumnarToRowExec`). This is Spark-version-agnostic — it touches no
+  // fork-specific constructor flags.
   private lazy val finalQuery: SparkPlan = query match {
-      case aqe: AdaptiveSparkPlanExec => aqe.copy(supportsColumnar = true)
+      case aqe: AdaptiveSparkPlanExec =>
+        // Drives AQE on `aqe` (posts per-stage GPU plan updates for the UI) and settles it.
+        val settledPlan = aqe.finalPhysicalPlan
+        settledPlan match {
+          case GpuColumnarToRowExec(inner, _) => inner
+          case other => other
+        }
       case GpuColumnarToRowExec(inner, _) => inner
       case p => p
-  }
-
-  /**
-   * Re-post the final, post-AQE plan to the SQL UI so the GPU nodes show up.
-   *
-   * An Iceberg (V2) write wraps its query in an `AdaptiveSparkPlanExec`. AQE's own
-   * final-plan update only refreshes its own subtree, so the SQL UI keeps showing this
-   * write node's pre-AQE plan and the GPU operators under it never appear. Once the write
-   * has executed (the AQE `executedPlan` is settled) we re-post a
-   * `SparkListenerSQLAdaptiveExecutionUpdate` for this execution with every
-   * `AdaptiveSparkPlanExec` replaced by its `executedPlan`.
-   *
-   * Uses `transformDown` (not a shallow match on the root) so nested
-   * `AdaptiveSparkPlanExec` — e.g. wrapped under a `ProjectExec` — are also unwrapped,
-   * keeping the unwrap symmetric with the deep AQE that produced the plan.
-   */
-  protected def postFinalPlanUpdateToSqlUi(): Unit = {
-    val executionIdStr = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    if (executionIdStr != null) {
-      // This is a purely observational UI refresh and is called inside the write's
-      // try/catch that aborts the write on any Throwable. A failure here (e.g. building
-      // SparkPlanInfo for an unusual plan node, or posting while the SparkContext is
-      // stopping) must never abort a write whose tasks have already committed, so log
-      // and swallow non-fatal errors instead of letting them propagate.
-      try {
-        val finalChildPlan = finalQuery.transformDown {
-          case aqe: AdaptiveSparkPlanExec => aqe.executedPlan
-        }
-        val planForUi = this.withNewChildren(Seq(finalChildPlan))
-        // Redact the plan description with the configured pattern, mirroring Spark's
-        // explain / AQE update path, so sensitive strings (e.g. credentials in options)
-        // are not written to the SQL UI / History Server event log.
-        val planDescription = Utils.redact(conf.stringRedactionPattern, planForUi.toString)
-        TrampolineUtil.postEvent(sparkContext,
-          SparkListenerSQLAdaptiveExecutionUpdate(
-            executionIdStr.toLong,
-            planDescription,
-            SparkPlanInfo.fromSparkPlan(planForUi)))
-      } catch {
-        case NonFatal(e) =>
-          logWarning("Failed to post the final GPU plan to the SQL UI for this V2 " +
-            "write; the write itself is unaffected.", e)
-      }
-    }
   }
 
   protected def writeWithV2(batchWrite: BatchWrite): Seq[InternalRow] = {
@@ -181,11 +157,6 @@ trait GpuV2TableWriteExec extends V2CommandExec with UnaryExecNode with GpuExec 
           batchWrite.onDataWriterCommit(commitMessage)
         }
       )
-
-      // The write has executed and the AQE plan is settled; refresh the SQL UI so the
-      // GPU plan is visible for this V2 write. Done before commit so the UI reflects the
-      // executed plan even if the commit later fails.
-      postFinalPlanUpdateToSqlUi()
 
       logInfo(s"Data source write support $batchWrite is committing.")
       batchWrite.commit(messages)


### PR DESCRIPTION
Fixes #15088.

### Description

DataSource V2 GPU table writes (`GpuV2TableWriteExec`: `GpuAppendData` /
`GpuOverwritePartitionsDynamic` / `GpuOverwriteByExpression` / `GpuWriteDelta`, and
CTAS/RTAS via a nested append) render with blank op times / task-level metrics on
every GPU plan node in the Spark SQL UI / History Server under AQE — only
broadcast-exchange (driver-side) metrics show. The values are in the raw event log
but never joined back to the plan. This is a follow-up to #14975, which made the GPU
child operators *appear* in the write's plan graph but did not make their metrics
render.

**Root cause.** The write executes a *copy* of its query's `AdaptiveSparkPlanExec`
(`aqe.copy(supportsColumnar = true)`). Spark's AQE posts its per-query-stage SQL-UI
updates by serializing `context.qe.executedPlan`, which walks the write node's
`child` — the *original*, never-executed AQE, frozen at its pre-GPU (CPU) plan. The
GPU operators the tasks actually update live in the copy with different `SQLMetric`
ids, so `SQLAppStatusListener` registers the CPU ids per stage (at job start) and
filters out every GPU task accumulator update → op times blank. Pure reads/joins are
unaffected (their top-level AQE *is* `context.qe.executedPlan`); V1 file writes are
unaffected (they execute their `child` directly). Reproducible on stock Apache Spark
— not EMR-specific.

**Fix.** Execute the original query `AdaptiveSparkPlanExec` itself via
`finalPhysicalPlan`, so Spark's own per-stage `onUpdatePlan` posts the GPU plan (node
names and GPU metric ids) before each stage's job — the same path pure reads already
use — then feed the columnar writer the source beneath the settled plan's
`GpuColumnarToRowExec`. This supersedes and removes the `postFinalPlanUpdateToSqlUi`
re-post added by #14975 (which only recovered the final write stage). The change is
Spark-version-agnostic (no fork-specific constructor flags; `finalPhysicalPlan` exists
across Spark 3.3–4.1). GPU V2 write exists only in the `spark350` shim
(3.5.0–3.5.8 / 4.0.0–4.0.2 / 4.1.1, non-Databricks); 3.3/3.4 and Databricks have no
GPU V2 write path.

**Testing.** Added `iceberg_write_sql_ui_test.py::test_v2_write_sql_ui_gpu_child_operator_metrics_are_visible`,
which asserts the V2 write's GPU child-operator `op time` metric ids appear in the
execution's metric-value map. Verified the op times render (matching raw task
accumulator sums) on vanilla Apache Spark 3.5.6 and Amazon EMR 7.9 (3.5.5-amzn)
across scan / filter / project / aggregate / shuffle + broadcast joins / sort /
window operators.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
